### PR TITLE
Configurable hlsDurationRequiredPartCount

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -134,21 +134,22 @@ type Conf struct {
 	RTMPServerCert string     `json:"rtmpServerCert"`
 
 	// HLS
-	HLS                bool           `json:"hls"`
-	HLSDisable         bool           `json:"hlsDisable"` // depreacted
-	HLSAddress         string         `json:"hlsAddress"`
-	HLSEncryption      bool           `json:"hlsEncryption"`
-	HLSServerKey       string         `json:"hlsServerKey"`
-	HLSServerCert      string         `json:"hlsServerCert"`
-	HLSAlwaysRemux     bool           `json:"hlsAlwaysRemux"`
-	HLSVariant         HLSVariant     `json:"hlsVariant"`
-	HLSSegmentCount    int            `json:"hlsSegmentCount"`
-	HLSSegmentDuration StringDuration `json:"hlsSegmentDuration"`
-	HLSPartDuration    StringDuration `json:"hlsPartDuration"`
-	HLSSegmentMaxSize  StringSize     `json:"hlsSegmentMaxSize"`
-	HLSAllowOrigin     string         `json:"hlsAllowOrigin"`
-	HLSTrustedProxies  IPsOrCIDRs     `json:"hlsTrustedProxies"`
-	HLSDirectory       string         `json:"hlsDirectory"`
+	HLS                          bool           `json:"hls"`
+	HLSDisable                   bool           `json:"hlsDisable"` // depreacted
+	HLSAddress                   string         `json:"hlsAddress"`
+	HLSEncryption                bool           `json:"hlsEncryption"`
+	HLSServerKey                 string         `json:"hlsServerKey"`
+	HLSServerCert                string         `json:"hlsServerCert"`
+	HLSAlwaysRemux               bool           `json:"hlsAlwaysRemux"`
+	HLSVariant                   HLSVariant     `json:"hlsVariant"`
+	HLSSegmentCount              int            `json:"hlsSegmentCount"`
+	HLSSegmentDuration           StringDuration `json:"hlsSegmentDuration"`
+	HLSPartDuration              StringDuration `json:"hlsPartDuration"`
+	HLSDurationRequiredPartCount int            `json:"hlsDurationRequiredPartCount"`
+	HLSSegmentMaxSize            StringSize     `json:"hlsSegmentMaxSize"`
+	HLSAllowOrigin               string         `json:"hlsAllowOrigin"`
+	HLSTrustedProxies            IPsOrCIDRs     `json:"hlsTrustedProxies"`
+	HLSDirectory                 string         `json:"hlsDirectory"`
 
 	// WebRTC
 	WebRTC                  bool              `json:"webrtc"`
@@ -364,6 +365,7 @@ func (conf *Conf) UnmarshalJSON(b []byte) error {
 	conf.HLSSegmentCount = 7
 	conf.HLSSegmentDuration = 1 * StringDuration(time.Second)
 	conf.HLSPartDuration = 200 * StringDuration(time.Millisecond)
+	conf.HLSDurationRequiredPartCount = 5
 	conf.HLSSegmentMaxSize = 50 * 1024 * 1024
 	conf.HLSAllowOrigin = "*"
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -387,6 +387,7 @@ func (p *Core) createResources(initial bool) error {
 			p.conf.HLSSegmentCount,
 			p.conf.HLSSegmentDuration,
 			p.conf.HLSPartDuration,
+			p.conf.HLSDurationRequiredPartCount,
 			p.conf.HLSSegmentMaxSize,
 			p.conf.HLSAllowOrigin,
 			p.conf.HLSTrustedProxies,

--- a/internal/core/hls_manager.go
+++ b/internal/core/hls_manager.go
@@ -40,6 +40,7 @@ type hlsManager struct {
 	segmentCount              int
 	segmentDuration           conf.StringDuration
 	partDuration              conf.StringDuration
+	durationRequiredPartCount int
 	segmentMaxSize            conf.StringSize
 	directory                 string
 	writeQueueSize            int
@@ -73,6 +74,7 @@ func newHLSManager(
 	segmentCount int,
 	segmentDuration conf.StringDuration,
 	partDuration conf.StringDuration,
+	durationRequiredPartCount int,
 	segmentMaxSize conf.StringSize,
 	allowOrigin string,
 	trustedProxies conf.IPsOrCIDRs,
@@ -92,6 +94,7 @@ func newHLSManager(
 		segmentCount:              segmentCount,
 		segmentDuration:           segmentDuration,
 		partDuration:              partDuration,
+		durationRequiredPartCount: durationRequiredPartCount,
 		segmentMaxSize:            segmentMaxSize,
 		directory:                 directory,
 		writeQueueSize:            writeQueueSize,
@@ -239,6 +242,7 @@ func (m *hlsManager) createMuxer(pathName string, remoteAddr string) *hlsMuxer {
 		m.segmentCount,
 		m.segmentDuration,
 		m.partDuration,
+		m.durationRequiredPartCount,
 		m.segmentMaxSize,
 		m.directory,
 		m.writeQueueSize,

--- a/internal/core/hls_muxer.go
+++ b/internal/core/hls_muxer.go
@@ -64,6 +64,7 @@ type hlsMuxer struct {
 	segmentCount              int
 	segmentDuration           conf.StringDuration
 	partDuration              conf.StringDuration
+	durationRequiredPartCount int
 	segmentMaxSize            conf.StringSize
 	directory                 string
 	writeQueueSize            int
@@ -94,6 +95,7 @@ func newHLSMuxer(
 	segmentCount int,
 	segmentDuration conf.StringDuration,
 	partDuration conf.StringDuration,
+	durationRequiredPartCount int,
 	segmentMaxSize conf.StringSize,
 	directory string,
 	writeQueueSize int,
@@ -111,6 +113,7 @@ func newHLSMuxer(
 		segmentCount:              segmentCount,
 		segmentDuration:           segmentDuration,
 		partDuration:              partDuration,
+		durationRequiredPartCount: durationRequiredPartCount,
 		segmentMaxSize:            segmentMaxSize,
 		directory:                 directory,
 		writeQueueSize:            writeQueueSize,
@@ -283,14 +286,15 @@ func (m *hlsMuxer) runInner(innerCtx context.Context, innerReady chan struct{}) 
 	}
 
 	m.muxer = &gohlslib.Muxer{
-		Variant:         gohlslib.MuxerVariant(m.variant),
-		SegmentCount:    m.segmentCount,
-		SegmentDuration: time.Duration(m.segmentDuration),
-		PartDuration:    time.Duration(m.partDuration),
-		SegmentMaxSize:  uint64(m.segmentMaxSize),
-		VideoTrack:      videoTrack,
-		AudioTrack:      audioTrack,
-		Directory:       muxerDirectory,
+		Variant:                   gohlslib.MuxerVariant(m.variant),
+		SegmentCount:              m.segmentCount,
+		SegmentDuration:           time.Duration(m.segmentDuration),
+		PartDuration:              time.Duration(m.partDuration),
+		DurationRequiredPartCount: uint64(m.durationRequiredPartCount),
+		SegmentMaxSize:            uint64(m.segmentMaxSize),
+		VideoTrack:                videoTrack,
+		AudioTrack:                audioTrack,
+		Directory:                 muxerDirectory,
 	}
 
 	err := m.muxer.Start()

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -162,6 +162,8 @@ hlsSegmentDuration: 1s
 # Part duration is influenced by the distance between video/audio samples
 # and is adjusted in order to produce segments with a similar duration.
 hlsPartDuration: 200ms
+# Minimum required part count to be able to determine first segment duration in Low-Latency variant.
+hlsDurationRequiredPartCount: 5
 # Maximum size of each segment.
 # This prevents RAM exhaustion.
 hlsSegmentMaxSize: 50M


### PR DESCRIPTION
Gohlslib PR ["Start streaming parts before first completed segment in HLS Low Latency"](https://github.com/bluenviron/gohlslib/pull/92) supports configuring the required part count to be able to determine the duration. This PR makes it configurable using mediamtx.yml


