### PR TITLE
add missing Prometheus exports (#2620, #2619): paths_bytes_sent, srt_conns, srt_conns_bytes_received, srt_conns_bytes_sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1433,6 +1433,7 @@ Obtaining:
 # metrics of every path
 paths{name="[path_name]",state="[state]"} 1
 paths_bytes_received{name="[path_name]",state="[state]"} 1234
+paths_bytes_sent{name="[path_name]",state="[state]"} 1234
 
 # metrics of every HLS muxer
 hls_muxers{name="[name]"} 1
@@ -1462,6 +1463,11 @@ rtsps_sessions_bytes_sent{id="[id]",state="[state]"} 187
 rtmp_conns{id="[id]",state="[state]"} 1
 rtmp_conns_bytes_received{id="[id]",state="[state]"} 1234
 rtmp_conns_bytes_sent{id="[id]",state="[state]"} 187
+
+# metrics of every SRT connection
+srt_conns{id="[id]",state="[state]"} 1
+srt_conns_bytes_received{id="[id]",state="[state]"} 1234
+srt_conns_bytes_sent{id="[id]",state="[state]"} 187
 
 # metrics of every WebRTC session
 webrtc_sessions{id="[id]"} 1

--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -393,6 +393,9 @@ components:
         bytesReceived:
           type: integer
           format: int64
+        bytesSent:
+          type: integer
+          format: int64
         readers:
           type: array
           items:

--- a/internal/core/api_test.go
+++ b/internal/core/api_test.go
@@ -422,6 +422,7 @@ func TestAPIPathsList(t *testing.T) {
 		Ready         bool       `json:"ready"`
 		Tracks        []string   `json:"tracks"`
 		BytesReceived uint64     `json:"bytesReceived"`
+		BytesSent     uint64     `json:"bytesSent"`
 	}
 
 	type pathList struct {
@@ -625,6 +626,7 @@ func TestAPIPathsGet(t *testing.T) {
 				Ready         bool       `json:"Ready"`
 				Tracks        []string   `json:"tracks"`
 				BytesReceived uint64     `json:"bytesReceived"`
+				BytesSent     uint64     `json:"bytesSent"`
 			}
 
 			var pathName string

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -509,6 +509,7 @@ func (p *Core) createResources(initial bool) error {
 			p.conf.RunOnConnectRestart,
 			p.conf.RunOnDisconnect,
 			p.externalCmdPool,
+			p.metrics,
 			p.pathManager,
 			p,
 		)

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -754,6 +754,12 @@ func (pa *path) doAPIPathsGet(req pathAPIPathsGetReq) {
 				}
 				return pa.stream.BytesReceived()
 			}(),
+			BytesSent: func() uint64 {
+				if pa.stream == nil {
+					return 0
+				}
+				return pa.stream.BytesSent()
+			}(),
 			Readers: func() []defs.APIPathSourceOrReader {
 				ret := []defs.APIPathSourceOrReader{}
 				for r := range pa.readers {

--- a/internal/core/srt_server.go
+++ b/internal/core/srt_server.go
@@ -67,6 +67,7 @@ type srtServer struct {
 	runOnConnectRestart bool
 	runOnDisconnect     string
 	externalCmdPool     *externalcmd.Pool
+	metrics             *metrics
 	pathManager         *pathManager
 	parent              srtServerParent
 
@@ -96,6 +97,7 @@ func newSRTServer(
 	runOnConnectRestart bool,
 	runOnDisconnect string,
 	externalCmdPool *externalcmd.Pool,
+	metrics *metrics,
 	pathManager *pathManager,
 	parent srtServerParent,
 ) (*srtServer, error) {
@@ -120,6 +122,7 @@ func newSRTServer(
 		runOnConnectRestart: runOnConnectRestart,
 		runOnDisconnect:     runOnDisconnect,
 		externalCmdPool:     externalCmdPool,
+		metrics:             metrics,
 		pathManager:         pathManager,
 		parent:              parent,
 		ctx:                 ctx,
@@ -135,6 +138,10 @@ func newSRTServer(
 	}
 
 	s.Log(logger.Info, "listener opened on "+address+" (UDP)")
+
+	if s.metrics != nil {
+		s.metrics.srtServerSet(s)
+	}
 
 	newSRTListener(
 		s.ln,

--- a/internal/defs/api.go
+++ b/internal/defs/api.go
@@ -35,6 +35,7 @@ type APIPath struct {
 	ReadyTime     *time.Time              `json:"readyTime"`
 	Tracks        []string                `json:"tracks"`
 	BytesReceived uint64                  `json:"bytesReceived"`
+	BytesSent     uint64                  `json:"bytesSent"`
 	Readers       []APIPathSourceOrReader `json:"readers"`
 }
 

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -24,6 +24,7 @@ type Stream struct {
 	desc *description.Session
 
 	bytesReceived *uint64
+	bytesSent     *uint64
 	smedias       map[*description.Media]*streamMedia
 	mutex         sync.RWMutex
 	rtspStream    *gortsplib.ServerStream
@@ -40,6 +41,7 @@ func New(
 	s := &Stream{
 		desc:          desc,
 		bytesReceived: new(uint64),
+		bytesSent:     new(uint64),
 	}
 
 	s.smedias = make(map[*description.Media]*streamMedia)
@@ -73,6 +75,11 @@ func (s *Stream) Desc() *description.Session {
 // BytesReceived returns received bytes.
 func (s *Stream) BytesReceived() uint64 {
 	return atomic.LoadUint64(s.bytesReceived)
+}
+
+// BytesSent returns sent bytes.
+func (s *Stream) BytesSent() uint64 {
+	return atomic.LoadUint64(s.bytesSent)
 }
 
 // RTSPStream returns the RTSP stream.

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -89,12 +89,14 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 
 	if s.rtspStream != nil {
 		for _, pkt := range u.GetRTPPackets() {
+	        atomic.AddUint64(s.bytesSent, unitSize(u))
 			s.rtspStream.WritePacketRTPWithNTP(medi, pkt, u.GetNTP()) //nolint:errcheck
 		}
 	}
 
 	if s.rtspsStream != nil {
 		for _, pkt := range u.GetRTPPackets() {
+	        atomic.AddUint64(s.bytesSent, unitSize(u))
 			s.rtspsStream.WritePacketRTPWithNTP(medi, pkt, u.GetNTP()) //nolint:errcheck
 		}
 	}
@@ -102,6 +104,7 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 	for writer, cb := range sf.readers {
 		ccb := cb
 		writer.Push(func() error {
+	        atomic.AddUint64(s.bytesSent, unitSize(u))
 			return ccb(u)
 		})
 	}


### PR DESCRIPTION
The following tries to resolve issues #2620 and #2019 by adding the following, missing Prometheus exports: paths_bytes_sent, srt_conns, srt_conns_bytes_received, srt_conns_bytes_sent