### PR TITLE
Create GitHub action for building binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,20 @@
+name: binaries
+
+on:
+  push:
+    branches:
+    - '**'
+
+jobs:
+  binaries:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - run: make binaries
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: binaries
+        path: binaries


### PR DESCRIPTION
This uses workflow_dispatch, so it won't run unless triggered manually.

It could be useful for people who fork the repo.