### PR TITLE
api: add path to RTMP connections, RTSP sessions, WebRTC sessions (#1962)

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -389,6 +389,8 @@ components:
         state:
           type: string
           enum: [idle, read, publish]
+        path:
+          type: string
         bytesReceived:
           type: integer
           format: int64
@@ -408,14 +410,14 @@ components:
         state:
           type: string
           enum: [idle, read, publish]
+        path:
+          type: string
         bytesReceived:
           type: integer
           format: int64
         bytesSent:
           type: integer
           format: int64
-        path:
-          type: string
 
     HLSMuxer:
       type: object
@@ -498,6 +500,8 @@ components:
         state:
           type: string
           enum: [read, publish]
+        path:
+          type: string
         bytesReceived:
           type: integer
           format: int64

--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -414,6 +414,8 @@ components:
         bytesSent:
           type: integer
           format: int64
+        path:
+          type: string
 
     HLSMuxer:
       type: object

--- a/internal/core/api_defs.go
+++ b/internal/core/api_defs.go
@@ -57,9 +57,9 @@ type apiRTMPConn struct {
 	Created       time.Time `json:"created"`
 	RemoteAddr    string    `json:"remoteAddr"`
 	State         string    `json:"state"`
+	Path          string    `json:"path"`
 	BytesReceived uint64    `json:"bytesReceived"`
 	BytesSent     uint64    `json:"bytesSent"`
-	Path          string    `json:"path"`
 }
 
 type apiRTMPConnsList struct {
@@ -73,6 +73,7 @@ type apiRTSPSession struct {
 	Created       time.Time `json:"created"`
 	RemoteAddr    string    `json:"remoteAddr"`
 	State         string    `json:"state"`
+	Path          string    `json:"path"`
 	BytesReceived uint64    `json:"bytesReceived"`
 	BytesSent     uint64    `json:"bytesSent"`
 }
@@ -91,6 +92,7 @@ type apiWebRTCSession struct {
 	LocalCandidate            string    `json:"localCandidate"`
 	RemoteCandidate           string    `json:"remoteCandidate"`
 	State                     string    `json:"state"`
+	Path                      string    `json:"path"`
 	BytesReceived             uint64    `json:"bytesReceived"`
 	BytesSent                 uint64    `json:"bytesSent"`
 }

--- a/internal/core/api_defs.go
+++ b/internal/core/api_defs.go
@@ -59,6 +59,7 @@ type apiRTMPConn struct {
 	State         string    `json:"state"`
 	BytesReceived uint64    `json:"bytesReceived"`
 	BytesSent     uint64    `json:"bytesSent"`
+	Path          string    `json:"path"`
 }
 
 type apiRTMPConnsList struct {

--- a/internal/core/api_test.go
+++ b/internal/core/api_test.go
@@ -685,25 +685,33 @@ func TestAPIProtocolList(t *testing.T) {
 					pa = "rtmpsconns"
 				}
 
+				type item struct {
+					State string `json:"state"`
+					Path  string `json:"path"`
+				}
+
 				var out struct {
-					ItemCount int `json:"itemCount"`
-					Items     []struct {
-						State string `json:"state"`
-					} `json:"items"`
+					ItemCount int    `json:"itemCount"`
+					Items     []item `json:"items"`
 				}
 				httpRequest(t, hc, http.MethodGet, "http://localhost:9997/v2/"+pa+"/list", nil, &out)
 
 				if ca != "rtsp conns" && ca != "rtsps conns" {
-					require.Equal(t, "publish", out.Items[0].State)
+					require.Equal(t, item{
+						State: "publish",
+						Path:  "mypath",
+					}, out.Items[0])
 				}
 
 			case "hls":
+				type item struct {
+					Created     string `json:"created"`
+					LastRequest string `json:"lastRequest"`
+				}
+
 				var out struct {
-					ItemCount int `json:"itemCount"`
-					Items     []struct {
-						Created     string `json:"created"`
-						LastRequest string `json:"lastRequest"`
-					} `json:"items"`
+					ItemCount int    `json:"itemCount"`
+					Items     []item `json:"items"`
 				}
 				httpRequest(t, hc, http.MethodGet, "http://localhost:9997/v2/hlsmuxers/list", nil, &out)
 
@@ -713,13 +721,9 @@ func TestAPIProtocolList(t *testing.T) {
 
 			case "webrtc":
 				type item struct {
-					Created                   time.Time `json:"created"`
-					RemoteAddr                string    `json:"remoteAddr"`
-					PeerConnectionEstablished bool      `json:"peerConnectionEstablished"`
-					LocalCandidate            string    `json:"localCandidate"`
-					RemoteCandidate           string    `json:"remoteCandidate"`
-					BytesReceived             uint64    `json:"bytesReceived"`
-					BytesSent                 uint64    `json:"bytesSent"`
+					PeerConnectionEstablished bool   `json:"peerConnectionEstablished"`
+					State                     string `json:"state"`
+					Path                      string `json:"path"`
 				}
 
 				var out struct {
@@ -728,7 +732,11 @@ func TestAPIProtocolList(t *testing.T) {
 				}
 				httpRequest(t, hc, http.MethodGet, "http://localhost:9997/v2/webrtcsessions/list", nil, &out)
 
-				require.Equal(t, true, out.Items[0].PeerConnectionEstablished)
+				require.Equal(t, item{
+					PeerConnectionEstablished: true,
+					State:                     "read",
+					Path:                      "mypath",
+				}, out.Items[0])
 			}
 		})
 	}

--- a/internal/core/webrtc_session.go
+++ b/internal/core/webrtc_session.go
@@ -180,12 +180,6 @@ func (s *webRTCSession) close() {
 	s.ctxCancel()
 }
 
-func (s *webRTCSession) safePC() *peerConnection {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	return s.pc
-}
-
 func (s *webRTCSession) run() {
 	defer s.wg.Done()
 
@@ -542,19 +536,21 @@ func (s *webRTCSession) apiReaderDescribe() pathAPISourceOrReader {
 }
 
 func (s *webRTCSession) apiItem() *apiWebRTCSession {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	peerConnectionEstablished := false
 	localCandidate := ""
 	remoteCandidate := ""
 	bytesReceived := uint64(0)
 	bytesSent := uint64(0)
 
-	pc := s.safePC()
-	if pc != nil {
+	if s.pc != nil {
 		peerConnectionEstablished = true
-		localCandidate = pc.localCandidate()
-		remoteCandidate = pc.remoteCandidate()
-		bytesReceived = pc.bytesReceived()
-		bytesSent = pc.bytesSent()
+		localCandidate = s.pc.localCandidate()
+		remoteCandidate = s.pc.remoteCandidate()
+		bytesReceived = s.pc.bytesReceived()
+		bytesSent = s.pc.bytesSent()
 	}
 
 	return &apiWebRTCSession{

--- a/internal/core/webrtc_session.go
+++ b/internal/core/webrtc_session.go
@@ -126,9 +126,9 @@ type webRTCSession struct {
 	created    time.Time
 	uuid       uuid.UUID
 	secret     uuid.UUID
-	pcMutex    sync.RWMutex
-	pc         *peerConnection
 	answerSent bool
+	mutex      sync.RWMutex
+	pc         *peerConnection
 
 	chAddRemoteCandidates chan webRTCSessionAddCandidatesReq
 }
@@ -181,8 +181,8 @@ func (s *webRTCSession) close() {
 }
 
 func (s *webRTCSession) safePC() *peerConnection {
-	s.pcMutex.RLock()
-	defer s.pcMutex.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	return s.pc
 }
 
@@ -491,9 +491,9 @@ outer:
 		}
 	}
 
-	s.pcMutex.Lock()
+	s.mutex.Lock()
 	s.pc = pc
-	s.pcMutex.Unlock()
+	s.mutex.Unlock()
 
 	return nil
 }
@@ -570,6 +570,7 @@ func (s *webRTCSession) apiItem() *apiWebRTCSession {
 			}
 			return "read"
 		}(),
+		Path:          s.req.pathName,
 		BytesReceived: bytesReceived,
 		BytesSent:     bytesSent,
 	}


### PR DESCRIPTION
Hello Alessandro,

Thanks for your great work! I have a project in mind where I need to create a webpage displaying a list of all active RTMP broadcasts, along with links to their corresponding WebRTC streams. Currently, I am using the /v2/rtmpconns/list endpoint to fetch all the RTMP streams and filter them based on their status. However, I am facing an issue as the path field is missing, and without it, I cannot construct the link to the WebRTC stream.

Hope this functionality will be useful for others too. Looking forward for your comments/remarks