### PR TITLE
fix when runOnDemand for HLS, variable MTX_QUERY is empty.

### DIFF
--- a/internal/servers/hls/http_server.go
+++ b/internal/servers/hls/http_server.go
@@ -199,6 +199,7 @@ func (s *httpServer) onRequest(ctx *gin.Context) {
 		mux, err := s.parent.getMuxer(serverGetMuxerReq{
 			path:           dir,
 			remoteAddr:     httpp.RemoteAddr(ctx),
+			query:          ctx.Request.URL.RawQuery,
 			sourceOnDemand: pathConf.SourceOnDemand,
 		})
 		if err != nil {

--- a/internal/servers/hls/muxer.go
+++ b/internal/servers/hls/muxer.go
@@ -59,6 +59,7 @@ type muxer struct {
 	pathName        string
 	pathManager     serverPathManager
 	parent          *Server
+	query           string
 
 	ctx             context.Context
 	ctxCancel       func()
@@ -124,6 +125,7 @@ func (m *muxer) runInner() error {
 		AccessRequest: defs.PathAccessRequest{
 			Name:     m.pathName,
 			SkipAuth: true,
+			Query:    m.query,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
# The following environment variables are available:
...
# * MTX_QUERY: query parameters (passed by first reader)
runOnDemand:
...
The comments in the configuration file say that MTX_QUERY is available, but in fact, it is empty when the HLS stream is requested.
I passed the query from the hls/http_server to the muxer.