### PR TITLE
allow RTMP streaming with codecid=av01 or hvc1

### DIFF
--- a/internal/rtmp/reader.go
+++ b/internal/rtmp/reader.go
@@ -103,7 +103,7 @@ func tracksFromMetadata(conn *Conn, payload []interface{}) (formats.Format, form
 			}
 
 		case string:
-			if vt == "avc1" {
+			if vt == "avc1" || vt == "hvc1" || vt == "av01" {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
Prior to this change, when trying to stream AV1 over enhanced RTMP using XSplit Broadcaster, the server was refusing the content with "unsupported video codec: av01" message.