### PR TITLE
remove warning when decoding VP8 or VP9

### DIFF
--- a/internal/formatprocessor/vp8.go
+++ b/internal/formatprocessor/vp8.go
@@ -81,7 +81,7 @@ func (t *formatProcessorVP8) Process(unit Unit, hasNonRTSPReaders bool) error { 
 
 			frame, pts, err := t.decoder.Decode(pkt)
 			if err != nil {
-				if err == rtpvp8.ErrMorePacketsNeeded {
+				if err == rtpvp8.ErrNonStartingPacketAndNoPrevious || err == rtpvp8.ErrMorePacketsNeeded {
 					return nil
 				}
 				return err

--- a/internal/formatprocessor/vp9.go
+++ b/internal/formatprocessor/vp9.go
@@ -81,7 +81,7 @@ func (t *formatProcessorVP9) Process(unit Unit, hasNonRTSPReaders bool) error { 
 
 			frame, pts, err := t.decoder.Decode(pkt)
 			if err != nil {
-				if err == rtpvp9.ErrMorePacketsNeeded {
+				if err == rtpvp9.ErrNonStartingPacketAndNoPrevious || err == rtpvp9.ErrMorePacketsNeeded {
 					return nil
 				}
 				return err


### PR DESCRIPTION
avoid printing 'received a non-starting fragment without any previous starting fragment'