### PR TITLE
Fix Dockerfile and docker run command for binary build

### DIFF
--- a/scripts/binaries.mk
+++ b/scripts/binaries.mk
@@ -13,7 +13,7 @@ WORKDIR /s
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
-ENV CGO_ENABLED 0
+ENV CGO_ENABLED=0
 RUN rm -rf tmp binaries
 RUN mkdir tmp binaries
 RUN cp mediamtx.yml LICENSE tmp/
@@ -69,5 +69,5 @@ export DOCKERFILE_BINARIES
 binaries:
 	echo "$$DOCKERFILE_BINARIES" | DOCKER_BUILDKIT=1 docker build . -f - \
 	-t temp
-	docker run --rm -v "$(PWD):/out" \
+	docker run --rm -v "$(shell pwd):/out" \
 	temp sh -c "rm -rf /out/binaries && cp -r /s/binaries /out/"


### PR DESCRIPTION
Error: 
 ```
- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 8)
docker run --rm -v :/out \
temp sh -c "rm -rf /out/binaries && cp -r /s/binaries /out/"
docker: invalid spec: :/out: empty section between colons.
See 'docker run --help'.
make: *** [scripts/binaries.mk:65: binaries] Error 125
```

This pull request addresses the two issues in the `binaries.mk` file that prevent the proper building of binaries using Docker:

1. Legacy ENV format: The Dockerfile was using the legacy `ENV key value` format, which results in a warning. The newer `ENV key=value` format is recommended. This PR updates the line to follow the new format: Changed `ENV CGO_ENABLED 0` to E`NV CGO_ENABLED=0`.

2. Empty section in volume mount path: The `docker run` command was using an invalid volume mount syntax, leading to an "empty section between colons" error. The `$(PWD)` macro was replaced with `$(shell pwd)` to correctly reference the current working directory.

Testing: After making these changes, I was able to successfully build the binaries using the provided instructions without encountering the errors mentioned.