### PR TITLE
HLS: iOS clients treat maxLiveSyncPlaybackRate as the default playback rate

### DIFF
--- a/internal/servers/hls/index.html
+++ b/internal/servers/hls/index.html
@@ -69,7 +69,7 @@ const loadStream = () => {
 	// but don't support fMP4s.
 	if (Hls.isSupported()) {
 		const hls = new Hls({
-			maxLiveSyncPlaybackRate: 1.5,
+			maxLiveSyncPlaybackRate: 1.0,
 		});
 
 		hls.on(Hls.Events.ERROR, (evt, data) => {


### PR DESCRIPTION
As highlighted in #3155, iOS clients are treating maxLiveSyncPlaybackRate as the default playback speed. Changing this to 1.0 (from 1.5) results in iOS clients streaming at 1.0 speed by default instead.