### PR TITLE
Add WebRTC stream id to whep response headers

### DIFF
--- a/internal/core/webrtc_http_server.go
+++ b/internal/core/webrtc_http_server.go
@@ -307,6 +307,7 @@ func (s *webRTCHTTPServer) onRequest(ctx *gin.Context) {
 			ctx.Writer.Header().Set("Content-Type", "application/sdp")
 			ctx.Writer.Header().Set("Access-Control-Expose-Headers", "E-Tag, Accept-Patch, Link")
 			ctx.Writer.Header().Set("E-Tag", res.sx.secret.String())
+			ctx.Writer.Header().Set("UUID", res.sx.uuid.String())
 			ctx.Writer.Header().Set("Accept-Patch", "application/trickle-ice-sdpfrag")
 			ctx.Writer.Header()["Link"] = iceServersToLinkHeader(s.parent.genICEServers())
 			ctx.Writer.Header().Set("Location", ctx.Request.URL.String())

--- a/internal/core/webrtc_http_server.go
+++ b/internal/core/webrtc_http_server.go
@@ -307,7 +307,7 @@ func (s *webRTCHTTPServer) onRequest(ctx *gin.Context) {
 			ctx.Writer.Header().Set("Content-Type", "application/sdp")
 			ctx.Writer.Header().Set("Access-Control-Expose-Headers", "E-Tag, Accept-Patch, Link")
 			ctx.Writer.Header().Set("E-Tag", res.sx.secret.String())
-			ctx.Writer.Header().Set("UUID", res.sx.uuid.String())
+			ctx.Writer.Header().Set("ID", res.sx.uuid.String())
 			ctx.Writer.Header().Set("Accept-Patch", "application/trickle-ice-sdpfrag")
 			ctx.Writer.Header()["Link"] = iceServersToLinkHeader(s.parent.genICEServers())
 			ctx.Writer.Header().Set("Location", ctx.Request.URL.String())

--- a/internal/core/webrtc_manager_test.go
+++ b/internal/core/webrtc_manager_test.go
@@ -58,7 +58,9 @@ func whipPostOffer(t *testing.T, hc *http.Client, ur string,
 	require.NotEqual(t, 0, len(servers))
 
 	etag := res.Header.Get("E-Tag")
-	require.NotEqual(t, 0, len(etag))
+	require.NotEqual(t, "", etag)
+
+	require.NotEqual(t, "", res.Header.Get("ID"))
 
 	sdp, err := io.ReadAll(res.Body)
 	require.NoError(t, err)


### PR DESCRIPTION
Hello, 

We plan to use Mediamtx for streaming WebRTC video / audio from local recorders like Dahua, but during testing we have found one issue - there is no information about internal WebRTC stream id in /whep request / response flow, so we don't have any information about stream that was created and cannot use Mediamtx HTTP API to list current WebRTC connections and find a stream that we just created.

So, I have a proposal to add this WebRTC stream id to /whep response headers, that will help to set info about current created stream and then manage it using Mediamtx HTTP API.

Best regards, 
Victor