### PR TITLE
RunOn.. commands - Propagate errors in restart configurations

### DIFF
--- a/internal/externalcmd/cmd.go
+++ b/internal/externalcmd/cmd.go
@@ -87,7 +87,6 @@ func (e *Cmd) run() {
 			return
 		}
 
-
 		if err != nil {
 			e.onExit(err)
 		} else {

--- a/internal/externalcmd/cmd.go
+++ b/internal/externalcmd/cmd.go
@@ -87,7 +87,12 @@ func (e *Cmd) run() {
 			return
 		}
 
-		e.onExit(fmt.Errorf("command exited with code 0"))
+
+		if err != nil {
+			e.onExit(err)
+		} else {
+			e.onExit(fmt.Errorf("command exited with code 0"))
+		}
 
 		select {
 		case <-time.After(restartPause):


### PR DESCRIPTION
The RunOn{Init,Ready, etc} commands call back with a generic 'exited with code 0' message if the command is specified with its relevant 'Restart' option set to 'yes'. eg

`runOnInit command exited: command exited with code 0`

This PR allows underlying `err` result to actually be seen in logs, eg

`runOnInit command exited: exec: "ffmpeg": executable file not found in %PATH%`
