### PR TITLE
fix rtmp server miss the opportunity to read metadata when clients send set chunk size message after publishing stream.

### DIFF
--- a/internal/protocols/rtmp/reader.go
+++ b/internal/protocols/rtmp/reader.go
@@ -501,6 +501,11 @@ func (r *Reader) readTracks() (format.Format, format.Format, error) {
 			}
 		}
 
+		// skip SetChunkSize
+		if _, ok := msg.(*message.SetChunkSize); ok {
+			continue
+		}
+
 		if data, ok := msg.(*message.DataAMF0); ok && len(data.Payload) >= 1 {
 			payload := data.Payload
 


### PR DESCRIPTION
some rtmp client will send set chunk size after publishing stream, which causes the metadata to fail to be read.
I add code to skip set chunk size message in readTracks() in rtmp/reader.go.
