### PR TITLE
KLV metadata handling

### DIFF
--- a/internal/formatprocessor/klv.go
+++ b/internal/formatprocessor/klv.go
@@ -1,0 +1,134 @@
+package formatprocessor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bluenviron/gortsplib/v4/pkg/format"
+	"github.com/bluenviron/gortsplib/v4/pkg/format/rtpsimpleaudio"
+	"github.com/bluenviron/gortsplib/v4/pkg/rtptime"
+	"github.com/pion/rtp"
+
+	"github.com/bluenviron/mediamtx/internal/unit"
+)
+
+type formatProcessorKLV struct {
+	udpMaxPayloadSize int
+	format            *format.KLV
+	timeEncoder       *rtptime.Encoder
+	encoder           *rtpsimpleaudio.Encoder
+	decoder           *rtpsimpleaudio.Decoder
+}
+
+func newKLV(
+	udpMaxPayloadSize int,
+	forma *format.KLV,
+	generateRTPPackets bool,
+) (*formatProcessorKLV, error) {
+	t := &formatProcessorKLV{
+		udpMaxPayloadSize: udpMaxPayloadSize,
+		format:            forma,
+	}
+
+	if generateRTPPackets {
+		err := t.createEncoder()
+		if err != nil {
+			return nil, err
+		}
+
+		t.timeEncoder = &rtptime.Encoder{
+			ClockRate: forma.ClockRate(),
+		}
+		err = t.timeEncoder.Initialize()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return t, nil
+}
+
+func (t *formatProcessorKLV) createEncoder() error {
+	t.encoder = &rtpsimpleaudio.Encoder{
+		PayloadMaxSize: t.udpMaxPayloadSize - 12,
+		PayloadType:    t.format.PayloadTyp,
+	}
+	return t.encoder.Init()
+}
+
+func (t *formatProcessorKLV) ProcessUnit(uu unit.Unit) error { //nolint:dupl
+	u := uu.(*unit.KLV)
+
+	var rtpPackets []*rtp.Packet
+	pts := u.PTS
+
+	if u.Packets != nil {
+		// ensure the format processor's encoder is initialized
+		if t.encoder == nil {
+			err := t.createEncoder()
+			if err != nil {
+				return err
+			}
+		}
+		pkt, err := t.encoder.Encode(u.Packets)
+		if err != nil {
+			return err
+		}
+
+		ts := t.timeEncoder.Encode(pts)
+		for _, pkt := range u.RTPPackets {
+			pkt.Timestamp += ts
+		}
+
+		rtpPackets = append(rtpPackets, pkt)
+	}
+
+	u.RTPPackets = rtpPackets
+
+	return nil
+}
+
+func (t *formatProcessorKLV) ProcessRTPPacket(
+	pkt *rtp.Packet,
+	ntp time.Time,
+	pts time.Duration,
+	hasNonRTSPReaders bool,
+) (Unit, error) {
+	u := &unit.KLV{
+		Base: unit.Base{
+			RTPPackets: []*rtp.Packet{pkt},
+			NTP:        ntp,
+			PTS:        pts,
+		},
+	}
+
+	// remove padding
+	pkt.Header.Padding = false
+	pkt.PaddingSize = 0
+
+	if pkt.MarshalSize() > t.udpMaxPayloadSize {
+		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
+			pkt.MarshalSize(), t.udpMaxPayloadSize)
+	}
+
+	// decode from RTP
+	if hasNonRTSPReaders || t.decoder != nil {
+		if t.decoder == nil {
+			var err error
+			t.decoder, err = t.format.CreateDecoder()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		packet, err := t.decoder.Decode(pkt)
+		if err != nil {
+			return nil, err
+		}
+
+		u.Packets = packet
+	}
+
+	// route packet as is
+	return u, nil
+}

--- a/internal/formatprocessor/klv_test.go
+++ b/internal/formatprocessor/klv_test.go
@@ -1,0 +1,110 @@
+package formatprocessor
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/asticode/go-astits"
+	"github.com/bluenviron/gortsplib/v4/pkg/format"
+	"github.com/bluenviron/mediacommon/pkg/formats/mpegts"
+	"github.com/bluenviron/mediamtx/internal/unit"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKlvCreateEncoder(t *testing.T) {
+	// create KLV format processor
+	klv_codec := mpegts.CodecKLV{
+		StreamType:      astits.StreamTypePrivateData,
+		StreamID:        1,
+		PTSDTSIndicator: 1,
+	}
+	forma := &format.KLV{
+		PayloadTyp: 96,
+		KLVCodec:   &klv_codec,
+	}
+	p, err := newKLV(1472, forma, false)
+	require.NoError(t, err)
+	err = p.createEncoder()
+	require.NoError(t, err)
+}
+
+func TestKlvProcessUnit(t *testing.T) {
+	// create KLV format processor
+	klv_codec := mpegts.CodecKLV{
+		StreamType:      astits.StreamTypePrivateData,
+		StreamID:        1,
+		PTSDTSIndicator: 1,
+	}
+	forma := &format.KLV{
+		PayloadTyp: 96,
+		KLVCodec:   &klv_codec,
+	}
+	p, err := newKLV(1472, forma, true)
+	require.NoError(t, err)
+	// create test Unit
+	theTime := time.Now()
+	when, err := time.ParseDuration("5s")
+	require.NoError(t, err)
+	u := unit.KLV{
+		unit.Base{
+			nil,
+			theTime,
+			when,
+		},
+		[]byte{1, 2, 3, 4},
+	}
+	uu := &u
+	// process the unit
+	err = p.ProcessUnit(uu)
+	require.NoError(t, err)
+	// compare output
+	for i, pkt := range u.RTPPackets {
+		fmt.Printf("RTP packet[%v]: %+v\n", i, pkt)
+	}
+}
+
+func TestKlvProcessRTPPacket(t *testing.T) {
+	// create KLV format processor
+	klv_codec := mpegts.CodecKLV{
+		StreamType:      astits.StreamTypePrivateData,
+		StreamID:        1,
+		PTSDTSIndicator: 1,
+	}
+	forma := &format.KLV{
+		PayloadTyp: 96,
+		KLVCodec:   &klv_codec,
+	}
+	p, err := newKLV(1472, forma, false)
+	require.NoError(t, err)
+	// create test RTP packet
+	pkt := &rtp.Packet{
+		Header: rtp.Header{
+			Version:        2,
+			Marker:         true,
+			PayloadType:    96,
+			SequenceNumber: 3446,
+			Timestamp:      175349,
+			SSRC:           563423,
+			Padding:        true,
+		},
+		Payload:     []byte{1, 2, 3, 4},
+		PaddingSize: 20,
+	}
+	// process the RTP packet
+	_, err = p.ProcessRTPPacket(pkt, time.Time{}, 0, false)
+	require.NoError(t, err)
+	// compare output
+	require.Equal(t, &rtp.Packet{
+		Header: rtp.Header{
+			Version:        2,
+			Marker:         true,
+			PayloadType:    96,
+			SequenceNumber: 3446,
+			Timestamp:      175349,
+			SSRC:           563423,
+		},
+		Payload: []byte{1, 2, 3, 4},
+	}, pkt)
+}

--- a/internal/formatprocessor/processor.go
+++ b/internal/formatprocessor/processor.go
@@ -55,6 +55,9 @@ func New(
 	case *format.Opus:
 		return newOpus(udpMaxPayloadSize, forma, generateRTPPackets)
 
+	case *format.KLV:
+		return newKLV(udpMaxPayloadSize, forma, generateRTPPackets)
+
 	case *format.MPEG4Audio:
 		return newMPEG4Audio(udpMaxPayloadSize, forma, generateRTPPackets)
 

--- a/internal/protocols/mpegts/from_stream.go
+++ b/internal/protocols/mpegts/from_stream.go
@@ -182,6 +182,24 @@ func FromStream(
 					return bw.Flush()
 				})
 
+			case *format.KLV:
+				codec := forma.KLVCodec
+				track := addTrack(codec) //&mcmpegts.CodecKLV{ })
+
+				stream.AddReader(writer, medi, forma, func(u unit.Unit) error {
+					tunit := u.(*unit.KLV)
+					if tunit.Packets == nil {
+						return nil
+					}
+
+					sconn.SetWriteDeadline(time.Now().Add(writeTimeout))
+					err := (*w).WriteKLV(track, durationGoToMPEGTS(tunit.PTS), tunit.Packets)
+					if err != nil {
+						return err
+					}
+					return bw.Flush()
+				})
+
 			case *format.MPEG4Audio:
 				co := forma.GetConfig()
 				if co == nil {

--- a/internal/protocols/mpegts/to_stream.go
+++ b/internal/protocols/mpegts/to_stream.go
@@ -128,6 +128,26 @@ func ToStream(r *mpegts.Reader, stream **stream.Stream) ([]*description.Media, e
 				return nil
 			})
 
+		case *mpegts.CodecKLV:
+			klvCodec := track.Codec.(*mpegts.CodecKLV)
+			medi = &description.Media{
+				Type: description.MediaTypeApplication,
+				Formats: []format.Format{&format.KLV{
+					PayloadTyp: 96,
+					KLVCodec:   klvCodec,
+				}},
+			}
+			r.OnDataKLV(track, func(pts int64, packets []byte) error {
+				(*stream).WriteUnit(medi, medi.Formats[0], &unit.KLV{
+					Base: unit.Base{
+						NTP: time.Now(),
+						PTS: decodeTime(pts),
+					},
+					Packets: packets,
+				})
+				return nil
+			})
+
 		case *mpegts.CodecMPEG4Audio:
 			medi = &description.Media{
 				Type: description.MediaTypeAudio,

--- a/internal/record/format_mpegts.go
+++ b/internal/record/format_mpegts.go
@@ -224,6 +224,26 @@ func (f *formatMPEGTS) initialize() {
 					)
 				})
 
+			case *rtspformat.KLV:
+				codec := forma.KLVCodec
+				track := addTrack(forma, codec)
+
+				f.ai.agent.Stream.AddReader(f.ai.writer, media, forma, func(u unit.Unit) error {
+					tunit := u.(*unit.KLV)
+					if tunit.Packets == nil {
+						return nil
+					}
+
+					return f.write(
+						tunit.PTS,
+						tunit.NTP,
+						false,
+						true,
+						func() error {
+							return f.mw.WriteKLV(track, durationGoToMPEGTS(tunit.PTS), tunit.Packets)
+						},
+					)
+				})
 			case *rtspformat.MPEG4Audio:
 				co := forma.GetConfig()
 				if co == nil {

--- a/internal/unit/klv.go
+++ b/internal/unit/klv.go
@@ -1,0 +1,7 @@
+package unit
+
+// KLV is a KLV data unit.
+type KLV struct {
+	Base
+	Packets []byte
+}


### PR DESCRIPTION
Changes to support KLV metadata handling in mediamtx.

See related KLV metadata pull requests in mediacommon, gortsplib, and mediamtx.

All these changes released to public domain for adding to parent project under parent project's license(s).