### PR TITLE
Don't allow the webrtc player to pause

### DIFF
--- a/internal/core/webrtc_read_index.html
+++ b/internal/core/webrtc_read_index.html
@@ -375,6 +375,14 @@ const initVideoElement = (callback, container) => {
 		setVideoAttributes(video);
 		container.append(video);
 		callback(video);
+
+		setInterval(() => {
+			if (video.paused) {
+				console.log("Video paused, resuming.");
+				video.pause();
+				video.play();
+			}
+		}, restartPause);
 	};
 };
 


### PR DESCRIPTION
I don't know why, maybe it's my specific sources, but there are times where the player will pause without throwing an error, this ensures that the player will always be in the playing state.

The player controls show that the video is still playing, but the video object says that the video is paused, this is why I `pause()` and then `play()`.