### PR TITLE
Fix: API v2/paths/get with nested path always results in 404

### DIFF
--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -233,7 +233,7 @@ func newAPI(
 	}
 
 	group.GET("/v2/paths/list", a.onPathsList)
-	group.GET("/v2/paths/get/:name", a.onPathsGet)
+	group.GET("/v2/paths/get/*name", a.onPathsGet)
 
 	if !interfaceIsEmpty(a.rtspServer) {
 		group.GET("/v2/rtspconns/list", a.onRTSPConnsList)
@@ -475,7 +475,14 @@ func (a *api) onPathsList(ctx *gin.Context) {
 }
 
 func (a *api) onPathsGet(ctx *gin.Context) {
-	data, err := a.pathManager.apiPathsGet(ctx.Param("name"))
+	name := ctx.Param("name")
+	if len(name) < 2 || name[0] != '/' {
+		ctx.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+	name = name[1:]
+
+	data, err := a.pathManager.apiPathsGet(name)
 	if err != nil {
 		abortWithError(ctx, err)
 		return

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -229,7 +229,7 @@ func newAPI(
 
 	if !interfaceIsEmpty(a.hlsManager) {
 		group.GET("/v2/hlsmuxers/list", a.onHLSMuxersList)
-		group.GET("/v2/hlsmuxers/get/:name", a.onHLSMuxersGet)
+		group.GET("/v2/hlsmuxers/get/*name", a.onHLSMuxersGet)
 	}
 
 	group.GET("/v2/paths/list", a.onPathsList)
@@ -778,7 +778,14 @@ func (a *api) onHLSMuxersList(ctx *gin.Context) {
 }
 
 func (a *api) onHLSMuxersGet(ctx *gin.Context) {
-	data, err := a.hlsManager.apiMuxersGet(ctx.Param("name"))
+	name := ctx.Param("name")
+	if len(name) < 2 || name[0] != '/' {
+		ctx.AbortWithStatus(http.StatusBadRequest)
+		return
+	}
+	name = name[1:]
+
+	data, err := a.hlsManager.apiMuxersGet(name)
 	if err != nil {
 		abortWithError(ctx, err)
 		return

--- a/internal/core/api_test.go
+++ b/internal/core/api_test.go
@@ -455,11 +455,13 @@ func TestAPIPathsGet(t *testing.T) {
 			}
 
 			var pathName string
-			if ca == "ok" {
+
+			switch ca {
+			case "ok":
 				pathName = "mypath"
-			} else if ca == "ok-nested" {
+			case "ok-nested":
 				pathName = "my/nested/path"
-			} else {
+			case "not found":
 				pathName = "nonexisting"
 			}
 

--- a/internal/core/api_test.go
+++ b/internal/core/api_test.go
@@ -440,12 +440,7 @@ func TestAPIPathsGet(t *testing.T) {
 
 	hc := &http.Client{Transport: &http.Transport{}}
 
-	source := gortsplib.Client{}
-	err := source.StartRecording("rtsp://localhost:8554/mypath", media.Medias{testMediaH264})
-	require.NoError(t, err)
-	defer source.Close()
-
-	for _, ca := range []string{"ok", "not found"} {
+	for _, ca := range []string{"ok", "ok-nested", "not found"} {
 		t.Run(ca, func(t *testing.T) {
 			type pathSource struct {
 				Type string `json:"type"`
@@ -462,15 +457,22 @@ func TestAPIPathsGet(t *testing.T) {
 			var pathName string
 			if ca == "ok" {
 				pathName = "mypath"
+			} else if ca == "ok-nested" {
+				pathName = "my/nested/path"
 			} else {
 				pathName = "nonexisting"
 			}
 
-			if ca == "ok" {
+			if ca == "ok" || ca == "ok-nested" {
+				source := gortsplib.Client{}
+				err := source.StartRecording("rtsp://localhost:8554/"+pathName, media.Medias{testMediaH264})
+				require.NoError(t, err)
+				defer source.Close()
+
 				var out path
 				httpRequest(t, hc, http.MethodGet, "http://localhost:9997/v2/paths/get/"+pathName, nil, &out)
 				require.Equal(t, path{
-					Name: "mypath",
+					Name: pathName,
 					Source: pathSource{
 						Type: "rtspSession",
 					},


### PR DESCRIPTION
Getting path information for nested paths always fails and gives a 404. This PR fixes this problem