### PR TITLE
Correction for missing `go generate` in `run` makefile

### DIFF
--- a/scripts/run.mk
+++ b/scripts/run.mk
@@ -5,6 +5,7 @@ WORKDIR /s
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
+RUN go generate ./...
 RUN go build -o /out .
 WORKDIR /
 ARG CONFIG_RUN


### PR DESCRIPTION
Follow-up on this issue comment:
https://github.com/bluenviron/mediamtx/issues/3097#issuecomment-1977747645