### PR TITLE
fix a compile error with recent libcamera

### DIFF
--- a/internal/rpicamera/exe/camera.cpp
+++ b/internal/rpicamera/exe/camera.cpp
@@ -29,7 +29,6 @@ using libcamera::Request;
 using libcamera::Size;
 using libcamera::Span;
 using libcamera::Stream;
-using libcamera::StreamRoles;
 using libcamera::StreamRole;
 using libcamera::StreamConfiguration;
 using libcamera::Transform;
@@ -140,7 +139,7 @@ bool camera_create(const parameters_t *params, camera_frame_cb frame_cb, camera_
         return false;
     }
 
-    StreamRoles stream_roles = { StreamRole::VideoRecording };
+    std::vector<libcamera::StreamRole> stream_roles = { StreamRole::VideoRecording };
     if (params->mode != NULL) {
         stream_roles.push_back(StreamRole::Raw);
     }


### PR DESCRIPTION
not sure if this is backward compatible with older version of libcamera, but there was an API change in recnet libcamera

see https://github.com/raspberrypi/libcamera/commit/26a4b83d1b9443795dbcb21fa6c23117f113216a