### PR TITLE
rpi camera: allow using decimal FPS (#1743)

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -262,7 +262,7 @@ components:
         rpiCameraMode:
           type: string
         rpiCameraFPS:
-          type: integer
+          type: number
         rpiCameraIDRPeriod:
           type: integer
         rpiCameraBitrate:

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -92,7 +92,7 @@ type PathConf struct {
 	RPICameraROI               string  `json:"rpiCameraROI"`
 	RPICameraTuningFile        string  `json:"rpiCameraTuningFile"`
 	RPICameraMode              string  `json:"rpiCameraMode"`
-	RPICameraFPS               int     `json:"rpiCameraFPS"`
+	RPICameraFPS               float64 `json:"rpiCameraFPS"`
 	RPICameraIDRPeriod         int     `json:"rpiCameraIDRPeriod"`
 	RPICameraBitrate           int     `json:"rpiCameraBitrate"`
 	RPICameraProfile           string  `json:"rpiCameraProfile"`

--- a/internal/rpicamera/exe/camera.cpp
+++ b/internal/rpicamera/exe/camera.cpp
@@ -345,7 +345,7 @@ static void fill_dynamic_controls(ControlList *ctrls, const parameters_t *params
 
     ctrls->set(controls::ExposureValue, params->ev);
 
-    int64_t frame_time = 1000000 / params->fps;
+    int64_t frame_time = (int64_t)(((float)1000000) / params->fps);
     ctrls->set(controls::FrameDurationLimits, Span<const int64_t, 2>({ frame_time, frame_time }));
 }
 

--- a/internal/rpicamera/exe/parameters.c
+++ b/internal/rpicamera/exe/parameters.c
@@ -96,7 +96,7 @@ bool parameters_unserialize(parameters_t *params, const uint8_t *buf, size_t buf
             }
             free(decoded_val);
         } else if (strcmp(key, "FPS") == 0) {
-            params->fps = atoi(val);
+            params->fps = atof(val);
         } else if (strcmp(key, "IDRPeriod") == 0) {
             params->idr_period = atoi(val);
         } else if (strcmp(key, "Bitrate") == 0) {

--- a/internal/rpicamera/exe/parameters.h
+++ b/internal/rpicamera/exe/parameters.h
@@ -27,7 +27,7 @@ typedef struct {
     window_t *roi;
     char *tuning_file;
     sensor_mode_t *mode;
-    unsigned int fps;
+    float fps;
     unsigned int idr_period;
     unsigned int bitrate;
     unsigned int profile;

--- a/internal/rpicamera/params.go
+++ b/internal/rpicamera/params.go
@@ -21,7 +21,7 @@ type Params struct {
 	ROI               string
 	TuningFile        string
 	Mode              string
-	FPS               int
+	FPS               float64
 	IDRPeriod         int
 	Bitrate           int
 	Profile           string


### PR DESCRIPTION
Fixes #1743 