### PR TITLE
feat: playback can skip gap between segments

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -207,13 +207,14 @@ type Conf struct {
 	PPROFTrustedProxies IPNetworks `json:"pprofTrustedProxies"`
 
 	// Playback
-	Playback               bool       `json:"playback"`
-	PlaybackAddress        string     `json:"playbackAddress"`
-	PlaybackEncryption     bool       `json:"playbackEncryption"`
-	PlaybackServerKey      string     `json:"playbackServerKey"`
-	PlaybackServerCert     string     `json:"playbackServerCert"`
-	PlaybackAllowOrigin    string     `json:"playbackAllowOrigin"`
-	PlaybackTrustedProxies IPNetworks `json:"playbackTrustedProxies"`
+	Playback                           bool       `json:"playback"`
+	PlaybackAddress                    string     `json:"playbackAddress"`
+	PlaybackEncryption                 bool       `json:"playbackEncryption"`
+	PlaybackServerKey                  string     `json:"playbackServerKey"`
+	PlaybackServerCert                 string     `json:"playbackServerCert"`
+	PlaybackAllowOrigin                string     `json:"playbackAllowOrigin"`
+	PlaybackTrustedProxies             IPNetworks `json:"playbackTrustedProxies"`
+	PlaybackSegmentAlwaysConcatenation bool       `json:"playbackSegmentAlwaysConcatenation"`
 
 	// RTSP server
 	RTSP              bool             `json:"rtsp"`
@@ -349,6 +350,7 @@ func (conf *Conf) setDefaults() {
 	conf.PlaybackServerKey = "server.key"
 	conf.PlaybackServerCert = "server.crt"
 	conf.PlaybackAllowOrigin = "*"
+	conf.PlaybackSegmentAlwaysConcatenation = false
 
 	// RTSP server
 	conf.RTSP = true

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -311,16 +311,17 @@ func (p *Core) createResources(initial bool) error {
 	if p.conf.Playback &&
 		p.playbackServer == nil {
 		i := &playback.Server{
-			Address:        p.conf.PlaybackAddress,
-			Encryption:     p.conf.PlaybackEncryption,
-			ServerKey:      p.conf.PlaybackServerKey,
-			ServerCert:     p.conf.PlaybackServerCert,
-			AllowOrigin:    p.conf.PlaybackAllowOrigin,
-			TrustedProxies: p.conf.PlaybackTrustedProxies,
-			ReadTimeout:    p.conf.ReadTimeout,
-			PathConfs:      p.conf.Paths,
-			AuthManager:    p.authManager,
-			Parent:         p,
+			Address:                    p.conf.PlaybackAddress,
+			Encryption:                 p.conf.PlaybackEncryption,
+			ServerKey:                  p.conf.PlaybackServerKey,
+			ServerCert:                 p.conf.PlaybackServerCert,
+			AllowOrigin:                p.conf.PlaybackAllowOrigin,
+			TrustedProxies:             p.conf.PlaybackTrustedProxies,
+			SegmentAlwaysConcatenation: p.conf.PlaybackSegmentAlwaysConcatenation,
+			ReadTimeout:                p.conf.ReadTimeout,
+			PathConfs:                  p.conf.Paths,
+			AuthManager:                p.authManager,
+			Parent:                     p,
 		}
 		err = i.Initialize()
 		if err != nil {
@@ -685,6 +686,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.PlaybackServerCert != p.conf.PlaybackServerCert ||
 		newConf.PlaybackAllowOrigin != p.conf.PlaybackAllowOrigin ||
 		!reflect.DeepEqual(newConf.PlaybackTrustedProxies, p.conf.PlaybackTrustedProxies) ||
+		newConf.PlaybackSegmentAlwaysConcatenation != p.conf.PlaybackSegmentAlwaysConcatenation ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		closeAuthManager ||
 		closeLogger

--- a/internal/playback/on_get.go
+++ b/internal/playback/on_get.go
@@ -46,6 +46,7 @@ func seekAndMux(
 	start time.Time,
 	duration time.Duration,
 	m muxer,
+	alwaysConcatenation bool,
 ) error {
 	if recordFormat == conf.RecordFormatFMP4 {
 		var firstInit *fmp4.Init
@@ -86,7 +87,7 @@ func seekAndMux(
 				return err
 			}
 
-			if !segmentFMP4CanBeConcatenated(firstInit, segmentEnd, init, seg.Start) {
+			if !segmentFMP4CanBeConcatenated(firstInit, segmentEnd, init, seg.Start, alwaysConcatenation) {
 				break
 			}
 
@@ -163,7 +164,7 @@ func (s *Server) onGet(ctx *gin.Context) {
 		return
 	}
 
-	err = seekAndMux(pathConf.RecordFormat, segments, start, duration, m)
+	err = seekAndMux(pathConf.RecordFormat, segments, start, duration, m, s.SegmentAlwaysConcatenation)
 	if err != nil {
 		// user aborted the download
 		var neterr *net.OpError

--- a/internal/playback/on_list.go
+++ b/internal/playback/on_list.go
@@ -64,7 +64,8 @@ func computeDurationAndConcatenate(
 					prevInit,
 					out[len(out)-1].Start.Add(time.Duration(out[len(out)-1].Duration)),
 					init,
-					seg.Start) {
+					seg.Start,
+					false) {
 					prevStart := out[len(out)-1].Start
 					curEnd := seg.Start.Add(maxDuration)
 					out[len(out)-1].Duration = listEntryDuration(curEnd.Sub(prevStart))

--- a/internal/playback/segment_fmp4.go
+++ b/internal/playback/segment_fmp4.go
@@ -54,10 +54,12 @@ func segmentFMP4CanBeConcatenated(
 	prevEnd time.Time,
 	curInit *fmp4.Init,
 	curStart time.Time,
+	alwaysConcatenation bool,
 ) bool {
 	return reflect.DeepEqual(prevInit, curInit) &&
-		!curStart.Before(prevEnd.Add(-concatenationTolerance)) &&
-		!curStart.After(prevEnd.Add(concatenationTolerance))
+		(alwaysConcatenation ||
+			(!curStart.Before(prevEnd.Add(-concatenationTolerance)) &&
+				!curStart.After(prevEnd.Add(concatenationTolerance))))
 }
 
 func segmentFMP4ReadInit(r io.ReadSeeker) (*fmp4.Init, error) {

--- a/internal/playback/server.go
+++ b/internal/playback/server.go
@@ -22,16 +22,17 @@ type serverAuthManager interface {
 
 // Server is the playback server.
 type Server struct {
-	Address        string
-	Encryption     bool
-	ServerKey      string
-	ServerCert     string
-	AllowOrigin    string
-	TrustedProxies conf.IPNetworks
-	ReadTimeout    conf.StringDuration
-	PathConfs      map[string]*conf.Path
-	AuthManager    serverAuthManager
-	Parent         logger.Writer
+	Address                    string
+	Encryption                 bool
+	ServerKey                  string
+	ServerCert                 string
+	AllowOrigin                string
+	TrustedProxies             conf.IPNetworks
+	ReadTimeout                conf.StringDuration
+	PathConfs                  map[string]*conf.Path
+	AuthManager                serverAuthManager
+	SegmentAlwaysConcatenation bool
+	Parent                     logger.Writer
 
 	httpServer *httpp.WrappedServer
 	mutex      sync.RWMutex

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -215,6 +215,8 @@ playbackAllowOrigin: '*'
 # If the server receives a request from one of these entries, IP in logs
 # will be taken from the X-Forwarded-For header.
 playbackTrustedProxies: []
+# Whether playback segments always concatenation
+playbackSegmentAlwaysConcatenation: no
 
 ###############################################
 # Global settings -> RTSP server


### PR DESCRIPTION
Related to #3510, It will be very useful to concat record segments by Mediamtx. In our project, the network is not stable and will generate a lot of small segments. Also, we need to playback the video in real time. It's very difficult for us to concat the segments out of mediamtx, this is the PR to concat the segments when playback by the mediamtx.

I don't know if this pull request can be merged, please help to review it, thanks a lot!