### PR TITLE
hls: fix infinite loop in web client when reading incompatible codecs

### DIFF
--- a/internal/servers/hls/index.html
+++ b/internal/servers/hls/index.html
@@ -33,9 +33,7 @@ const create = (video) => {
 		});
 
 		hls.on(Hls.Events.ERROR, (evt, data) => {
-			if (data.type === Hls.ErrorTypes.MEDIA_ERROR)
-				hls.recoverMediaError();
-			else if (data.fatal) {
+			if (data.fatal) {
 				hls.destroy();
 				setTimeout(() => create(video), 2000);
 			}


### PR DESCRIPTION
when a player received a stream with incompatible codecs, it started polling the server for index.m3u8 in an infinite loop. This was caused by #2631