### PR TITLE
remove whitespace from hashBuf

### DIFF
--- a/internal/servers/hls/hlsjsdownloader/main.go
+++ b/internal/servers/hls/hlsjsdownloader/main.go
@@ -45,10 +45,10 @@ func do() error {
 		return err
 	}
 
-	hashBuf = []byte(strings.TrimSpace(string(hashBuf)))
-	hash := make([]byte, hex.DecodedLen(len(hashBuf)))
+	str := strings.TrimSpace(string(hashBuf))
 
-	if _, err = hex.Decode(hash, bytes.TrimSpace(hashBuf)); err != nil {
+	hash, err := hex.DecodeString(str)
+	if err != nil {
 		return err
 	}
 

--- a/internal/servers/hls/hlsjsdownloader/main.go
+++ b/internal/servers/hls/hlsjsdownloader/main.go
@@ -44,6 +44,8 @@ func do() error {
 	if err != nil {
 		return err
 	}
+
+	hashBuf = []byte(strings.TrimSpace(string(hashBuf)))
 	hash := make([]byte, hex.DecodedLen(len(hashBuf)))
 
 	if _, err = hex.Decode(hash, bytes.TrimSpace(hashBuf)); err != nil {


### PR DESCRIPTION
In Windows, `go generate ./...` was causing a `ERR: hash mismatch` error.

To resolve this issue, I added a line to trim any whitespace from the `hashBuf`

errors no longer occur