### PR TITLE
fix unexpected behavior of authInternalUsers or authHTTPExclude

### DIFF
--- a/internal/conf/auth_internal_users.go
+++ b/internal/conf/auth_internal_users.go
@@ -1,5 +1,9 @@
 package conf
 
+import (
+	"encoding/json"
+)
+
 // AuthInternalUserPermission is a permission of a user.
 type AuthInternalUserPermission struct {
 	Action AuthAction `json:"action"`
@@ -12,4 +16,26 @@ type AuthInternalUser struct {
 	Pass        Credential                   `json:"pass"`
 	IPs         IPNetworks                   `json:"ips"`
 	Permissions []AuthInternalUserPermission `json:"permissions"`
+}
+
+// AuthInternalUsers is a list of AuthInternalUser
+type AuthInternalUsers []AuthInternalUser
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *AuthInternalUsers) UnmarshalJSON(b []byte) error {
+	// remove default value before loading new value
+	// https://github.com/golang/go/issues/21092
+	*s = nil
+	return json.Unmarshal(b, (*[]AuthInternalUser)(s))
+}
+
+// AuthInternalUserPermissions is a list of AuthInternalUserPermission
+type AuthInternalUserPermissions []AuthInternalUserPermission
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *AuthInternalUserPermissions) UnmarshalJSON(b []byte) error {
+	// remove default value before loading new value
+	// https://github.com/golang/go/issues/21092
+	*s = nil
+	return json.Unmarshal(b, (*[]AuthInternalUserPermission)(s))
 }

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -120,6 +120,7 @@ func anyPathHasDeprecatedCredentials(paths map[string]*OptionalPath) bool {
 }
 
 // Conf is a configuration.
+// WARNING: Avoid using slices directly due to https://github.com/golang/go/issues/21092
 type Conf struct {
 	// General
 	LogLevel            LogLevel        `json:"logLevel"`
@@ -135,12 +136,12 @@ type Conf struct {
 	RunOnDisconnect     string          `json:"runOnDisconnect"`
 
 	// Authentication
-	AuthMethod                AuthMethod                   `json:"authMethod"`
-	AuthInternalUsers         []AuthInternalUser           `json:"authInternalUsers"`
-	AuthHTTPAddress           string                       `json:"authHTTPAddress"`
-	ExternalAuthenticationURL *string                      `json:"externalAuthenticationURL,omitempty"` // deprecated
-	AuthHTTPExclude           []AuthInternalUserPermission `json:"authHTTPExclude"`
-	AuthJWTJWKS               string                       `json:"authJWTJWKS"`
+	AuthMethod                AuthMethod                  `json:"authMethod"`
+	AuthInternalUsers         AuthInternalUsers           `json:"authInternalUsers"`
+	AuthHTTPAddress           string                      `json:"authHTTPAddress"`
+	ExternalAuthenticationURL *string                     `json:"externalAuthenticationURL,omitempty"` // deprecated
+	AuthHTTPExclude           AuthInternalUserPermissions `json:"authHTTPExclude"`
+	AuthJWTJWKS               string                      `json:"authJWTJWKS"`
 
 	// Control API
 	API               bool       `json:"api"`
@@ -222,24 +223,24 @@ type Conf struct {
 	HLSDirectory       string         `json:"hlsDirectory"`
 
 	// WebRTC server
-	WebRTC                      bool              `json:"webrtc"`
-	WebRTCDisable               *bool             `json:"webrtcDisable,omitempty"` // deprecated
-	WebRTCAddress               string            `json:"webrtcAddress"`
-	WebRTCEncryption            bool              `json:"webrtcEncryption"`
-	WebRTCServerKey             string            `json:"webrtcServerKey"`
-	WebRTCServerCert            string            `json:"webrtcServerCert"`
-	WebRTCAllowOrigin           string            `json:"webrtcAllowOrigin"`
-	WebRTCTrustedProxies        IPNetworks        `json:"webrtcTrustedProxies"`
-	WebRTCLocalUDPAddress       string            `json:"webrtcLocalUDPAddress"`
-	WebRTCLocalTCPAddress       string            `json:"webrtcLocalTCPAddress"`
-	WebRTCIPsFromInterfaces     bool              `json:"webrtcIPsFromInterfaces"`
-	WebRTCIPsFromInterfacesList []string          `json:"webrtcIPsFromInterfacesList"`
-	WebRTCAdditionalHosts       []string          `json:"webrtcAdditionalHosts"`
-	WebRTCICEServers2           []WebRTCICEServer `json:"webrtcICEServers2"`
-	WebRTCICEUDPMuxAddress      *string           `json:"webrtcICEUDPMuxAddress,omitempty"`  // deprecated
-	WebRTCICETCPMuxAddress      *string           `json:"webrtcICETCPMuxAddress,omitempty"`  // deprecated
-	WebRTCICEHostNAT1To1IPs     *[]string         `json:"webrtcICEHostNAT1To1IPs,omitempty"` // deprecated
-	WebRTCICEServers            *[]string         `json:"webrtcICEServers,omitempty"`        // deprecated
+	WebRTC                      bool             `json:"webrtc"`
+	WebRTCDisable               *bool            `json:"webrtcDisable,omitempty"` // deprecated
+	WebRTCAddress               string           `json:"webrtcAddress"`
+	WebRTCEncryption            bool             `json:"webrtcEncryption"`
+	WebRTCServerKey             string           `json:"webrtcServerKey"`
+	WebRTCServerCert            string           `json:"webrtcServerCert"`
+	WebRTCAllowOrigin           string           `json:"webrtcAllowOrigin"`
+	WebRTCTrustedProxies        IPNetworks       `json:"webrtcTrustedProxies"`
+	WebRTCLocalUDPAddress       string           `json:"webrtcLocalUDPAddress"`
+	WebRTCLocalTCPAddress       string           `json:"webrtcLocalTCPAddress"`
+	WebRTCIPsFromInterfaces     bool             `json:"webrtcIPsFromInterfaces"`
+	WebRTCIPsFromInterfacesList []string         `json:"webrtcIPsFromInterfacesList"`
+	WebRTCAdditionalHosts       []string         `json:"webrtcAdditionalHosts"`
+	WebRTCICEServers2           WebRTCICEServers `json:"webrtcICEServers2"`
+	WebRTCICEUDPMuxAddress      *string          `json:"webrtcICEUDPMuxAddress,omitempty"`  // deprecated
+	WebRTCICETCPMuxAddress      *string          `json:"webrtcICETCPMuxAddress,omitempty"`  // deprecated
+	WebRTCICEHostNAT1To1IPs     *[]string        `json:"webrtcICEHostNAT1To1IPs,omitempty"` // deprecated
+	WebRTCICEServers            *[]string        `json:"webrtcICEServers,omitempty"`        // deprecated
 
 	// SRT server
 	SRT        bool   `json:"srt"`

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -324,3 +324,31 @@ func TestSampleConfFile(t *testing.T) {
 		require.Equal(t, conf1.Paths, conf2.Paths)
 	}()
 }
+
+// needed due to https://github.com/golang/go/issues/21092
+func TestConfOverrideDefaultSlices(t *testing.T) {
+	tmpf, err := createTempFile([]byte(
+		"authInternalUsers:\n" +
+			"  - user: user1\n" +
+			"  - user: user2\n" +
+			"authHTTPExclude:\n" +
+			"  - path: ''\n"))
+	require.NoError(t, err)
+	defer os.Remove(tmpf)
+
+	conf, _, err := Load(tmpf, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, AuthInternalUsers{
+		{
+			User: "user1",
+		},
+		{
+			User: "user2",
+		},
+	}, conf.AuthInternalUsers)
+
+	require.Equal(t, AuthInternalUserPermissions{
+		{},
+	}, conf.AuthHTTPExclude)
+}

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -81,6 +81,7 @@ func FindPathConf(pathConfs map[string]*Path, name string) (string, *Path, []str
 }
 
 // Path is a path configuration.
+// WARNING: Avoid using slices directly due to https://github.com/golang/go/issues/21092
 type Path struct {
 	Regexp *regexp.Regexp `json:"-"`    // filled by Check()
 	Name   string         `json:"name"` // filled by Check()

--- a/internal/conf/webrtc_ice_server.go
+++ b/internal/conf/webrtc_ice_server.go
@@ -1,9 +1,22 @@
 package conf
 
+import "encoding/json"
+
 // WebRTCICEServer is a WebRTC ICE Server.
 type WebRTCICEServer struct {
 	URL        string `json:"url"`
 	Username   string `json:"username"`
 	Password   string `json:"password"`
 	ClientOnly bool   `json:"clientOnly"`
+}
+
+// WebRTCICEServers is a list of WebRTCICEServer
+type WebRTCICEServers []WebRTCICEServer
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *WebRTCICEServers) UnmarshalJSON(b []byte) error {
+	// remove default value before loading new value
+	// https://github.com/golang/go/issues/21092
+	*s = nil
+	return json.Unmarshal(b, (*[]WebRTCICEServer)(s))
 }


### PR DESCRIPTION
when some subfields of authInternalUsers and authHTTPExclude were not set explicitly in the configuration file, default values were used in their place. This is caused by a strange behavior of Go (https://github.com/golang/go/issues/21092)