### PR TITLE
api: fix crash when retrieving RTMP and SRT connections (#2430)

### DIFF
--- a/internal/core/rtmp_conn.go
+++ b/internal/core/rtmp_conn.go
@@ -644,7 +644,7 @@ func (c *rtmpConn) apiItem() *apiRTMPConn {
 	bytesReceived := uint64(0)
 	bytesSent := uint64(0)
 
-	if c.conn != nil {
+	if c.rconn != nil {
 		bytesReceived = c.rconn.BytesReceived()
 		bytesSent = c.rconn.BytesSent()
 	}

--- a/internal/core/srt_conn.go
+++ b/internal/core/srt_conn.go
@@ -697,7 +697,7 @@ func (c *srtConn) apiItem() *apiSRTConn {
 	bytesReceived := uint64(0)
 	bytesSent := uint64(0)
 
-	if c.conn != nil {
+	if c.sconn != nil {
 		var s srt.Statistics
 		c.sconn.Stats(&s)
 		bytesReceived = s.Accumulated.ByteRecv


### PR DESCRIPTION
I fixed the issue I opened https://github.com/bluenviron/mediamtx/issues/2430

There was a variable name issue in the nil checks. Probably a typo. Please merge