### PR TITLE
webrtc: expose the location header

### DIFF
--- a/internal/core/webrtc_http_server.go
+++ b/internal/core/webrtc_http_server.go
@@ -262,7 +262,7 @@ func (s *webRTCHTTPServer) onRequest(ctx *gin.Context) {
 			}
 
 			ctx.Writer.Header().Set("Content-Type", "application/sdp")
-			ctx.Writer.Header().Set("Access-Control-Expose-Headers", "ETag, Accept-Patch, Link")
+			ctx.Writer.Header().Set("Access-Control-Expose-Headers", "ETag, Accept-Patch, Link, Location")
 			ctx.Writer.Header().Set("ETag", res.sx.secret.String())
 			ctx.Writer.Header().Set("ID", res.sx.uuid.String())
 			ctx.Writer.Header().Set("Accept-Patch", "application/trickle-ice-sdpfrag")


### PR DESCRIPTION
The [suggested WHEP reference client](https://github.com/bluenviron/mediamtx/issues/2424#issuecomment-1736839160) is not able to access the `Location` header at:

https://github.com/medooze/whip-whep-js/blob/v1.0.3/whep.js#L86-L87

This PR allows the browser to expose that header to the javascript code.

PS: It [also needs to use the `DELETE` method](https://github.com/medooze/whip-whep-js/blob/v1.0.3/whep.js#L481-L485). should I add it to this PR too? or another PR?

Though, this is still not enough to get that client working, as it fails with:

```
2023/10/03 20:52:30 DEB [WebRTC] [conn [::1]:44266] PATCH /camera_sub/whep
2023/10/03 20:52:30 DEB [WebRTC] [conn [::1]:44266] [c->s] PATCH /camera_sub/whep HTTP/1.1
Host: localhost:8889
Accept: */*
Accept-Encoding: gzip, deflate, br
Accept-Language: en-US,en;q=0.9,pt-PT;q=0.8,pt;q=0.7
Connection: keep-alive
Content-Length: 105
Content-Type: application/trickle-ice-sdpfrag
Origin: http://localhost:8080
Referer: http://localhost:8080/
Sec-Ch-Ua: "Google Chrome";v="117", "Not;A=Brand";v="8", "Chromium";v="117"
Sec-Ch-Ua-Mobile: ?0
Sec-Ch-Ua-Platform: "Linux"
Sec-Fetch-Dest: empty
Sec-Fetch-Mode: cors
Sec-Fetch-Site: same-site
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36

a=ice-ufrag:w08e
a=ice-pwd:6j8Xfsi7cdr8nYnyvEuoT/vT
m=video 9 RTP/AVP 0
a=mid:0
a=end-of-candidates

2023/10/03 20:52:30 DEB [WebRTC] [conn [::1]:44266] [s->c] HTTP/1.1 400 Bad Request
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
Server: mediamtx


2023/10/03 20:52:36 DEB [WebRTC] [session 3c3ca543] peer connection state: disconnected
2023/10/03 20:52:36 DEB [WebRTC] [session 3c3ca543] peer connection state: closed
2023/10/03 20:52:36 INF [WebRTC] [session 3c3ca543] closed: peer connection closed
```

Should I open an new issue in this repository for that problem (and full test application and error)?