### PR TITLE
Add database and record audio parametrs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,10 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
+	github.com/jackc/pgx/v5 v5.5.1 // indirect
+	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
@@ -66,6 +70,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,14 @@ github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZH
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
+github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.5.1 h1:5I9etrGkLrN+2XPCsi6XLlV5DITbSL/xBZdmAxFcXPI=
+github.com/jackc/pgx/v5 v5.5.1/go.mod h1:Ig06C2Vu0t5qXC60W8sqIthScaEnFvojjj9dSljmHRA=
+github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
+github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
@@ -231,6 +239,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -168,6 +168,7 @@ type Conf struct {
 
 	// Record (deprecated)
 	Record                *bool           `json:"record,omitempty"`                // deprecated
+	RecordAudio           *bool           `json:"recordAudio,omitempty"`           // deprecated
 	RecordPath            *string         `json:"recordPath,omitempty"`            // deprecated
 	RecordFormat          *RecordFormat   `json:"recordFormat,omitempty"`          // deprecated
 	RecordPartDuration    *StringDuration `json:"recordPartDuration,omitempty"`    // deprecated
@@ -440,6 +441,9 @@ func (conf *Conf) Check() error {
 	// Record
 	if conf.Record != nil {
 		conf.PathDefaults.Record = *conf.Record
+	}
+	if conf.RecordAudio != nil {
+		conf.PathDefaults.RecordAudio = *conf.RecordAudio
 	}
 	if conf.RecordPath != nil {
 		conf.PathDefaults.RecordPath = *conf.RecordPath

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -180,6 +180,9 @@ type Conf struct {
 	// Paths
 	OptionalPaths map[string]*OptionalPath `json:"paths"`
 	Paths         map[string]*Path         `json:"-"` // filled by Check()
+
+	// Database
+	Database Database `json:"database"`
 }
 
 func (conf *Conf) setDefaults() {
@@ -249,6 +252,8 @@ func (conf *Conf) setDefaults() {
 	conf.SRTAddress = ":8890"
 
 	conf.PathDefaults.setDefaults()
+
+	conf.Database.setDefaults()
 }
 
 // Load loads a Conf.

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -53,6 +53,7 @@ func TestConfFromFile(t *testing.T) {
 			SourceOnDemandStartTimeout: 10 * StringDuration(time.Second),
 			SourceOnDemandCloseAfter:   10 * StringDuration(time.Second),
 			RecordPath:                 "./recordings/%path/%Y-%m-%d_%H-%M-%S-%f",
+			RecordAudio:                true,
 			RecordFormat:               RecordFormatFMP4,
 			RecordPartDuration:         100000000,
 			RecordSegmentDuration:      3600000000000,

--- a/internal/conf/database.go
+++ b/internal/conf/database.go
@@ -1,0 +1,33 @@
+package conf
+
+type Database struct {
+	Use            bool   `json:"use"`
+	DbAddress      string `json:"dbAddress"`
+	DbPort         int    `json:"dbPort"`
+	DbName         string `json:"dbName"`
+	DbUser         string `json:"dbUser"`
+	DbPassword     string `json:"dbPassword"`
+	MaxConnections int    `json:"maxConnections"`
+	Sql            Sql    `json:"sql"`
+}
+
+type Sql struct {
+	InsertPath string `json:"insertPath"`
+	UpdateSize string `json:"updateSize"`
+}
+
+func (db *Database) setDefaults() {
+
+	db.Use = false
+	db.DbAddress = "127.0.0.1"
+	db.DbPort = 5432
+	db.DbName = "postgres"
+	db.DbUser = "postgres"
+	db.DbPassword = ""
+	db.MaxConnections = 0
+	db.Sql = Sql{
+		InsertPath: "",
+		UpdateSize: "",
+	}
+
+}

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -155,6 +155,7 @@ func (pconf *Path) setDefaults() {
 
 	// Record
 	pconf.RecordPath = "./recordings/%path/%Y-%m-%d_%H-%M-%S-%f"
+	pconf.RecordAudio = true
 	pconf.RecordFormat = RecordFormatFMP4
 	pconf.RecordPartDuration = 100 * StringDuration(time.Millisecond)
 	pconf.RecordSegmentDuration = 3600 * StringDuration(time.Second)

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -64,6 +64,7 @@ type Path struct {
 
 	// Record
 	Record                bool           `json:"record"`
+	RecordAudio           bool           `json:"recordAudio"`
 	RecordPath            string         `json:"recordPath"`
 	RecordFormat          RecordFormat   `json:"recordFormat"`
 	RecordPartDuration    StringDuration `json:"recordPartDuration"`

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bluenviron/mediamtx/internal/hooks"
 	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/record"
+	"github.com/bluenviron/mediamtx/internal/storage"
 	"github.com/bluenviron/mediamtx/internal/stream"
 )
 
@@ -113,6 +114,8 @@ type path struct {
 
 	// out
 	done chan struct{}
+
+	stor storage.Storage
 }
 
 func newPath(
@@ -130,6 +133,7 @@ func newPath(
 	wg *sync.WaitGroup,
 	externalCmdPool *externalcmd.Pool,
 	parent pathParent,
+	stor storage.Storage,
 ) *path {
 	ctx, ctxCancel := context.WithCancel(parentCtx)
 
@@ -166,6 +170,7 @@ func newPath(
 		chRemoveReader:                 make(chan defs.PathRemoveReaderReq),
 		chAPIPathsGet:                  make(chan pathAPIPathsGetReq),
 		done:                           make(chan struct{}),
+		stor:                           stor,
 	}
 
 	pa.Log(logger.Debug, "created")
@@ -852,6 +857,7 @@ func (pa *path) startRecording() {
 			}
 		},
 		Parent: pa,
+		Stor:   pa.stor,
 	}
 	pa.recordAgent.Initialize()
 }

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -856,8 +856,9 @@ func (pa *path) startRecording() {
 					nil)
 			}
 		},
-		Parent: pa,
-		Stor:   pa.stor,
+		Parent:      pa,
+		Stor:        pa.stor,
+		RecordAudio: pa.conf.RecordAudio,
 	}
 	pa.recordAgent.Initialize()
 }

--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -420,7 +420,8 @@ func (pm *pathManager) createPath(
 		matches,
 		&pm.wg,
 		pm.externalCmdPool,
-		pm)
+		pm,
+		pm.stor)
 
 	pm.paths[name] = pa
 

--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bluenviron/mediamtx/internal/defs"
 	"github.com/bluenviron/mediamtx/internal/externalcmd"
 	"github.com/bluenviron/mediamtx/internal/logger"
+	"github.com/bluenviron/mediamtx/internal/storage"
 )
 
 func pathConfCanBeUpdated(oldPathConf *conf.Path, newPathConf *conf.Path) bool {
@@ -110,6 +111,8 @@ type pathManager struct {
 	chAddPublisher   chan defs.PathAddPublisherReq
 	chAPIPathsList   chan pathAPIPathsListReq
 	chAPIPathsGet    chan pathAPIPathsGetReq
+
+	stor storage.Storage
 }
 
 func newPathManager(
@@ -124,6 +127,7 @@ func newPathManager(
 	pathConfs map[string]*conf.Path,
 	externalCmdPool *externalcmd.Pool,
 	parent pathManagerParent,
+	stor storage.Storage,
 ) *pathManager {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 
@@ -154,6 +158,7 @@ func newPathManager(
 		chAddPublisher:            make(chan defs.PathAddPublisherReq),
 		chAPIPathsList:            make(chan pathAPIPathsListReq),
 		chAPIPathsGet:             make(chan pathAPIPathsGetReq),
+		stor:                      stor,
 	}
 
 	for pathConfName, pathConf := range pm.pathConfs {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,0 +1,52 @@
+package database
+
+import (
+	"context"
+
+	"github.com/bluenviron/mediamtx/internal/conf"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func CreatePgxConf(cfg conf.Database) *pgxpool.Config {
+
+	if cfg.Use {
+		conf, _ := pgxpool.ParseConfig("")
+		conf.ConnConfig.User = cfg.DbUser
+		conf.ConnConfig.Password = cfg.DbPassword
+		conf.ConnConfig.Host = cfg.DbAddress
+		conf.ConnConfig.Port = uint16(cfg.DbPort)
+		conf.ConnConfig.Database = cfg.DbName
+		conf.MaxConns = int32(cfg.MaxConnections)
+		conf.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+		return conf
+	}
+
+	return nil
+
+}
+
+func CreateDbPool(ctx context.Context, conf *pgxpool.Config) (*pgxpool.Pool, error) {
+
+	if conf == nil {
+		return nil, nil
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, conf)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = pool.Exec(ctx, "SELECT '1'")
+	if err != nil {
+		return nil, err
+	}
+
+	return pool, nil
+}
+
+func ClosePool(pool *pgxpool.Pool) {
+	if pool != nil {
+		pool.Close()
+	}
+}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,0 +1,37 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/bluenviron/mediamtx/internal/conf"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreatePgxConf(t *testing.T) {
+
+	t.Run("Not use database", func(t *testing.T) {
+		confD := conf.Database{
+			Use: false,
+		}
+
+		pgConf := CreatePgxConf(confD)
+		require.Nil(t, pgConf)
+	})
+
+	t.Run("Use database", func(t *testing.T) {
+		confD := conf.Database{
+			Use:            true,
+			DbUser:         "postgres",
+			DbPassword:     "",
+			DbAddress:      "127.0.0.1",
+			DbPort:         5432,
+			DbName:         "postgres",
+			MaxConnections: 0,
+		}
+
+		pgConf := CreatePgxConf(confD)
+
+		require.NotNil(t, pgConf)
+	})
+
+}

--- a/internal/record/agent.go
+++ b/internal/record/agent.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/logger"
+	"github.com/bluenviron/mediamtx/internal/storage"
 	"github.com/bluenviron/mediamtx/internal/stream"
 )
 
@@ -27,6 +28,8 @@ type Agent struct {
 
 	terminate chan struct{}
 	done      chan struct{}
+
+	Stor storage.Storage
 }
 
 // Initialize initializes Agent.
@@ -48,6 +51,7 @@ func (w *Agent) Initialize() {
 
 	w.currentInstance = &agentInstance{
 		agent: w,
+		stor:  w.Stor,
 	}
 	w.currentInstance.initialize()
 
@@ -86,6 +90,7 @@ func (w *Agent) run() {
 
 		w.currentInstance = &agentInstance{
 			agent: w,
+			stor:  w.Stor,
 		}
 		w.currentInstance.initialize()
 	}

--- a/internal/record/agent.go
+++ b/internal/record/agent.go
@@ -17,6 +17,7 @@ type Agent struct {
 	PartDuration      time.Duration
 	SegmentDuration   time.Duration
 	PathName          string
+	StreamName        string
 	Stream            *stream.Stream
 	OnSegmentCreate   OnSegmentFunc
 	OnSegmentComplete OnSegmentFunc

--- a/internal/record/agent.go
+++ b/internal/record/agent.go
@@ -30,7 +30,8 @@ type Agent struct {
 	terminate chan struct{}
 	done      chan struct{}
 
-	Stor storage.Storage
+	Stor        storage.Storage
+	RecordAudio bool
 }
 
 // Initialize initializes Agent.
@@ -51,8 +52,9 @@ func (w *Agent) Initialize() {
 	w.done = make(chan struct{})
 
 	w.currentInstance = &agentInstance{
-		agent: w,
-		stor:  w.Stor,
+		agent:       w,
+		stor:        w.Stor,
+		recordAudio: w.RecordAudio,
 	}
 	w.currentInstance.initialize()
 
@@ -90,8 +92,9 @@ func (w *Agent) run() {
 		}
 
 		w.currentInstance = &agentInstance{
-			agent: w,
-			stor:  w.Stor,
+			agent:       w,
+			stor:        w.Stor,
+			recordAudio: w.RecordAudio,
 		}
 		w.currentInstance.initialize()
 	}

--- a/internal/record/agent_instance.go
+++ b/internal/record/agent_instance.go
@@ -34,6 +34,7 @@ type agentInstance struct {
 }
 
 func (a *agentInstance) initialize() {
+	a.agent.StreamName = a.agent.PathName
 	a.pathFormat = a.agent.PathFormat
 
 	a.pathFormat = strings.ReplaceAll(a.pathFormat, "%path", a.agent.PathName)
@@ -53,7 +54,7 @@ func (a *agentInstance) initialize() {
 
 	paths := strings.Split(a.agent.PathName, "/")
 	if len(paths) > 1 {
-		a.agent.PathName = paths[len(paths)-1]
+		a.agent.StreamName = paths[len(paths)-1]
 	}
 
 	switch a.agent.Format {

--- a/internal/record/agent_instance.go
+++ b/internal/record/agent_instance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bluenviron/mediamtx/internal/asyncwriter"
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/logger"
+	"github.com/bluenviron/mediamtx/internal/storage"
 )
 
 // OnSegmentFunc is the prototype of the function passed as runOnSegmentStart / runOnSegmentComplete
@@ -28,6 +29,8 @@ type agentInstance struct {
 
 	terminate chan struct{}
 	done      chan struct{}
+
+	stor storage.Storage
 }
 
 func (a *agentInstance) initialize() {

--- a/internal/record/agent_instance.go
+++ b/internal/record/agent_instance.go
@@ -51,6 +51,11 @@ func (a *agentInstance) initialize() {
 
 	a.writer = asyncwriter.New(a.agent.WriteQueueSize, a.agent)
 
+	paths := strings.Split(a.agent.PathName, "/")
+	if len(paths) > 1 {
+		a.agent.PathName = paths[len(paths)-1]
+	}
+
 	switch a.agent.Format {
 	case conf.RecordFormatMPEGTS:
 		a.format = &formatMPEGTS{

--- a/internal/record/agent_instance.go
+++ b/internal/record/agent_instance.go
@@ -30,7 +30,8 @@ type agentInstance struct {
 	terminate chan struct{}
 	done      chan struct{}
 
-	stor storage.Storage
+	stor        storage.Storage
+	recordAudio bool
 }
 
 func (a *agentInstance) initialize() {

--- a/internal/record/agent_test.go
+++ b/internal/record/agent_test.go
@@ -274,6 +274,7 @@ func TestAgentFMP4NegativeDTS(t *testing.T) {
 		PathName:        "mypath",
 		Stream:          stream,
 		Parent:          &nilLogger{},
+		RecordAudio:     true,
 	}
 	w.Initialize()
 

--- a/internal/record/format_fmp4.go
+++ b/internal/record/format_fmp4.go
@@ -586,6 +586,11 @@ func (f *formatFMP4) initialize() {
 				})
 
 			case *rtspformat.Opus:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				codec := &fmp4.CodecOpus{
 					ChannelCount: func() int {
 						if forma.IsStereo {
@@ -622,6 +627,11 @@ func (f *formatFMP4) initialize() {
 				})
 
 			case *rtspformat.MPEG4Audio:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				codec := &fmp4.CodecMPEG4Audio{
 					Config: *forma.GetConfig(),
 				}
@@ -654,6 +664,11 @@ func (f *formatFMP4) initialize() {
 				})
 
 			case *rtspformat.MPEG1Audio:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				codec := &fmp4.CodecMPEG1Audio{
 					SampleRate:   32000,
 					ChannelCount: 2,
@@ -702,6 +717,11 @@ func (f *formatFMP4) initialize() {
 				})
 
 			case *rtspformat.AC3:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				codec := &fmp4.CodecAC3{
 					SampleRate:   forma.SampleRate,
 					ChannelCount: forma.ChannelCount,
@@ -768,12 +788,27 @@ func (f *formatFMP4) initialize() {
 				})
 
 			case *rtspformat.G722:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				// TODO
 
 			case *rtspformat.G711:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				// TODO
 
 			case *rtspformat.LPCM:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				codec := &fmp4.CodecLPCM{
 					LittleEndian: false,
 					BitDepth:     forma.BitDepth,

--- a/internal/record/format_fmp4_part.go
+++ b/internal/record/format_fmp4_part.go
@@ -86,7 +86,7 @@ func (p *formatFMP4Part) close() error {
 			err := p.s.f.a.stor.Req.ExecQuery(
 				fmt.Sprintf(
 					p.s.f.a.stor.Sql.InsertPath,
-					p.s.f.a.agent.PathName,
+					p.s.f.a.agent.StreamName,
 					pathRec+"/",
 					paths[len(paths)-1],
 					time.Now().Format("2006-01-02 15:04:05"),

--- a/internal/record/format_fmp4_segment.go
+++ b/internal/record/format_fmp4_segment.go
@@ -1,8 +1,10 @@
 package record
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aler9/writerseeker"
@@ -68,6 +70,26 @@ func (s *formatFMP4Segment) close() error {
 
 		if err2 == nil {
 			s.f.a.agent.OnSegmentComplete(s.path)
+
+			if s.f.a.stor.Use {
+				stat, err3 := os.Stat(s.path)
+				if err3 == nil {
+					paths := strings.Split(s.path, "/")
+					err4 := s.f.a.stor.Req.ExecQuery(
+						fmt.Sprintf(
+							s.f.a.stor.Sql.UpdateSize,
+							fmt.Sprint(stat.Size()),
+							time.Now().Format("2006-01-02 15:04:05"),
+							paths[len(paths)-1]),
+					)
+					if err4 != nil {
+						return err4
+					}
+
+					return err
+				}
+				err = err3
+			}
 		}
 	}
 

--- a/internal/record/format_mpegts.go
+++ b/internal/record/format_mpegts.go
@@ -179,6 +179,11 @@ func (f *formatMPEGTS) initialize() {
 				})
 
 			case *rtspformat.Opus:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				track := addTrack(&mpegts.CodecOpus{
 					ChannelCount: func() int {
 						if forma.IsStereo {
@@ -203,6 +208,11 @@ func (f *formatMPEGTS) initialize() {
 				})
 
 			case *rtspformat.MPEG4Audio:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				track := addTrack(&mpegts.CodecMPEG4Audio{
 					Config: *forma.GetConfig(),
 				})
@@ -222,6 +232,11 @@ func (f *formatMPEGTS) initialize() {
 				})
 
 			case *rtspformat.MPEG1Audio:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				track := addTrack(&mpegts.CodecMPEG1Audio{})
 
 				f.a.agent.Stream.AddReader(f.a.writer, media, forma, func(u unit.Unit) error {
@@ -239,6 +254,11 @@ func (f *formatMPEGTS) initialize() {
 				})
 
 			case *rtspformat.AC3:
+
+				if !f.a.recordAudio {
+					continue
+				}
+
 				track := addTrack(&mpegts.CodecAC3{})
 
 				sampleRate := time.Duration(forma.SampleRate)

--- a/internal/record/format_mpegts_segment.go
+++ b/internal/record/format_mpegts_segment.go
@@ -91,7 +91,7 @@ func (s *formatMPEGTSSegment) Write(p []byte) (int, error) {
 			err := s.f.a.stor.Req.ExecQuery(
 				fmt.Sprintf(
 					s.f.a.stor.Sql.InsertPath,
-					s.f.a.agent.PathName,
+					s.f.a.agent.StreamName,
 					pathRec+"/",
 					paths[len(paths)-1],
 					time.Now().Format("2006-01-02 15:04:05"),

--- a/internal/storage/model.go
+++ b/internal/storage/model.go
@@ -1,0 +1,12 @@
+package storage
+
+import (
+	"github.com/bluenviron/mediamtx/internal/conf"
+	"github.com/bluenviron/mediamtx/internal/storage/psql"
+)
+
+type Storage struct {
+	Use bool
+	Req psql.Requests
+	Sql conf.Sql
+}

--- a/internal/storage/psql/interface.go
+++ b/internal/storage/psql/interface.go
@@ -1,0 +1,5 @@
+package psql
+
+type Requests interface {
+	ExecQuery(query string) error
+}

--- a/internal/storage/psql/model.go
+++ b/internal/storage/psql/model.go
@@ -1,0 +1,19 @@
+package psql
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Req struct {
+	ctx  context.Context
+	pool *pgxpool.Pool
+}
+
+func NewReq(ctx context.Context, pool *pgxpool.Pool) *Req {
+	return &Req{
+		ctx:  ctx,
+		pool: pool,
+	}
+}

--- a/internal/storage/psql/requests.go
+++ b/internal/storage/psql/requests.go
@@ -1,0 +1,11 @@
+package psql
+
+func (r *Req) ExecQuery(query string) error {
+
+	_, err := r.pool.Exec(r.ctx, query)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -2,14 +2,13 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/bluenviron/mediamtx/internal/core"
 )
 
 func main() {
-	fmt.Println(1)
+
 	s, ok := core.New(os.Args[1:])
 	if !ok {
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -2,12 +2,14 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/bluenviron/mediamtx/internal/core"
 )
 
 func main() {
+	fmt.Println(1)
 	s, ok := core.New(os.Args[1:])
 	if !ok {
 		os.Exit(1)

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -559,3 +559,27 @@ paths:
   # Settings under path "all_others" are applied to all paths that
   # do not match another entry.
   all_others:
+
+###############################################
+# Database settings
+database:
+  # Use database or not (use PostgreSQL)
+  use: true
+  # Database address
+  dbAddress: 127.0.0.1
+  # Database port
+  dbPort: 5432
+  # Database name
+  dbName: 
+  # Database user
+  dbUser: 
+  # Database password
+  dbPassword: 
+  # Maximum number of connections
+  maxConnections: 1
+  # SQL queryes 
+  sql:
+    # SQL query to insert video record
+    insertPath: "INSERT INTO \"video_record\" (\"code_mp_cam\", \"path_record\", \"file_name\", \"date_time_start\") VALUES ('%s', '%s', '%s', '%s')" 
+    # SQL query to update video record
+    updateSize: "UPDATE \"video_record\" SET \"file_size\"='%s', \"date_time_end\"='%s' WHERE \"file_name\"='%s'" 

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -297,7 +297,7 @@ pathDefaults:
   # Record streams to disk.
   record: no
   # Save audio from stream.
-  recordAudio: no
+  recordAudio: yes
   # Path of recording segments.
   # Extension is added automatically.
   # Available variables are %path (path name), %Y %m %d %H %M %S %f %s (time in strftime format)

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -296,6 +296,8 @@ pathDefaults:
 
   # Record streams to disk.
   record: no
+  # Save audio from stream.
+  recordAudio: no
   # Path of recording segments.
   # Extension is added automatically.
   # Available variables are %path (path name), %Y %m %d %H %M %S %f %s (time in strftime format)
@@ -564,7 +566,7 @@ paths:
 # Database settings
 database:
   # Use database or not (use PostgreSQL)
-  use: true
+  use: no
   # Database address
   dbAddress: 127.0.0.1
   # Database port

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -578,10 +578,12 @@ database:
   # Database password
   dbPassword: 
   # Maximum number of connections
-  maxConnections: 1
+  maxConnections: 0
   # SQL queryes 
   sql:
     # SQL query to insert video record
-    insertPath: "INSERT INTO \"video_record\" (\"code_mp_cam\", \"path_record\", \"file_name\", \"date_time_start\") VALUES ('%s', '%s', '%s', '%s')" 
+    # EXAMPLE insertPath: "INSERT INTO \"video_record\" (\"code_mp_cam\", \"path_record\", \"file_name\", \"date_time_start\") VALUES ('%s', '%s', '%s', '%s')" 
+    insertPath: ""
     # SQL query to update video record
-    updateSize: "UPDATE \"video_record\" SET \"file_size\"='%s', \"date_time_end\"='%s' WHERE \"file_name\"='%s'" 
+    # EXAMPLE updateSize: "UPDATE \"video_record\" SET \"file_size\"='%s', \"date_time_end\"='%s' WHERE \"file_name\"='%s'" 
+    updateSize: ""


### PR DESCRIPTION
Added functionality:
Entering information about saved files into the database (PostgreSQL).
Ability to disable audio in saved files.

The configuration file has the ability to disable/enable work with the database.

Algorithm:
When a new file is created, information about the file is entered into the database. Later, when a file segment is closed, the file information is updated in the database.
If, after creating the file, the information could not be entered into the database, the created file is deleted.
This functionality is implemented for fmp4 and mpegts.

With the recordAudio: no parameter, audio format packets will be skipped to be saved to a file, but the audio stream will not be changed in the broadcast itself.