### PR TITLE
api: make replace paths idempotent

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -758,9 +758,8 @@ func (conf *Conf) PatchPath(name string, optional2 *OptionalPath) error {
 
 // ReplacePath replaces a path.
 func (conf *Conf) ReplacePath(name string, optional2 *OptionalPath) error {
-	_, ok := conf.OptionalPaths[name]
-	if !ok {
-		return ErrPathNotFound
+	if conf.OptionalPaths == nil {
+		conf.OptionalPaths = make(map[string]*OptionalPath)
 	}
 
 	conf.OptionalPaths[name] = optional2


### PR DESCRIPTION
Don't return a 404 error if the path doesn't exist yet

Fixes https://github.com/bluenviron/mediamtx/issues/3361