### PR TITLE
Add example for overriding array parameter with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ There are 3 ways to change the configuration:
    ```
    RTSP_RTSPADDRESS="127.0.0.1:8554" ./rtsp-simple-server
    ```
+   
+   Parameters that have array as value can be overriden by setting a comma-separated list. For example:
+   ```
+   RTSP_PROTOCOLS="tcp,udp"
+   ```
 
    Parameters in maps can be overridden by using underscores, in the following way:
 


### PR DESCRIPTION
I figured this out by looking at the original code added by https://github.com/aler9/rtsp-simple-server/commit/5ca500504064fe389eeec02106ec4d31a50765fb.

The code is now at [internal/conf/env.go](https://github.com/aler9/rtsp-simple-server/blob/main/internal/conf/env.go) and the slice processing part has been removed in https://github.com/aler9/rtsp-simple-server/commit/0d4d81c3336243ced35a0e48cd71aabbf0c4f560. Not sure why it was removed, but setting the value as comma-separated list still works.