### PR TITLE
Endpoints for managing recordings

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -1819,7 +1819,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /v3/recodings/list:
+  /v3/recordings/list:
     get:
       operationId: listRecordings
       summary: Lists all the stored recordings

--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -640,6 +640,12 @@ components:
           items:
             $ref: '#/components/schemas/WebRTCSession'
 
+    RecordingsList:
+      type: array
+      items:
+        type: string
+
+
 paths:
   /v3/config/global/get:
     get:
@@ -1812,3 +1818,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  /v3/recodings/list:
+    get:
+      operationId: listRecordings
+      summary: Lists all the stored recordings
+      description: Returns an array with all the stored recordings (path from the specified recordings directory)
+      responses:
+        '200':
+          description: Operation was successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordingsList'
+        '500':
+          description: server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -186,6 +187,8 @@ func (a *API) Initialize() error {
 
 	group.GET("/v3/paths/list", a.onPathsList)
 	group.GET("/v3/paths/get/*name", a.onPathsGet)
+
+	group.GET("/v3/recordings/list", a.onListRecordings)
 
 	if !interfaceIsEmpty(a.HLSServer) {
 		group.GET("/v3/hlsmuxers/list", a.onHLSMuxersList)
@@ -967,6 +970,21 @@ func (a *API) onSRTConnsKick(ctx *gin.Context) {
 	}
 
 	ctx.Status(http.StatusOK)
+}
+
+func (a *API) onListRecordings(ctx *gin.Context) {
+	files, err := os.ReadDir(a.Conf.PathDefaults.RecordPath)
+	if err != nil {
+		a.writeError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	var fileNames []string
+	for _, f := range files {
+		fileNames = append(fileNames, f.Name())
+	}
+
+	ctx.JSON(http.StatusOK, fileNames)
 }
 
 // ReloadConf is called by core.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -37,3 +37,31 @@ func TestPaginate(t *testing.T) {
 	require.Equal(t, 2, pageCount)
 	require.Equal(t, []int{4, 5}, items)
 }
+
+func TestPathToUnparametrizedRoot(t *testing.T) {
+	fromRoot := []string{"/root/directory/%%param", "/root/directory"}
+	relative := []string{"./root/directory/%%param", "./root/directory"}
+	fromRootNoParam := []string{"/root/directory", "/root/directory"}
+	relativeNoParam := []string{"./root/directory", "./root/directory"}
+	fromRootMultipleParams := []string{"/root/directory/%%param2/%%param3", "/root/directory"}
+	relativeMultipleParam := []string{"./root/directory/%%param/%%param2/%%param3", "./root/directory"}
+
+	require.Equal(t, PathToUnparametrizedRoot(fromRoot[0]), fromRoot[1])
+	require.Equal(t, PathToUnparametrizedRoot(relative[0]), relative[1])
+	require.Equal(t, PathToUnparametrizedRoot(fromRootNoParam[0]), fromRootNoParam[1])
+	require.Equal(t, PathToUnparametrizedRoot(relativeNoParam[0]), relativeNoParam[1])
+	require.Equal(t, PathToUnparametrizedRoot(fromRootMultipleParams[0]), fromRootMultipleParams[1])
+	require.Equal(t, PathToUnparametrizedRoot(relativeMultipleParam[0]), relativeMultipleParam[1])
+}
+
+func TestIsPathSafe(t *testing.T) {
+	safePath := "simple/path/to/recording.mp4"
+	unSafePath := "../../sh"
+	unSafePathFromRoot := "/../../sh"
+	unSafePathRelative := "./../../sh"
+
+	require.True(t, isPathSafe(safePath))
+	require.False(t, isPathSafe(unSafePath))
+	require.False(t, isPathSafe(unSafePathFromRoot))
+	require.False(t, isPathSafe(unSafePathRelative))
+}


### PR DESCRIPTION
This is a WIP pull request (I am still working on the whole feature) that I am posting to ask if it makes sense to have this API extension. The aim here would be having some interface to manage the recorded streams via the REST API, allowing operations as 
* listing
* deletion
* streaming (still need to be added, I am trying to figure out how to stream from file or if it is easier to just create a stream and run an FFMPEG script)

Does this feature make sense?