### PR TITLE
fix: whep gathering failure leaks peer connections

### DIFF
--- a/internal/protocols/webrtc/whip_client.go
+++ b/internal/protocols/webrtc/whip_client.go
@@ -78,6 +78,7 @@ func (c *WHIPClient) Publish(
 
 	err = c.pc.SetAnswer(res.Answer)
 	if err != nil {
+		WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String()) //nolint:errcheck
 		c.pc.Close()
 		return nil, err
 	}
@@ -91,6 +92,7 @@ outer:
 		case ca := <-c.pc.NewLocalCandidate():
 			err := WHIPPatchCandidate(ctx, c.HTTPClient, c.URL.String(), offer, res.ETag, ca)
 			if err != nil {
+				WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String()) //nolint:errcheck
 				c.pc.Close()
 				return nil, err
 			}
@@ -101,6 +103,7 @@ outer:
 			break outer
 
 		case <-t.C:
+			WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String()) //nolint:errcheck
 			c.pc.Close()
 			return nil, fmt.Errorf("deadline exceeded while waiting connection")
 		}
@@ -156,6 +159,7 @@ func (c *WHIPClient) Read(ctx context.Context) ([]*IncomingTrack, error) {
 	var sdp sdp.SessionDescription
 	err = sdp.Unmarshal([]byte(res.Answer.SDP))
 	if err != nil {
+		WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String()) //nolint:errcheck
 		c.pc.Close()
 		return nil, err
 	}
@@ -163,12 +167,14 @@ func (c *WHIPClient) Read(ctx context.Context) ([]*IncomingTrack, error) {
 	// check that there are at most two tracks
 	_, err = TrackCount(sdp.MediaDescriptions)
 	if err != nil {
+		WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String()) //nolint:errcheck
 		c.pc.Close()
 		return nil, err
 	}
 
 	err = c.pc.SetAnswer(res.Answer)
 	if err != nil {
+		WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String()) //nolint:errcheck
 		c.pc.Close()
 		return nil, err
 	}
@@ -182,6 +188,7 @@ outer:
 		case ca := <-c.pc.NewLocalCandidate():
 			err := WHIPPatchCandidate(ctx, c.HTTPClient, c.URL.String(), offer, res.ETag, ca)
 			if err != nil {
+				WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String()) //nolint:errcheck
 				c.pc.Close()
 				return nil, err
 			}
@@ -192,6 +199,7 @@ outer:
 			break outer
 
 		case <-t.C:
+			WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String()) //nolint:errcheck
 			c.pc.Close()
 			return nil, fmt.Errorf("deadline exceeded while waiting connection")
 		}
@@ -199,6 +207,7 @@ outer:
 
 	tracks, err := c.pc.GatherIncomingTracks(ctx, 0)
 	if err != nil {
+		WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String()) //nolint:errcheck
 		c.pc.Close()
 		return nil, err
 	}

--- a/internal/protocols/webrtc/whip_client.go
+++ b/internal/protocols/webrtc/whip_client.go
@@ -197,7 +197,13 @@ outer:
 		}
 	}
 
-	return c.pc.GatherIncomingTracks(ctx, 0)
+	tracks, err := c.pc.GatherIncomingTracks(ctx, 0)
+	if err != nil {
+		c.pc.Close()
+		return nil, err
+	}
+
+	return tracks, nil
 }
 
 // Close closes the client.

--- a/internal/protocols/webrtc/whip_client.go
+++ b/internal/protocols/webrtc/whip_client.go
@@ -210,7 +210,6 @@ outer:
 func (c *WHIPClient) Close() error {
 	err := WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String())
 	c.pc.Close()
-	c.HTTPClient.CloseIdleConnections()
 	return err
 }
 

--- a/internal/protocols/webrtc/whip_client.go
+++ b/internal/protocols/webrtc/whip_client.go
@@ -210,6 +210,7 @@ outer:
 func (c *WHIPClient) Close() error {
 	err := WHIPDeleteSession(context.Background(), c.HTTPClient, c.URL.String())
 	c.pc.Close()
+	c.HTTPClient.CloseIdleConnections()
 	return err
 }
 

--- a/internal/staticsources/webrtc/source.go
+++ b/internal/staticsources/webrtc/source.go
@@ -40,15 +40,18 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 
 	u.Scheme = strings.ReplaceAll(u.Scheme, "whep", "http")
 
-	client := webrtc.WHIPClient{
-		HTTPClient: &http.Client{
-			Timeout: time.Duration(s.ReadTimeout),
-			Transport: &http.Transport{
-				TLSClientConfig: tls.ConfigForFingerprint(params.Conf.SourceFingerprint),
-			},
+	hc := &http.Client{
+		Timeout: time.Duration(s.ReadTimeout),
+		Transport: &http.Transport{
+			TLSClientConfig: tls.ConfigForFingerprint(params.Conf.SourceFingerprint),
 		},
-		URL: u,
-		Log: s,
+	}
+	defer hc.CloseIdleConnections()
+
+	client := webrtc.WHIPClient{
+		HTTPClient: hc,
+		URL:        u,
+		Log:        s,
 	}
 
 	tracks, err := client.Read(params.Context)

--- a/internal/staticsources/webrtc/source.go
+++ b/internal/staticsources/webrtc/source.go
@@ -56,7 +56,6 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 
 	tracks, err := client.Read(params.Context)
 	if err != nil {
-		client.Close() //nolint:errcheck
 		return err
 	}
 	defer client.Close() //nolint:errcheck

--- a/internal/staticsources/webrtc/source.go
+++ b/internal/staticsources/webrtc/source.go
@@ -53,7 +53,7 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 
 	tracks, err := client.Read(params.Context)
 	if err != nil {
-		client.Close()
+		client.Close() //nolint:errcheck
 		return err
 	}
 	defer client.Close() //nolint:errcheck

--- a/internal/staticsources/webrtc/source.go
+++ b/internal/staticsources/webrtc/source.go
@@ -53,6 +53,7 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 
 	tracks, err := client.Read(params.Context)
 	if err != nil {
+		client.Close()
 		return err
 	}
 	defer client.Close() //nolint:errcheck


### PR DESCRIPTION
Tentative fix for #3118

It still leaks, but less; Here is what remains leaking:

```
goroutine profile: total 128
50 @ 0x100843218 0x10083cae8 0x100876730 0x1008b8538 0x1008b9880 0x1008b9871 0x100a20cb8 0x100a32234 0x100b5ddd0 0x100ac7488 0x100ac75f0 0x100b5ed58 0x10087d084
#	0x10087672f	internal/poll.runtime_pollWait+0x9f		/opt/homebrew/opt/go/libexec/src/runtime/netpoll.go:345
#	0x1008b8537	internal/poll.(*pollDesc).wait+0x27		/opt/homebrew/opt/go/libexec/src/internal/poll/fd_poll_runtime.go:84
#	0x1008b987f	internal/poll.(*pollDesc).waitRead+0x1ff	/opt/homebrew/opt/go/libexec/src/internal/poll/fd_poll_runtime.go:89
#	0x1008b9870	internal/poll.(*FD).Read+0x1f0			/opt/homebrew/opt/go/libexec/src/internal/poll/fd_unix.go:164
#	0x100a20cb7	net.(*netFD).Read+0x27				/opt/homebrew/opt/go/libexec/src/net/fd_posix.go:55
#	0x100a32233	net.(*conn).Read+0x33				/opt/homebrew/opt/go/libexec/src/net/net.go:179
#	0x100b5ddcf	net/http.(*persistConn).Read+0x4f		/opt/homebrew/opt/go/libexec/src/net/http/transport.go:1976
#	0x100ac7487	bufio.(*Reader).fill+0xf7			/opt/homebrew/opt/go/libexec/src/bufio/bufio.go:110
#	0x100ac75ef	bufio.(*Reader).Peek+0x5f			/opt/homebrew/opt/go/libexec/src/bufio/bufio.go:148
#	0x100b5ed57	net/http.(*persistConn).readLoop+0x157		/opt/homebrew/opt/go/libexec/src/net/http/transport.go:2140

50 @ 0x100843218 0x1008566b8 0x100b60600 0x10087d084
#	0x100b605ff	net/http.(*persistConn).writeLoop+0x9f	/opt/homebrew/opt/go/libexec/src/net/http/transport.go:2443
```