### PR TITLE
webrtc: support publishing H265 tracks (#3435)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Live streams can be published to the server with:
 |--------|--------|------------|------------|
 |[SRT clients](#srt-clients)||H265, H264, MPEG-4 Video (H263, Xvid), MPEG-1/2 Video|Opus, MPEG-4 Audio (AAC), MPEG-1/2 Audio (MP3), AC-3|
 |[SRT cameras and servers](#srt-cameras-and-servers)||H265, H264, MPEG-4 Video (H263, Xvid), MPEG-1/2 Video|Opus, MPEG-4 Audio (AAC), MPEG-1/2 Audio (MP3), AC-3|
-|[WebRTC clients](#webrtc-clients)|Browser-based, WHIP|AV1, VP9, VP8, H264|Opus, G722, G711 (PCMA, PCMU)|
-|[WebRTC servers](#webrtc-servers)|WHEP|AV1, VP9, VP8, H264|Opus, G722, G711 (PCMA, PCMU)|
+|[WebRTC clients](#webrtc-clients)|Browser-based, WHIP|AV1, VP9, VP8, H265, H264|Opus, G722, G711 (PCMA, PCMU)|
+|[WebRTC servers](#webrtc-servers)|WHEP|AV1, VP9, VP8, H265, H264|Opus, G722, G711 (PCMA, PCMU)|
 |[RTSP clients](#rtsp-clients)|UDP, TCP, RTSPS|AV1, VP9, VP8, H265, H264, MPEG-4 Video (H263, Xvid), MPEG-1/2 Video, M-JPEG and any RTP-compatible codec|Opus, MPEG-4 Audio (AAC), MPEG-1/2 Audio (MP3), AC-3, G726, G722, G711 (PCMA, PCMU), LPCM and any RTP-compatible codec|
 |[RTSP cameras and servers](#rtsp-cameras-and-servers)|UDP, UDP-Multicast, TCP, RTSPS|AV1, VP9, VP8, H265, H264, MPEG-4 Video (H263, Xvid), MPEG-1/2 Video, M-JPEG and any RTP-compatible codec|Opus, MPEG-4 Audio (AAC), MPEG-1/2 Audio (MP3), AC-3, G726, G722, G711 (PCMA, PCMU), LPCM and any RTP-compatible codec|
 |[RTMP clients](#rtmp-clients)|RTMP, RTMPS, Enhanced RTMP|AV1, VP9, H265, H264|MPEG-4 Audio (AAC), MPEG-1/2 Audio (MP3), G711 (PCMA, PCMU), LPCM|

--- a/internal/protocols/webrtc/outgoing_track.go
+++ b/internal/protocols/webrtc/outgoing_track.go
@@ -54,6 +54,15 @@ func (t *OutgoingTrack) codecParameters() (webrtc.RTPCodecParameters, error) {
 			PayloadType: 96,
 		}, nil
 
+	case *format.H265:
+		return webrtc.RTPCodecParameters{
+			RTPCodecCapability: webrtc.RTPCodecCapability{
+				MimeType:  webrtc.MimeTypeH265,
+				ClockRate: 90000,
+			},
+			PayloadType: 96,
+		}, nil
+
 	case *format.H264:
 		return webrtc.RTPCodecParameters{
 			RTPCodecCapability: webrtc.RTPCodecCapability{
@@ -205,6 +214,7 @@ func (t *OutgoingTrack) isVideo() bool {
 	case *format.AV1,
 		*format.VP9,
 		*format.VP8,
+		*format.H265,
 		*format.H264:
 		return true
 	}

--- a/internal/protocols/webrtc/peer_connection_test.go
+++ b/internal/protocols/webrtc/peer_connection_test.go
@@ -84,6 +84,17 @@ func TestPeerConnectionPublishRead(t *testing.T) {
 			},
 		},
 		{
+			"h265",
+			test.FormatH265,
+			webrtc.RTPCodecCapability{
+				MimeType:  "video/H265",
+				ClockRate: 90000,
+			},
+			&format.H265{
+				PayloadTyp: 96,
+			},
+		},
+		{
 			"h264",
 			test.FormatH264,
 			webrtc.RTPCodecCapability{

--- a/internal/protocols/webrtc/tracks_to_medias.go
+++ b/internal/protocols/webrtc/tracks_to_medias.go
@@ -10,21 +10,9 @@ func TracksToMedias(tracks []*IncomingTrack) []*description.Media {
 	ret := make([]*description.Media, len(tracks))
 
 	for i, track := range tracks {
-		forma := track.Format()
-
-		var mediaType description.MediaType
-
-		switch forma.(type) {
-		case *format.AV1, *format.VP9, *format.VP8, *format.H264:
-			mediaType = description.MediaTypeVideo
-
-		default:
-			mediaType = description.MediaTypeAudio
-		}
-
 		ret[i] = &description.Media{
-			Type:    mediaType,
-			Formats: []format.Format{forma},
+			Type:    track.typ,
+			Formats: []format.Format{track.format},
 		}
 	}
 


### PR DESCRIPTION
Fixes #3435

IMPORTANT NOTE: this doesn't allow to read H265 tracks with WebRTC, just to publish them. The inability to read H265 tracks with WebRTC is not in any way related to the server but depends on browsers and on the fact that they are not legally entitled to embed a H265 decoder inside them.