### PR TITLE
HLS: make closeAfterInactivity configurable

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -199,6 +199,8 @@ components:
           type: string
         hlsDirectory:
           type: string
+        hlsMuxerCloseAfter:
+          type: string
 
         # WebRTC server
         webrtc:

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -221,6 +221,7 @@ type Conf struct {
 	HLSPartDuration    StringDuration `json:"hlsPartDuration"`
 	HLSSegmentMaxSize  StringSize     `json:"hlsSegmentMaxSize"`
 	HLSDirectory       string         `json:"hlsDirectory"`
+	HLSMuxerCloseAfter StringDuration `json:"hlsMuxerCloseAfter"`
 
 	// WebRTC server
 	WebRTC                      bool             `json:"webrtc"`
@@ -378,6 +379,7 @@ func (conf *Conf) setDefaults() {
 	conf.HLSSegmentDuration = 1 * StringDuration(time.Second)
 	conf.HLSPartDuration = 200 * StringDuration(time.Millisecond)
 	conf.HLSSegmentMaxSize = 50 * 1024 * 1024
+	conf.HLSMuxerCloseAfter = 60 * StringDuration(time.Second)
 
 	// WebRTC server
 	conf.WebRTC = true

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -546,6 +546,7 @@ func (p *Core) createResources(initial bool) error {
 			Directory:       p.conf.HLSDirectory,
 			ReadTimeout:     p.conf.ReadTimeout,
 			WriteQueueSize:  p.conf.WriteQueueSize,
+			MuxerCloseAfter: p.conf.HLSMuxerCloseAfter,
 			PathManager:     p.pathManager,
 			Parent:          p,
 		}
@@ -826,6 +827,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.HLSDirectory != p.conf.HLSDirectory ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteQueueSize != p.conf.WriteQueueSize ||
+		newConf.HLSMuxerCloseAfter != p.conf.HLSMuxerCloseAfter ||
 		closePathManager ||
 		closeMetrics ||
 		closeLogger

--- a/internal/servers/hls/muxer.go
+++ b/internal/servers/hls/muxer.go
@@ -15,9 +15,8 @@ import (
 )
 
 const (
-	closeCheckPeriod     = 1 * time.Second
-	closeAfterInactivity = 60 * time.Second
-	recreatePause        = 10 * time.Second
+	closeCheckPeriod = 1 * time.Second
+	recreatePause    = 10 * time.Second
 )
 
 func int64Ptr(v int64) *int64 {
@@ -55,6 +54,7 @@ type muxer struct {
 	segmentMaxSize  conf.StringSize
 	directory       string
 	writeQueueSize  int
+	closeAfter      conf.StringDuration
 	wg              *sync.WaitGroup
 	pathName        string
 	pathManager     serverPathManager
@@ -221,7 +221,7 @@ func (m *muxer) runInner() error {
 
 		case <-activityCheckTimer.C:
 			t := time.Unix(0, atomic.LoadInt64(m.lastRequestTime))
-			if time.Since(t) >= closeAfterInactivity {
+			if time.Since(t) >= time.Duration(m.closeAfter) {
 				return fmt.Errorf("not used anymore")
 			}
 			activityCheckTimer = time.NewTimer(closeCheckPeriod)

--- a/internal/servers/hls/server.go
+++ b/internal/servers/hls/server.go
@@ -75,6 +75,7 @@ type Server struct {
 	Directory       string
 	ReadTimeout     conf.StringDuration
 	WriteQueueSize  int
+	MuxerCloseAfter conf.StringDuration
 	PathManager     serverPathManager
 	Parent          serverParent
 
@@ -232,6 +233,7 @@ func (s *Server) createMuxer(pathName string, remoteAddr string, query string) *
 		pathManager:     s.PathManager,
 		parent:          s,
 		query:           query,
+		closeAfter:      s.MuxerCloseAfter,
 	}
 	r.initialize()
 	s.muxers[pathName] = r

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -329,6 +329,9 @@ hlsSegmentMaxSize: 50M
 # This decreases performance, since reading from disk is less performant than
 # reading from RAM, but allows to save RAM.
 hlsDirectory: ''
+# The muxer will be closed when there are no
+# reader requests and this amount of time has passed.
+hlsMuxerCloseAfter: 60s
 
 ###############################################
 # Global settings -> WebRTC server


### PR DESCRIPTION
"closeAfterInactivity"  was dead code fixed at 60 seconds, indicates the muxer will be closed when there is no readers request and this amount of time has passed.
This PR adds "hlsMuxerCloseAfter" in mediamtx.yml to do the same thing.