### PR TITLE
Update README.md - added protocol in basic usage section for gstreamer

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ makepkg -si
    or _GStreamer_:
 
    ```sh
-   gst-launch-1.0 rtspclientsink name=s location=rtsp://localhost:8554/mystream filesrc location=file.mp4 \
+   gst-launch-1.0 rtspclientsink protocols=tcp name=s location=rtsp://localhost:8554/mystream filesrc location=file.mp4 \
    ! qtdemux name=d d.video_0 ! queue ! s.sink_0 d.audio_0 ! queue ! s.sink_1
    ```
 


### PR DESCRIPTION
Added `protocols=tcp` in basic usage section of gstreamer