### PR TITLE
JWT claim as escaped string (not Object)

### DIFF
--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -302,9 +302,9 @@ func (m *Manager) authenticateJWT(req *Request) error {
 	if len(v["jwt"]) != 1 {
 		return fmt.Errorf("JWT not provided")
 	}
-	cc := customClaims{permissionsKey: m.JWTClaimKey}
-	//var cc customClaims
-	//cc.permissionsKey = m.JWTClaimKey
+
+	var cc customClaims
+	cc.permissionsKey = m.JWTClaimKey
 	_, err = jwt.ParseWithClaims(v["jwt"][0], &cc, keyfunc)
 	if err != nil {
 		return err


### PR DESCRIPTION
Further to PRs #3560 and #3692.

Now that is it possible to specify any claim key for the permissions within the JWT, the next step is to allow for OAuth providers that do not support (or only support in certain use cases) object claims.  Specifically in the case of AZ B2C extension claims are permitted to be `bool`, `int` or `string`.  To over come this limitation is is possible to put the permissions in the claim as a stringified JSON object.

So this below (as it appears when using the keycloak example in the README.md)
```json
"mediamtx_permissions": [
    {
        "action": "read",
        "path": "~^mypath"
    }
]
```

Becomes:
```json
"mediamtx_permissions": "[{\"action\": \"read\", \"path\": \"~^mypath\" }]"
```

The changes in #3692 capture the `rawPermissions` as part of the claim extraction process, the changes in this PR inject at this point to determine if the `json.RawMessage` is a sting based on the leading character.  If it is a string then a string conversion is conducted to unquote it.  The result is then passed on to the remainder of the extraction function.

(@aler9 you, having read my poor attempts at go, will no doubt realise that go is not my first language, so I assume there is a better way of checking to see if the `rawPermissions` is in fact a string - if you know it then i am all ears)

