### PR TITLE
onDemandPublisherStop when publisher removed  #3455

### DIFF
--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -826,6 +826,9 @@ func (pa *path) executeRemoveReader(r defs.Reader) {
 func (pa *path) executeRemovePublisher() {
 	if pa.stream != nil {
 		pa.setNotReady()
+		if pa.conf.HasOnDemandPublisher() && pa.onDemandPublisherState != pathOnDemandStateInitial {
+			pa.onDemandPublisherStop("publisher removed")
+		}
 	}
 
 	pa.source = nil


### PR DESCRIPTION
This should call `onDemandPublisherStop` when a publisher is removed instead of waiting for `onDemandPublisherCloseTimer` to timeout which would cause the path to block if `runOnDemandCloseAfter` is set (#3455).