### PR TITLE
webrtc: fix WHIP/WHEP implementation (#1857)

### DIFF
--- a/internal/core/webrtc_http_server.go
+++ b/internal/core/webrtc_http_server.go
@@ -309,6 +309,7 @@ func (s *webRTCHTTPServer) onRequest(ctx *gin.Context) {
 			ctx.Writer.Header().Set("E-Tag", res.sx.secret.String())
 			ctx.Writer.Header().Set("Accept-Patch", "application/trickle-ice-sdpfrag")
 			ctx.Writer.Header()["Link"] = iceServersToLinkHeader(s.parent.genICEServers())
+			ctx.Writer.Header().Set("Location", ctx.Request.URL.String())
 			ctx.Writer.WriteHeader(http.StatusCreated)
 			ctx.Writer.Write(res.answer)
 

--- a/internal/core/webrtc_publish_index.html
+++ b/internal/core/webrtc_publish_index.html
@@ -232,16 +232,19 @@ class Transmitter {
                     headers: {
                         'Content-Type': 'application/sdp',
                     },
-                    body: JSON.stringify(desc),
+                    body: desc.sdp,
                 })
                     .then((res) => {
                         if (res.status !== 201) {
                             throw new Error('bad status code');
                         }
                         this.eTag = res.headers.get('E-Tag');
-                        return res.json();
+                        return res.text();
                     })
-                    .then((answer) => this.onRemoteDescription(answer))
+                    .then((sdp) => this.onRemoteDescription(new RTCSessionDescription({
+                        type: 'answer',
+                        sdp,
+                    })))
                     .catch((err) => {
                         console.log('error: ' + err);
                         this.scheduleRestart();

--- a/internal/core/webrtc_read_index.html
+++ b/internal/core/webrtc_read_index.html
@@ -143,16 +143,19 @@ class WHEPClient {
                     headers: {
                         'Content-Type': 'application/sdp',
                     },
-                    body: JSON.stringify(desc),
+                    body: desc.sdp,
                 })
                     .then((res) => {
                         if (res.status !== 201) {
                             throw new Error('bad status code');
                         }
                         this.eTag = res.headers.get('E-Tag');
-                        return res.json();
+                        return res.text();
                     })
-                    .then((answer) => this.onRemoteDescription(answer))
+                    .then((sdp) => this.onRemoteDescription(new RTCSessionDescription({
+                        type: 'answer',
+                        sdp,
+                    })))
                     .catch((err) => {
                         console.log('error: ' + err);
                         this.scheduleRestart();


### PR DESCRIPTION
offers and answers are now encoded in SDP in place of JSON; Location header is set by the server.

This fixes compatibility with GStreamer and whipsink.