### PR TITLE
Add tzdata to Docker images

### DIFF
--- a/scripts/dockerhub.mk
+++ b/scripts/dockerhub.mk
@@ -1,7 +1,8 @@
 DOCKER_REPOSITORY = bluenviron/mediamtx
 
 define DOCKERFILE_DOCKERHUB
-FROM scratch
+FROM $(ALPINE_IMAGE)
+RUN apk add --no-cache tzdata
 ARG TARGETPLATFORM
 ADD tmp/binaries/$$TARGETPLATFORM.tar.gz /
 ENTRYPOINT [ "/mediamtx" ]
@@ -10,7 +11,7 @@ export DOCKERFILE_DOCKERHUB
 
 define DOCKERFILE_DOCKERHUB_FFMPEG
 FROM $(ALPINE_IMAGE)
-RUN apk add --no-cache ffmpeg
+RUN apk add --no-cache ffmpeg tzdata
 ARG TARGETPLATFORM
 ADD tmp/binaries/$$TARGETPLATFORM.tar.gz /
 ENTRYPOINT [ "/mediamtx" ]


### PR DESCRIPTION
By default, the timezone will always be UTC in the container and there's no way to change it, with tzdata package preinstalled we can specify the timezone in the container by passing the `TZ` environment variable.