### PR TITLE
Per-path availability metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,23 +418,21 @@ wget -qO- localhost:9998/metrics
 Obtaining:
 
 ```
-paths{state="ready"} 2 1628760831152
-paths{state="notReady"} 0 1628760831152
-rtsp_sessions{state="idle"} 0 1628760831152
-rtsp_sessions{state="read"} 0 1628760831152
-rtsp_sessions{state="publish"} 1 1628760831152
-rtsps_sessions{state="idle"} 0 1628760831152
-rtsps_sessions{state="read"} 0 1628760831152
-rtsps_sessions{state="publish"} 0 1628760831152
-rtmp_conns{state="idle"} 0 1628760831152
-rtmp_conns{state="read"} 0 1628760831152
-rtmp_conns{state="publish"} 1 1628760831152
+paths{name="<path_name>",state="ready"} 1
+rtsp_sessions{state="idle"} 0
+rtsp_sessions{state="read"} 0
+rtsp_sessions{state="publish"} 1
+rtsps_sessions{state="idle"} 0
+rtsps_sessions{state="read"} 0
+rtsps_sessions{state="publish"} 0
+rtmp_conns{state="idle"} 0
+rtmp_conns{state="read"} 0
+rtmp_conns{state="publish"} 1
 ```
 
 where:
 
-* `paths{state="ready"}` is the count of paths that are ready
-* `paths{state="notReady"}` is the count of paths that are not ready
+* `paths{name="<path_name>",state="ready"} 1` is a metric for every path that shows the path state
 * `rtsp_sessions{state="idle"}` is the count of RTSP sessions that are idle
 * `rtsp_sessions{state="read"}` is the count of RTSP sessions that are reading
 * `rtsp_sessions{state="publish"}` is the counf ot RTSP sessions that are publishing

--- a/internal/core/metrics_test.go
+++ b/internal/core/metrics_test.go
@@ -31,7 +31,7 @@ func TestMetrics(t *testing.T) {
 		&gortsplib.TrackConfigH264{SPS: []byte{0x01, 0x02, 0x03, 0x04}, PPS: []byte{0x01, 0x02, 0x03, 0x04}})
 	require.NoError(t, err)
 
-	source, err := gortsplib.DialPublish("rtsp://localhost:8554/mypath",
+	source, err := gortsplib.DialPublish("rtsp://localhost:8554/rtsp_path",
 		gortsplib.Tracks{track})
 	require.NoError(t, err)
 	defer source.Close()
@@ -42,7 +42,7 @@ func TestMetrics(t *testing.T) {
 		"-i", "emptyvideo.mkv",
 		"-c", "copy",
 		"-f", "flv",
-		"rtmp://localhost:1935/test1/test2",
+		"rtmp://localhost:1935/rtmp_path",
 	})
 	require.NoError(t, err)
 	defer cnt1.close()
@@ -66,16 +66,16 @@ func TestMetrics(t *testing.T) {
 	}
 
 	require.Equal(t, map[string]string{
-		"paths{state=\"notReady\"}":         "0",
-		"paths{state=\"ready\"}":            "2",
-		"rtmp_conns{state=\"idle\"}":        "0",
-		"rtmp_conns{state=\"publish\"}":     "1",
-		"rtmp_conns{state=\"read\"}":        "0",
-		"rtsp_sessions{state=\"idle\"}":     "0",
-		"rtsp_sessions{state=\"publish\"}":  "1",
-		"rtsp_sessions{state=\"read\"}":     "0",
-		"rtsps_sessions{state=\"idle\"}":    "0",
-		"rtsps_sessions{state=\"publish\"}": "0",
-		"rtsps_sessions{state=\"read\"}":    "0",
+		"paths{name=\"rtsp_path\",state=\"ready\"}": "1",
+		"paths{name=\"rtmp_path\",state=\"ready\"}": "1",
+		"rtmp_conns{state=\"idle\"}":                "0",
+		"rtmp_conns{state=\"publish\"}":             "1",
+		"rtmp_conns{state=\"read\"}":                "0",
+		"rtsp_sessions{state=\"idle\"}":             "0",
+		"rtsp_sessions{state=\"publish\"}":          "1",
+		"rtsp_sessions{state=\"read\"}":             "0",
+		"rtsps_sessions{state=\"idle\"}":            "0",
+		"rtsps_sessions{state=\"publish\"}":         "0",
+		"rtsps_sessions{state=\"read\"}":            "0",
 	}, vals)
 }


### PR DESCRIPTION
Hi, first of all, thanks for this tool, it's a great thing!
With this I handle a lot of streams, and I thought it would be very useful to have a availability metric for each path to monitor their status, and here it is.
I think that there is nothing here that could raise many questions, except of timestamps in metrics. They are not really needed, Prometheus docs says:

```
Accordingly, you should not set timestamps on the metrics you expose, let Prometheus take care of that. If you think you need timestamps, then you probably need the Pushgateway instead.
```
https://prometheus.io/docs/instrumenting/writing_exporters/#scheduling

so I removed them.

Also, I'm not entirely sure that the test for the new metric is written correctly.

Thanks!