### PR TITLE
api: return 404 when a path configuration is not found (#2067)

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -605,6 +605,8 @@ paths:
           description: the request was successful.
         '400':
           description: invalid request.
+        '404':
+          description: configuration not found.
         '500':
           description: internal server error.
 
@@ -625,6 +627,8 @@ paths:
           description: the request was successful.
         '400':
           description: invalid request.
+        '404':
+          description: configuration not found.
         '500':
           description: internal server error.
 

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -409,7 +409,7 @@ func (a *api) onConfigPathsEdit(ctx *gin.Context) {
 
 	newConfPath, ok := newConf.Paths[name]
 	if !ok {
-		ctx.AbortWithStatus(http.StatusBadRequest)
+		ctx.AbortWithStatus(http.StatusNotFound)
 		return
 	}
 


### PR DESCRIPTION
this involves /v2/config/paths/edit and /v2/config/paths/remove