### PR TITLE
webrtc: fix crash when reading from path 'publish' (#2688)

### DIFF
--- a/internal/core/webrtc_http_server.go
+++ b/internal/core/webrtc_http_server.go
@@ -348,7 +348,7 @@ func (s *webRTCHTTPServer) onRequest(ctx *gin.Context) {
 
 		case len(ctx.Request.URL.Path) >= 2:
 			switch {
-			case strings.HasSuffix(ctx.Request.URL.Path, "/publish"):
+			case len(ctx.Request.URL.Path) > len("/publish") && strings.HasSuffix(ctx.Request.URL.Path, "/publish"):
 				s.onPage(ctx, ctx.Request.URL.Path[1:len(ctx.Request.URL.Path)-len("/publish")], true)
 
 			case ctx.Request.URL.Path[len(ctx.Request.URL.Path)-1] != '/':

--- a/internal/core/webrtc_manager_test.go
+++ b/internal/core/webrtc_manager_test.go
@@ -21,13 +21,13 @@ import (
 
 func TestWebRTCPages(t *testing.T) {
 	p, ok := newInstance("paths:\n" +
-		"  stream:\n")
+		"  all:\n")
 	require.Equal(t, true, ok)
 	defer p.Close()
 
 	hc := &http.Client{Transport: &http.Transport{}}
 
-	for _, path := range []string{"/stream", "/stream/publish"} {
+	for _, path := range []string{"/stream", "/stream/publish", "/publish"} {
 		func() {
 			req, err := http.NewRequest(http.MethodGet, "http://localhost:8889"+path, nil)
 			require.NoError(t, err)


### PR DESCRIPTION
Fixes #2688