### PR TITLE
Restart ICE only on failed connection states

### DIFF
--- a/internal/protocols/webrtc/to_stream_test.go
+++ b/internal/protocols/webrtc/to_stream_test.go
@@ -375,16 +375,16 @@ func TestToStream(t *testing.T) {
 						err2 := pc2.AddRemoteCandidate(cnd)
 						require.NoError(t, err2)
 
-					case <-pc1.Connected():
+					case <-pc1.Ready():
 						return
 					}
 				}
 			}()
 
-			err = pc1.WaitUntilConnected(context.Background())
+			err = pc1.WaitUntilReady(context.Background())
 			require.NoError(t, err)
 
-			err = pc2.WaitUntilConnected(context.Background())
+			err = pc2.WaitUntilReady(context.Background())
 			require.NoError(t, err)
 
 			err = pc1.OutgoingTracks[0].WriteRTP(&rtp.Packet{

--- a/internal/protocols/whip/client.go
+++ b/internal/protocols/whip/client.go
@@ -100,7 +100,7 @@ outer:
 
 		case <-c.pc.GatheringDone():
 
-		case <-c.pc.Connected():
+		case <-c.pc.Ready():
 			break outer
 
 		case <-t.C:
@@ -190,7 +190,7 @@ outer:
 
 		case <-c.pc.GatheringDone():
 
-		case <-c.pc.Connected():
+		case <-c.pc.Ready():
 			break outer
 
 		case <-t.C:
@@ -230,7 +230,7 @@ func (c *Client) Close() error {
 // Wait waits for client errors.
 func (c *Client) Wait(ctx context.Context) error {
 	select {
-	case <-c.pc.Disconnected():
+	case <-c.pc.Failed():
 		return fmt.Errorf("peer connection closed")
 
 	case <-ctx.Done():

--- a/internal/servers/webrtc/publisher.js
+++ b/internal/servers/webrtc/publisher.js
@@ -372,7 +372,7 @@
         return;
       }
 
-      if (this.pc.iceConnectionState === 'disconnected') {
+      if (this.pc.iceConnectionState === 'failed') {
         this.handleError('peer connection closed');
       } else if (this.pc.iceConnectionState === 'connected') {
         if (this.conf.onConnected !== undefined) {

--- a/internal/servers/webrtc/reader.js
+++ b/internal/servers/webrtc/reader.js
@@ -468,7 +468,7 @@
         return;
       }
 
-      if (this.pc.iceConnectionState === 'disconnected') {
+      if (this.pc.iceConnectionState === 'failed') {
         this.handleError('peer connection closed');
       }
     };

--- a/internal/servers/webrtc/session.go
+++ b/internal/servers/webrtc/session.go
@@ -193,7 +193,7 @@ func (s *session) runPublish() (int, error) {
 
 	go s.readRemoteCandidates(pc)
 
-	err = pc.WaitUntilConnected(s.ctx)
+	err = pc.WaitUntilReady(s.ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -300,7 +300,7 @@ func (s *session) runRead() (int, error) {
 
 	go s.readRemoteCandidates(pc)
 
-	err = pc.WaitUntilConnected(s.ctx)
+	err = pc.WaitUntilReady(s.ctx)
 	if err != nil {
 		stream.RemoveReader(s)
 		return 0, err

--- a/internal/servers/webrtc/session.go
+++ b/internal/servers/webrtc/session.go
@@ -226,7 +226,7 @@ func (s *session) runPublish() (int, error) {
 	pc.StartReading()
 
 	select {
-	case <-pc.Disconnected():
+	case <-pc.Failed():
 		return 0, fmt.Errorf("peer connection closed")
 
 	case <-s.ctx.Done():
@@ -327,7 +327,7 @@ func (s *session) runRead() (int, error) {
 	defer stream.RemoveReader(s)
 
 	select {
-	case <-pc.Disconnected():
+	case <-pc.Failed():
 		return 0, fmt.Errorf("peer connection closed")
 
 	case err := <-stream.ReaderError(s):

--- a/internal/staticsources/webrtc/source_test.go
+++ b/internal/staticsources/webrtc/source_test.go
@@ -81,7 +81,7 @@ func TestSource(t *testing.T) {
 				w.Write([]byte(answer.SDP))
 
 				go func() {
-					err3 := pc.WaitUntilConnected(context.Background())
+					err3 := pc.WaitUntilReady(context.Background())
 					require.NoError(t, err3)
 
 					err3 = outgoingTracks[0].WriteRTP(&rtp.Packet{


### PR DESCRIPTION
According to https://www.w3.org/TR/webrtc/#dictionary-rtcofferoptions-members ,

> Note
> Performing an ICE restart is recommended when [iceConnectionState](https://www.w3.org/TR/webrtc/#dom-peerconnection-ice-connection-state) transitions to "[failed](https://www.w3.org/TR/webrtc/#dom-rtciceconnectionstate-failed)". An application may additionally choose to listen for the [iceConnectionState](https://www.w3.org/TR/webrtc/#dom-peerconnection-ice-connection-state) transition to "[disconnected](https://www.w3.org/TR/webrtc/#dom-rtciceconnectionstate-disconnected)" and then use other sources of information (such as using [getStats](https://www.w3.org/TR/webrtc/#widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector) to measure if the number of bytes sent or received over the next couple of seconds increases) to determine whether an ICE restart is advisable.

This PR changes the default webrtc implementation to follow such guidance. We've seen instances where choppy networks trigger a lot of renegotiations that aren't necessary. 
