### PR TITLE
fix hot reloading on Windows when letter case changes (#2585)

### DIFF
--- a/internal/confwatcher/confwatcher.go
+++ b/internal/confwatcher/confwatcher.go
@@ -90,6 +90,7 @@ outer:
 
 			currentWatchedPath, _ := filepath.EvalSymlinks(w.watchedPath)
 			eventPath, _ := filepath.Abs(event.Name)
+			eventPath, _ = filepath.EvalSymlinks(eventPath)
 
 			if currentWatchedPath == "" {
 				// watched file was removed; wait for write event to trigger reload


### PR DESCRIPTION
The current behavior of performing "evalSymlinks" on the "watchedPath" seems to lead to mismatches and ignored changes if the event-reported "eventPath" is not similarly processed on Windows.
