### PR TITLE
fix default value of some settings

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -371,6 +371,8 @@ func (conf *Conf) UnmarshalJSON(b []byte) error {
 	conf.RTMP = true
 	conf.RTMPAddress = ":1935"
 	conf.RTMPSAddress = ":1936"
+	conf.RTMPServerKey = "server.key"
+	conf.RTMPServerCert = "server.crt"
 
 	// HLS
 	conf.HLS = true
@@ -391,13 +393,14 @@ func (conf *Conf) UnmarshalJSON(b []byte) error {
 	conf.WebRTCServerCert = "server.crt"
 	conf.WebRTCAllowOrigin = "*"
 	conf.WebRTCICEServers2 = []WebRTCICEServer{{URL: "stun:stun.l.google.com:19302"}}
+	conf.WebRTCICEHostNAT1To1IPs = []string{}
 
 	// SRT
 	conf.SRT = true
 	conf.SRTAddress = ":8890"
 
 	// Record
-	conf.RecordPath = "./recordings/%path/%Y-%m-%d_%H-%M-%S"
+	conf.RecordPath = "./recordings/%path/%Y-%m-%d_%H-%M-%S-%f"
 	conf.RecordFormat = "fmp4"
 	conf.RecordPartDuration = 100 * StringDuration(time.Millisecond)
 	conf.RecordSegmentDuration = 3600 * StringDuration(time.Second)

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -58,11 +58,18 @@ func TestConfFromFile(t *testing.T) {
 			RPICameraContrast:          1,
 			RPICameraSaturation:        1,
 			RPICameraSharpness:         1,
+			RPICameraExposure:          "normal",
+			RPICameraAWB:               "auto",
+			RPICameraDenoise:           "off",
+			RPICameraMetering:          "centre",
 			RPICameraFPS:               30,
 			RPICameraIDRPeriod:         60,
 			RPICameraBitrate:           1000000,
 			RPICameraProfile:           "main",
 			RPICameraLevel:             "4.1",
+			RPICameraAfMode:            "auto",
+			RPICameraAfRange:           "normal",
+			RPICameraAfSpeed:           "normal",
 			RPICameraTextOverlay:       "%Y-%m-%d %H:%M:%S - MediaMTX",
 			RunOnDemandStartTimeout:    5 * StringDuration(time.Second),
 			RunOnDemandCloseAfter:      10 * StringDuration(time.Second),
@@ -129,11 +136,18 @@ func TestConfFromFileAndEnv(t *testing.T) {
 		RPICameraContrast:          1,
 		RPICameraSaturation:        1,
 		RPICameraSharpness:         1,
+		RPICameraExposure:          "normal",
+		RPICameraAWB:               "auto",
+		RPICameraDenoise:           "off",
+		RPICameraMetering:          "centre",
 		RPICameraFPS:               30,
 		RPICameraIDRPeriod:         60,
 		RPICameraBitrate:           1000000,
 		RPICameraProfile:           "main",
 		RPICameraLevel:             "4.1",
+		RPICameraAfMode:            "auto",
+		RPICameraAfRange:           "normal",
+		RPICameraAfSpeed:           "normal",
 		RPICameraTextOverlay:       "%Y-%m-%d %H:%M:%S - MediaMTX",
 		RunOnDemandStartTimeout:    10 * StringDuration(time.Second),
 		RunOnDemandCloseAfter:      10 * StringDuration(time.Second),
@@ -161,11 +175,18 @@ func TestConfFromEnvOnly(t *testing.T) {
 		RPICameraContrast:          1,
 		RPICameraSaturation:        1,
 		RPICameraSharpness:         1,
+		RPICameraExposure:          "normal",
+		RPICameraAWB:               "auto",
+		RPICameraDenoise:           "off",
+		RPICameraMetering:          "centre",
 		RPICameraFPS:               30,
 		RPICameraIDRPeriod:         60,
 		RPICameraBitrate:           1000000,
 		RPICameraProfile:           "main",
 		RPICameraLevel:             "4.1",
+		RPICameraAfMode:            "auto",
+		RPICameraAfRange:           "normal",
+		RPICameraAfSpeed:           "normal",
 		RPICameraTextOverlay:       "%Y-%m-%d %H:%M:%S - MediaMTX",
 		RunOnDemandStartTimeout:    10 * StringDuration(time.Second),
 		RunOnDemandCloseAfter:      10 * StringDuration(time.Second),
@@ -290,4 +311,35 @@ func TestConfErrors(t *testing.T) {
 			require.EqualError(t, err, ca.err)
 		})
 	}
+}
+
+func TestSampleConfFile(t *testing.T) {
+	func() {
+		conf1, confPath1, err := Load("../../mediamtx.yml", nil)
+		require.NoError(t, err)
+		require.Equal(t, "../../mediamtx.yml", confPath1)
+		delete(conf1.Paths, "all")
+
+		conf2, confPath2, err := Load("", nil)
+		require.NoError(t, err)
+		require.Equal(t, "", confPath2)
+
+		require.Equal(t, conf1, conf2)
+	}()
+
+	func() {
+		conf1, confPath1, err := Load("../../mediamtx.yml", nil)
+		require.NoError(t, err)
+		require.Equal(t, "../../mediamtx.yml", confPath1)
+
+		tmpf, err := writeTempFile([]byte("paths:\n  all:"))
+		require.NoError(t, err)
+		defer os.Remove(tmpf)
+
+		conf2, confPath2, err := Load(tmpf, nil)
+		require.NoError(t, err)
+		require.Equal(t, tmpf, confPath2)
+
+		require.Equal(t, conf1.Paths, conf2.Paths)
+	}()
 }

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -395,11 +395,18 @@ func (pconf *PathConf) UnmarshalJSON(b []byte) error {
 	pconf.RPICameraContrast = 1
 	pconf.RPICameraSaturation = 1
 	pconf.RPICameraSharpness = 1
+	pconf.RPICameraExposure = "normal"
+	pconf.RPICameraAWB = "auto"
+	pconf.RPICameraDenoise = "off"
+	pconf.RPICameraMetering = "centre"
 	pconf.RPICameraFPS = 30
 	pconf.RPICameraIDRPeriod = 60
 	pconf.RPICameraBitrate = 1000000
 	pconf.RPICameraProfile = "main"
 	pconf.RPICameraLevel = "4.1"
+	pconf.RPICameraAfMode = "auto"
+	pconf.RPICameraAfRange = "normal"
+	pconf.RPICameraAfSpeed = "normal"
 	pconf.RPICameraTextOverlay = "%Y-%m-%d %H:%M:%S - MediaMTX"
 
 	// External commands


### PR DESCRIPTION
rtmpServerKey, rtmpServerCert, recordPath, rpiCameraExposure, rpiCameraAWB, rpiCameraDenoise, rpiCameraMetering, rpiCameraAfMode, rpiCameraAfRange, rpiCameraAfSpeed were not set correctly when missing in the configuration file.