### PR TITLE
externalcmd: fix crash when manually pushing to an ondemand path

### DIFF
--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -518,9 +518,11 @@ func (pa *path) onDemandCloseSource() {
 		pa.source.(sourceStatic).Close()
 		pa.source = nil
 	} else {
-		pa.Log(logger.Info, "on demand command stopped")
-		pa.onDemandCmd.Close()
-		pa.onDemandCmd = nil
+		if pa.onDemandCmd != nil {
+			pa.Log(logger.Info, "on demand command stopped")
+			pa.onDemandCmd.Close()
+			pa.onDemandCmd = nil
+		}
 
 		if pa.source != nil {
 			pa.source.(publisher).Close()


### PR DESCRIPTION
This fixes the following crash which occurs if someone is pushing an RTSP stream to a path which is configured to be on-demand :

```
2021/08/26 17:29:38 I [0/0] [RTSP] [conn 172.30.0.1:54786] opened
2021/08/26 17:29:38 I [0/0] [RTSP] [session 639351179] opened by 172.30.0.1:54786
2021/08/26 17:29:38 I [0/0] [path nil-pointer-crash] created
2021/08/26 17:29:38 I [1/0] [RTSP] [session 639351179] is publishing to path 'nil-pointer-crash', 2 tracks with UDP
2021/08/26 17:29:40 I [1/0] [path nil-pointer-crash] on demand command stopped
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x9f090e]

goroutine 85 [running]:
github.com/aler9/rtsp-simple-server/internal/externalcmd.(*Cmd).Close(...)
	/src/internal/externalcmd/cmd.go:47
github.com/aler9/rtsp-simple-server/internal/core.(*path).onDemandCloseSource(0xc000583080)
	/src/internal/core/path.go:517 +0x24e
github.com/aler9/rtsp-simple-server/internal/core.(*path).run(0xc000583080)
	/src/internal/core/path.go:344 +0xfb6
created by github.com/aler9/rtsp-simple-server/internal/core.newPath
	/src/internal/core/path.go:274 +0x5aa
```