### PR TITLE
rtmp: fix crash when publishing video-only tracks (#1819)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1217,7 +1217,7 @@ For more advanced options, you can create and serve a custom web page by startin
 
 * WebRTC
   * [WebRTC: Real-Time Communication in Browsers](https://www.w3.org/TR/webrtc/)
-  * [WebRTC Ingestion Protocol (WHIP)](https://datatracker.ietf.org/doc/draft-ietf-wish-whip/)
+  * [WebRTC HTTP Ingestion Protocol (WHIP)](https://datatracker.ietf.org/doc/draft-ietf-wish-whip/)
   * [WebRTC HTTP Egress Protocol (WHEP)](https://datatracker.ietf.org/doc/draft-murillo-whep/)
 
 * Video and audio codecs

--- a/internal/rtmp/tracks/read.go
+++ b/internal/rtmp/tracks/read.go
@@ -44,7 +44,7 @@ func trackFromH264DecoderConfig(data []byte) (formats.Format, error) {
 	}, nil
 }
 
-func trackFromAACDecoderConfig(data []byte) (*formats.MPEG4Audio, error) {
+func trackFromAACDecoderConfig(data []byte) (formats.Format, error) {
 	var mpegConf mpeg4audio.Config
 	err := mpegConf.Unmarshal(data)
 	if err != nil {
@@ -261,10 +261,10 @@ func readTracksFromMetadata(r *message.ReadWriter, payload []interface{}) (forma
 	}
 }
 
-func readTracksFromMessages(r *message.ReadWriter, msg message.Message) (formats.Format, *formats.MPEG4Audio, error) {
+func readTracksFromMessages(r *message.ReadWriter, msg message.Message) (formats.Format, formats.Format, error) {
 	var startTime *time.Duration
 	var videoTrack formats.Format
-	var audioTrack *formats.MPEG4Audio
+	var audioTrack formats.Format
 
 	// analyze 1 second of packets
 outer:


### PR DESCRIPTION
this fixes a regression introduced in v0.23.0.

Fixes #1819