### PR TITLE
deprecate path.playback parameter

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -223,10 +223,8 @@ components:
         fallback:
           type: string
 
-        # Record and playback
+        # Record
         record:
-          type: boolean
-        playback:
           type: boolean
         recordPath:
           type: string

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1128,11 +1128,6 @@ func (a *API) onRecordingsGet(ctx *gin.Context) {
 		return
 	}
 
-	if !pathConf.Playback {
-		a.writeError(ctx, http.StatusBadRequest, fmt.Errorf("playback is disabled on path '%s'", pathName))
-		return
-	}
-
 	ctx.JSON(http.StatusOK, recordingEntry(pathConf, pathName))
 }
 
@@ -1152,11 +1147,6 @@ func (a *API) onRecordingDeleteSegment(ctx *gin.Context) {
 	_, pathConf, _, err := conf.FindPathConf(c.Paths, pathName)
 	if err != nil {
 		a.writeError(ctx, http.StatusBadRequest, err)
-		return
-	}
-
-	if !pathConf.Playback {
-		a.writeError(ctx, http.StatusBadRequest, fmt.Errorf("playback is disabled on path '%s'", pathName))
 		return
 	}
 

--- a/internal/api/record.go
+++ b/internal/api/record.go
@@ -103,14 +103,12 @@ func getAllPathsWithRecordings(paths map[string]*conf.Path) []string {
 	pathNames := []string{}
 
 	for _, pathConf := range paths {
-		if pathConf.Playback {
-			if pathConf.Regexp == nil {
-				if fixedPathHasRecordings(pathConf) {
-					pathNames = append(pathNames, pathConf.Name)
-				}
-			} else {
-				pathNames = append(pathNames, regexpPathGetRecordings(pathConf)...)
+		if pathConf.Regexp == nil {
+			if fixedPathHasRecordings(pathConf) {
+				pathNames = append(pathNames, pathConf.Name)
 			}
+		} else {
+			pathNames = append(pathNames, regexpPathGetRecordings(pathConf)...)
 		}
 	}
 

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -52,7 +52,6 @@ func TestConfFromFile(t *testing.T) {
 			Source:                     "publisher",
 			SourceOnDemandStartTimeout: 10 * StringDuration(time.Second),
 			SourceOnDemandCloseAfter:   10 * StringDuration(time.Second),
-			Playback:                   true,
 			RecordPath:                 "./recordings/%path/%Y-%m-%d_%H-%M-%S-%f",
 			RecordFormat:               RecordFormatFMP4,
 			RecordPartDuration:         100000000,

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -95,9 +95,9 @@ type Path struct {
 	SRTReadPassphrase          string         `json:"srtReadPassphrase"`
 	Fallback                   string         `json:"fallback"`
 
-	// Record and playback
+	// Record
 	Record                bool           `json:"record"`
-	Playback              bool           `json:"playback"`
+	Playback              *bool          `json:"playback,omitempty"` // deprecated
 	RecordPath            string         `json:"recordPath"`
 	RecordFormat          RecordFormat   `json:"recordFormat"`
 	RecordPartDuration    StringDuration `json:"recordPartDuration"`
@@ -187,8 +187,7 @@ func (pconf *Path) setDefaults() {
 	pconf.SourceOnDemandStartTimeout = 10 * StringDuration(time.Second)
 	pconf.SourceOnDemandCloseAfter = 10 * StringDuration(time.Second)
 
-	// Record and playback
-	pconf.Playback = true
+	// Record
 	pconf.RecordPath = "./recordings/%path/%Y-%m-%d_%H-%M-%S-%f"
 	pconf.RecordFormat = RecordFormatFMP4
 	pconf.RecordPartDuration = 100 * StringDuration(time.Millisecond)

--- a/internal/playback/on_get_test.go
+++ b/internal/playback/on_get_test.go
@@ -250,7 +250,6 @@ func TestOnGet(t *testing.T) {
 		ReadTimeout: conf.StringDuration(10 * time.Second),
 		PathConfs: map[string]*conf.Path{
 			"mypath": {
-				Playback:   true,
 				RecordPath: filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
 			},
 		},
@@ -345,7 +344,6 @@ func TestOnGetDifferentInit(t *testing.T) {
 		ReadTimeout: conf.StringDuration(10 * time.Second),
 		PathConfs: map[string]*conf.Path{
 			"mypath": {
-				Playback:   true,
 				RecordPath: filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
 			},
 		},
@@ -421,7 +419,6 @@ func TestOnGetNTPCompensation(t *testing.T) {
 		ReadTimeout: conf.StringDuration(10 * time.Second),
 		PathConfs: map[string]*conf.Path{
 			"mypath": {
-				Playback:   true,
 				RecordPath: filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
 			},
 		},

--- a/internal/playback/on_list.go
+++ b/internal/playback/on_list.go
@@ -96,11 +96,6 @@ func (p *Server) onList(ctx *gin.Context) {
 		return
 	}
 
-	if !pathConf.Playback {
-		p.writeError(ctx, http.StatusBadRequest, fmt.Errorf("playback is disabled on path '%s'", pathName))
-		return
-	}
-
 	segments, err := FindSegments(pathConf, pathName)
 	if err != nil {
 		if errors.Is(err, errNoSegmentsFound) {

--- a/internal/playback/on_list_test.go
+++ b/internal/playback/on_list_test.go
@@ -31,7 +31,6 @@ func TestOnList(t *testing.T) {
 		ReadTimeout: conf.StringDuration(10 * time.Second),
 		PathConfs: map[string]*conf.Path{
 			"mypath": {
-				Playback:   true,
 				RecordPath: filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
 			},
 		},
@@ -90,7 +89,6 @@ func TestOnListDifferentInit(t *testing.T) {
 		ReadTimeout: conf.StringDuration(10 * time.Second),
 		PathConfs: map[string]*conf.Path{
 			"mypath": {
-				Playback:   true,
 				RecordPath: filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
 			},
 		},

--- a/internal/playback/segment.go
+++ b/internal/playback/segment.go
@@ -1,7 +1,6 @@
 package playback
 
 import (
-	"fmt"
 	"io/fs"
 	"path/filepath"
 	"sort"
@@ -24,10 +23,6 @@ func findSegmentsInTimespan(
 	start time.Time,
 	duration time.Duration,
 ) ([]*Segment, error) {
-	if !pathConf.Playback {
-		return nil, fmt.Errorf("playback is disabled on path '%s'", pathName)
-	}
-
 	recordPath := record.PathAddExtension(
 		strings.ReplaceAll(pathConf.RecordPath, "%path", pathName),
 		pathConf.RecordFormat,
@@ -99,10 +94,6 @@ func FindSegments(
 	pathConf *conf.Path,
 	pathName string,
 ) ([]*Segment, error) {
-	if !pathConf.Playback {
-		return nil, fmt.Errorf("playback is disabled on path '%s'", pathName)
-	}
-
 	recordPath := record.PathAddExtension(
 		strings.ReplaceAll(pathConf.RecordPath, "%path", pathName),
 		pathConf.RecordFormat,

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -372,12 +372,10 @@ pathDefaults:
   fallback:
 
   ###############################################
-  # Default path settings -> Record and playback
+  # Default path settings -> Record
 
   # Record streams to disk.
   record: no
-  # Enable serving recordings with the playback server.
-  playback: yes
   # Path of recording segments.
   # Extension is added automatically.
   # Available variables are %path (path name), %Y %m %d %H %M %S %f %s (time in strftime format)


### PR DESCRIPTION
this has become useless after the introduction of the new authentication system, that already allows to select which paths are available for playback