### PR TITLE
record: set MTX_SEGMENT_DURATION in runOnRecordSegmentComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1669,6 +1669,7 @@ pathDefaults:
   # * G1, G2, ...: regular expression groups, if path name is
   #   a regular expression.
   # * MTX_SEGMENT_PATH: segment file path
+  # * MTX_SEGMENT_DURATION: segment duration
   runOnRecordSegmentComplete: curl http://my-custom-server/webhook?path=$MTX_PATH&segment_path=$MTX_SEGMENT_PATH
 ```
 

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -810,6 +810,9 @@ func (pa *path) startRecording() {
 			if pa.conf.RunOnRecordSegmentComplete != "" {
 				env := pa.ExternalCmdEnv()
 				env["MTX_SEGMENT_PATH"] = segmentPath
+				env["MTX_SEGMENT_DURATION"] = strconv.FormatFloat(
+					time.Duration(pa.conf.RecordSegmentDuration).Seconds(), 'f', -1, 64,
+				)
 
 				pa.Log(logger.Info, "runOnRecordSegmentComplete command launched")
 				externalcmd.NewCmd(

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -675,6 +675,7 @@ pathDefaults:
   # * G1, G2, ...: regular expression groups, if path name is
   #   a regular expression.
   # * MTX_SEGMENT_PATH: segment file path
+  # * MTX_SEGMENT_DURATION: segment duration
   runOnRecordSegmentComplete:
 
 ###############################################


### PR DESCRIPTION
Provide `MTX_SEGMENT_DURATION` to the external command in the `runOnRecordSegmentComplete` hook. The duration of individual segments is useful when creating an HLS playlist.

Issue #2983