### PR TITLE
selinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1459,6 +1459,13 @@ WantedBy=multi-user.target
 EOF
 ```
 
+If SELinux is enabled (for instance in case of RedHat, Rocky, CentOS++), add correct security context:
+
+```sh
+semanage fcontext -a -t bin_t /usr/local/bin/mediamtx
+restorecon -Fv /usr/local/bin/mediamtx
+```
+
 Enable and start the service:
 
 ```sh


### PR DESCRIPTION
documentation was lacking information on security context to binary which resulted SELinux based distros to deny execution trough service. I've added documentation how to fix this without turning SELinux off.

Closes #3700