### PR TITLE
feat: added TLS encryption support to API calls (HTTPS)

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -92,6 +92,9 @@ type Conf struct {
 	ExternalAuthenticationURL string          `json:"externalAuthenticationURL"`
 	API                       bool            `json:"api"`
 	APIAddress                string          `json:"apiAddress"`
+	APIEncryption             bool            `json:"apiEncryption"`
+	APIServerKey              string          `json:"APIServerKey"`
+	APIServerCert             string          `json:"APIServerCert"`
 	Metrics                   bool            `json:"metrics"`
 	MetricsAddress            string          `json:"metricsAddress"`
 	PPROF                     bool            `json:"pprof"`

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -254,8 +254,8 @@ func newAPI(
 		network,
 		address,
 		time.Duration(readTimeout),
-		"",
-		"",
+		conf.APIServerCert,
+		conf.APIServerKey,
 		router,
 		a,
 	)

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -51,9 +51,9 @@ APIEncryption: no
 # This can be generated with:
 # openssl genrsa -out server.key 2048
 # openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
-APIServerKey: server.key
+APIServerKey:
 # Path to the server certificates (or optional chain of certificates)
-APIServerCert: server.crt
+APIServerCert:
 
 # Enable Prometheus-compatible metrics.
 metrics: no

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -45,6 +45,15 @@ externalAuthenticationURL:
 api: no
 # Address of the API listener.
 apiAddress: 127.0.0.1:9997
+# Encrypt the HTTP interface with TLS (HTTPS)
+APIEncryption: no
+# Path to the server key. This is needed only when encryption is enabled.
+# This can be generated with:
+# openssl genrsa -out server.key 2048
+# openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
+APIServerKey: server.key
+# Path to the server certificates (or optional chain of certificates)
+APIServerCert: server.crt
 
 # Enable Prometheus-compatible metrics.
 metrics: no


### PR DESCRIPTION
Solving #2491, I added support for TLS-encryption for the HTTP API calls. The gin server was already set up to do so, the only thing missing were the conf paths.