### PR TITLE
Fix DELETE URL problem

### DIFF
--- a/internal/servers/webrtc/http_server.go
+++ b/internal/servers/webrtc/http_server.go
@@ -158,8 +158,8 @@ func (s *httpServer) onWHIPOptions(ctx *gin.Context, path string, publish bool) 
 	}
 
 	ctx.Writer.Header().Set("Access-Control-Allow-Methods", "OPTIONS, GET, POST, PATCH, DELETE")
-	ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, If-Match")
-	ctx.Writer.Header().Set("Access-Control-Expose-Headers", "Link")
+	ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, If-Match, Access-Control-Allow-Methods, ETag")
+	ctx.Writer.Header().Set("Access-Control-Expose-Headers", "Link, Access-Control-Allow-Methods, ETag")
 	ctx.Writer.Header()["Link"] = webrtc.LinkHeaderMarshal(servers)
 	ctx.Writer.WriteHeader(http.StatusNoContent)
 }
@@ -198,12 +198,16 @@ func (s *httpServer) onWHIPPost(ctx *gin.Context, path string, publish bool) {
 	}
 
 	ctx.Writer.Header().Set("Content-Type", "application/sdp")
-	ctx.Writer.Header().Set("Access-Control-Expose-Headers", "ETag, ID, Accept-Patch, Link, Location")
+	ctx.Writer.Header().Set("Access-Control-Expose-Headers", "ETag, ID, Accept-Patch, Link, Location, Access-Control-Allow-Methods")
 	ctx.Writer.Header().Set("ETag", "*")
 	ctx.Writer.Header().Set("ID", res.sx.uuid.String())
 	ctx.Writer.Header().Set("Accept-Patch", "application/trickle-ice-sdpfrag")
 	ctx.Writer.Header()["Link"] = webrtc.LinkHeaderMarshal(servers)
-	ctx.Writer.Header().Set("Location", sessionLocation(publish, res.sx.secret))
+		scheme := ctx.Request.URL.Scheme
+	if scheme == "" {
+		scheme = "http"
+	}
+	ctx.Writer.Header().Set("Location", scheme + "://" + ctx.Request.Host + ctx.Request.URL.Path + "/" + res.sx.secret.String())
 	ctx.Writer.WriteHeader(http.StatusCreated)
 	ctx.Writer.Write(res.answer)
 }
@@ -285,7 +289,7 @@ func (s *httpServer) onRequest(ctx *gin.Context) {
 	if ctx.Request.Method == http.MethodOptions &&
 		ctx.Request.Header.Get("Access-Control-Request-Method") != "" {
 		ctx.Writer.Header().Set("Access-Control-Allow-Methods", "OPTIONS, GET, POST, PATCH, DELETE")
-		ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, If-Match")
+		ctx.Writer.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, If-Match, Access-Control-Allow-Methods, ETag")
 		ctx.Writer.WriteHeader(http.StatusNoContent)
 		return
 	}

--- a/internal/servers/webrtc/http_server.go
+++ b/internal/servers/webrtc/http_server.go
@@ -203,9 +203,13 @@ func (s *httpServer) onWHIPPost(ctx *gin.Context, path string, publish bool) {
 	ctx.Writer.Header().Set("ID", res.sx.uuid.String())
 	ctx.Writer.Header().Set("Accept-Patch", "application/trickle-ice-sdpfrag")
 	ctx.Writer.Header()["Link"] = webrtc.LinkHeaderMarshal(servers)
-		scheme := ctx.Request.URL.Scheme
+	scheme := ctx.Request.URL.Scheme
 	if scheme == "" {
 		scheme = "http"
+	}
+	// Nginx detection
+	if ctx.Request.Header.Get("X-Forwarded-Proto") == "https" {
+		scheme = "https"
 	}
 	ctx.Writer.Header().Set("Location", scheme + "://" + ctx.Request.Host + ctx.Request.URL.Path + "/" + res.sx.secret.String())
 	ctx.Writer.WriteHeader(http.StatusCreated)

--- a/internal/servers/webrtc/http_server.go
+++ b/internal/servers/webrtc/http_server.go
@@ -203,15 +203,7 @@ func (s *httpServer) onWHIPPost(ctx *gin.Context, path string, publish bool) {
 	ctx.Writer.Header().Set("ID", res.sx.uuid.String())
 	ctx.Writer.Header().Set("Accept-Patch", "application/trickle-ice-sdpfrag")
 	ctx.Writer.Header()["Link"] = webrtc.LinkHeaderMarshal(servers)
-	scheme := ctx.Request.URL.Scheme
-	if scheme == "" {
-		scheme = "http"
-	}
-	// Nginx detection
-	if ctx.Request.Header.Get("X-Forwarded-Proto") == "https" {
-		scheme = "https"
-	}
-	ctx.Writer.Header().Set("Location", scheme + "://" + ctx.Request.Host + ctx.Request.URL.Path + "/" + res.sx.secret.String())
+	ctx.Writer.Header().Set("Location", ctx.Request.URL.Path + "/" + res.sx.secret.String())
 	ctx.Writer.WriteHeader(http.StatusCreated)
 	ctx.Writer.Write(res.answer)
 }


### PR DESCRIPTION
This PR addresses a problem with DELETE (missing FQDN, discussed here https://github.com/bluenviron/mediamtx/issues/3177) and fixes some CORS issues, which prevented this client to operate properly in trickle-ICE mode https://github.com/Eyevinn/whip