### PR TITLE
playback: fix concatenation of segments with multiple tracks

### DIFF
--- a/internal/playback/on_get_test.go
+++ b/internal/playback/on_get_test.go
@@ -59,27 +59,40 @@ func writeSegment1(t *testing.T, fpath string) {
 		},
 		{
 			SequenceNumber: 1,
-			Tracks: []*fmp4.PartTrack{{
-				ID:       1,
-				BaseTime: 30 * 90000,
-				Samples: []*fmp4.PartSample{
-					{
-						Duration:        30 * 90000,
-						IsNonSyncSample: false,
-						Payload:         []byte{1, 2},
-					},
-					{
-						Duration:        1 * 90000,
-						IsNonSyncSample: false,
-						Payload:         []byte{3, 4},
-					},
-					{
-						Duration:        1 * 90000,
-						IsNonSyncSample: true,
-						Payload:         []byte{5, 6},
+			Tracks: []*fmp4.PartTrack{
+				{
+					ID:       1,
+					BaseTime: 30 * 90000,
+					Samples: []*fmp4.PartSample{
+						{
+							Duration:        30 * 90000,
+							IsNonSyncSample: false,
+							Payload:         []byte{1, 2},
+						},
+						{
+							Duration:        1 * 90000,
+							IsNonSyncSample: false,
+							Payload:         []byte{3, 4},
+						},
+						{
+							Duration:        1 * 90000,
+							IsNonSyncSample: true,
+							Payload:         []byte{5, 6},
+						},
 					},
 				},
-			}},
+				{
+					ID:       2,
+					BaseTime: 29 * 90000,
+					Samples: []*fmp4.PartSample{
+						{
+							Duration:        30 * 90000,
+							IsNonSyncSample: false,
+							Payload:         []byte{1, 2},
+						},
+					},
+				},
+			},
 		},
 	}
 	err = parts.Marshal(&buf2)

--- a/internal/playback/on_list.go
+++ b/internal/playback/on_list.go
@@ -47,7 +47,7 @@ func computeDurationAndConcatenate(recordFormat conf.RecordFormat, segments []*S
 					return err
 				}
 
-				duration, err := fmp4ReadDuration(f)
+				maxDuration, err := fmp4ReadMaxDuration(f)
 				if err != nil {
 					return err
 				}
@@ -58,12 +58,12 @@ func computeDurationAndConcatenate(recordFormat conf.RecordFormat, segments []*S
 					init,
 					seg.Start) {
 					prevStart := out[len(out)-1].Start
-					curEnd := seg.Start.Add(duration)
+					curEnd := seg.Start.Add(maxDuration)
 					out[len(out)-1].Duration = listEntryDuration(curEnd.Sub(prevStart))
 				} else {
 					out = append(out, listEntry{
 						Start:    seg.Start,
-						Duration: listEntryDuration(duration),
+						Duration: listEntryDuration(maxDuration),
 					})
 				}
 


### PR DESCRIPTION
the duration of segments was computed erroneously, since it was taking into consideration the last track only. Now the duration of a segment corresponds to the maximum duration among all tracks.