### PR TITLE
fix single aac file rtmp publish error.

### DIFF
--- a/internal/protocols/rtmp/reader.go
+++ b/internal/protocols/rtmp/reader.go
@@ -327,6 +327,9 @@ func tracksFromMetadata(conn *Conn, payload []interface{}) (format.Format, forma
 			}
 
 			if audioTrack == nil {
+				if len(msg.Payload) == 0 {
+					continue
+				}
 				switch {
 				case msg.Codec == message.CodecMPEG4Audio &&
 					msg.AACType == message.AudioAACTypeConfig:

--- a/internal/protocols/rtmp/reader_test.go
+++ b/internal/protocols/rtmp/reader_test.go
@@ -333,6 +333,77 @@ func TestReadTracks(t *testing.T) {
 			},
 		},
 		{
+			"aac, issue mediamtx/3414 (empty audio payload)",
+			nil,
+			&format.MPEG4Audio{
+				PayloadTyp: 96,
+				Config: &mpeg4audio.Config{
+					Type:         2,
+					SampleRate:   44100,
+					ChannelCount: 2,
+				},
+				SizeLength:       13,
+				IndexLength:      3,
+				IndexDeltaLength: 3,
+			},
+			[]message.Message{
+				&message.DataAMF0{
+					ChunkStreamID:   4,
+					MessageStreamID: 1,
+					Payload: []interface{}{
+						"@setDataFrame",
+						"onMetaData",
+						amf0.Object{
+							{
+								Key:   "videodatarate",
+								Value: float64(0),
+							},
+							{
+								Key:   "videocodecid",
+								Value: float64(0),
+							},
+							{
+								Key:   "audiodatarate",
+								Value: float64(0),
+							},
+							{
+								Key:   "audiocodecid",
+								Value: float64(message.CodecMPEG4Audio),
+							},
+						},
+					},
+				},
+				&message.Audio{
+					ChunkStreamID:   message.AudioChunkStreamID,
+					MessageStreamID: 0x1000000,
+					Codec:           message.CodecMPEG4Audio,
+					Rate:            message.Rate44100,
+					Depth:           message.Depth16,
+					IsStereo:        true,
+					AACType:         message.AudioAACTypeConfig,
+					Payload:         nil,
+				},
+				&message.Audio{
+					ChunkStreamID:   message.AudioChunkStreamID,
+					MessageStreamID: 0x1000000,
+					Codec:           message.CodecMPEG4Audio,
+					Rate:            message.Rate44100,
+					Depth:           message.Depth16,
+					IsStereo:        true,
+					AACType:         message.AudioAACTypeConfig,
+					Payload: func() []byte {
+						enc, err2 := mpeg4audio.Config{
+							Type:         2,
+							SampleRate:   44100,
+							ChannelCount: 2,
+						}.Marshal()
+						require.NoError(t, err2)
+						return enc
+					}(),
+				},
+			},
+		},
+		{
 			"h265 + aac, obs studio pre 29.1 h265",
 			&format.H265{
 				PayloadTyp: 96,


### PR DESCRIPTION
## Which version are you using?

current main branch.

## Which operating system are you using?

- [x] macOS amd64 standard


## Describe the issue

when I publish an aac file by ffmpeg to `mediamtx`, I met an error.

> 2024/06/01 17:10:55 INF [RTMP] [conn [::1]:57689] closed: not enough bits

The root cause is the `mediamtx` want to parse an audio message with empty payload.

## Describe how to replicate the issue

<!--
the maintainers must be able to REPLICATE your issue to solve it - therefore, describe in a very detailed way how to replicate it.
-->

1. start the server: `./mediamtx`
2. publish an aac file with ffmpeg: `ffmpeg -stream_loop -1 -re -i music.aac -c copy -f flv -y rtmp://localhost/live/test`
3. check the `mediamtx` log: `INF [RTMP] [conn [::1]:57689] closed: not enough bits`
    and `ffmpeg` cmd exit with error.

## Did you attach the server logs?

yes 
<details>

<summary>MediaMTX logs</summary>

```
2024/06/01 17:10:53 INF MediaMTX v0.0.0
2024/06/01 17:10:53 INF configuration loaded from /Users/jacobsu/hack/media/mediamtx/mediamtx.yml
2024/06/01 17:10:53 INF [RTSP] listener opened on :8554 (TCP), :8000 (UDP/RTP), :8001 (UDP/RTCP)
2024/06/01 17:10:53 INF [RTMP] listener opened on :1935
2024/06/01 17:10:53 INF [HLS] listener opened on :8888
2024/06/01 17:10:53 INF [WebRTC] listener opened on :8889 (HTTP), :8189 (ICE/UDP)
2024/06/01 17:10:53 INF [SRT] listener opened on :8890 (UDP)
2024/06/01 17:10:55 INF [RTMP] [conn [::1]:57689] opened
2024/06/01 17:10:55 INF [RTMP] [conn [::1]:57689] closed: not enough bits
```

</details>

## Did you attach a network dump?
no