### PR TITLE
Expose E-Tag header for cross-origin WHEP requests

### DIFF
--- a/internal/core/webrtc_http_server.go
+++ b/internal/core/webrtc_http_server.go
@@ -305,6 +305,7 @@ func (s *webRTCHTTPServer) onRequest(ctx *gin.Context) {
 			}
 
 			ctx.Writer.Header().Set("Content-Type", "application/sdp")
+			ctx.Writer.Header().Set("Access-Control-Expose-Headers", "E-Tag", "Accept-Patch", "Link")
 			ctx.Writer.Header().Set("E-Tag", res.sx.secret.String())
 			ctx.Writer.Header().Set("Accept-Patch", "application/trickle-ice-sdpfrag")
 			ctx.Writer.Header()["Link"] = iceServersToLinkHeader(s.parent.genICEServers())


### PR DESCRIPTION
Add the `access-control-expose-headers: E-Tag` header to the `/whep` response to allow access to the `E-Tag` header when making a cross-origin request.