### PR TITLE
fix: improve unsafe path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1260,7 +1260,7 @@ There are 3 ways to change the configuration:
    * available in the root folder of the Docker image (`/mediamtx.yml`); it can be overridden in this way:
 
      ```
-     docker run --rm -it --network=host -v $PWD/mediamtx.yml:/mediamtx.yml bluenviron/mediamtx
+     docker run --rm -it --network=host -v "${PWD}/mediamtx.yml:/mediamtx.yml" bluenviron/mediamtx
      ```
 
    The configuration can be changed dynamically when the server is running (hot reloading) by writing to the configuration file. Changes are detected and applied without disconnecting existing clients, whenever it's possible.

--- a/README.md
+++ b/README.md
@@ -1260,7 +1260,7 @@ There are 3 ways to change the configuration:
    * available in the root folder of the Docker image (`/mediamtx.yml`); it can be overridden in this way:
 
      ```
-     docker run --rm -it --network=host -v "${PWD}/mediamtx.yml:/mediamtx.yml" bluenviron/mediamtx
+     docker run --rm -it --network=host -v "${PWD}/mediamtx.yml:/mediamtx.yml:ro" bluenviron/mediamtx
      ```
 
    The configuration can be changed dynamically when the server is running (hot reloading) by writing to the configuration file. Changes are detected and applied without disconnecting existing clients, whenever it's possible.

--- a/scripts/apidocs.mk
+++ b/scripts/apidocs.mk
@@ -6,5 +6,5 @@ export DOCKERFILE_APIDOCS_GEN
 
 apidocs:
 	echo "$$DOCKERFILE_APIDOCS_GEN" | docker build . -f - -t temp
-	docker run --rm -v $(PWD)/apidocs:/s -w /s temp \
+	docker run --rm -v "$(PWD)/apidocs:/s" -w /s temp \
 	sh -c "redoc-cli bundle openapi.yaml"

--- a/scripts/binaries.mk
+++ b/scripts/binaries.mk
@@ -15,38 +15,38 @@ RUN go generate ./...
 
 FROM build-base AS build-windows-amd64
 ENV GOOS=windows GOARCH=amd64
-RUN go build -o tmp/$(BINARY_NAME).exe
-RUN cd tmp && zip -q ../binaries/$(BINARY_NAME)_$$(cat ../internal/core/VERSION)_windows_amd64.zip $(BINARY_NAME).exe mediamtx.yml LICENSE
+RUN go build -o "tmp/$(BINARY_NAME).exe"
+RUN cd tmp && zip -q "../binaries/$(BINARY_NAME)_$$(cat ../internal/core/VERSION)_windows_amd64.zip" "$(BINARY_NAME).exe" mediamtx.yml LICENSE
 
 FROM build-base AS build-linux-amd64
 ENV GOOS=linux GOARCH=amd64
-RUN go build -o tmp/$(BINARY_NAME)
-RUN tar -C tmp -czf binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_linux_amd64.tar.gz --owner=0 --group=0 $(BINARY_NAME) mediamtx.yml LICENSE
+RUN go build -o "tmp/$(BINARY_NAME)"
+RUN tar -C tmp -czf "binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_linux_amd64.tar.gz" --owner=0 --group=0 "$(BINARY_NAME)" mediamtx.yml LICENSE
 
 FROM build-base AS build-darwin-amd64
 ENV GOOS=darwin GOARCH=amd64
-RUN go build -o tmp/$(BINARY_NAME)
-RUN tar -C tmp -czf binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_darwin_amd64.tar.gz --owner=0 --group=0 $(BINARY_NAME) mediamtx.yml LICENSE
+RUN go build -o "tmp/$(BINARY_NAME)"
+RUN tar -C tmp -czf "binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_darwin_amd64.tar.gz" --owner=0 --group=0 "$(BINARY_NAME)" mediamtx.yml LICENSE
 
 FROM build-base AS build-darwin-arm64
 ENV GOOS=darwin GOARCH=arm64
-RUN go build -o tmp/$(BINARY_NAME)
-RUN tar -C tmp -czf binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_darwin_arm64.tar.gz --owner=0 --group=0 $(BINARY_NAME) mediamtx.yml LICENSE
+RUN go build -o "tmp/$(BINARY_NAME)"
+RUN tar -C tmp -czf "binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_darwin_arm64.tar.gz" --owner=0 --group=0 "$(BINARY_NAME)" mediamtx.yml LICENSE
 
 FROM build-base AS build-linux-armv6
 ENV GOOS=linux GOARCH=arm GOARM=6
-RUN go build -o tmp/$(BINARY_NAME)
-RUN tar -C tmp -czf binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_linux_armv6.tar.gz --owner=0 --group=0 $(BINARY_NAME) mediamtx.yml LICENSE
+RUN go build -o "tmp/$(BINARY_NAME)"
+RUN tar -C tmp -czf "binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_linux_armv6.tar.gz" --owner=0 --group=0 "$(BINARY_NAME)" mediamtx.yml LICENSE
 
 FROM build-base AS build-linux-armv7
 ENV GOOS=linux GOARCH=arm GOARM=7
-RUN go build -o tmp/$(BINARY_NAME)
-RUN tar -C tmp -czf binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_linux_armv7.tar.gz --owner=0 --group=0 $(BINARY_NAME) mediamtx.yml LICENSE
+RUN go build -o "tmp/$(BINARY_NAME)"
+RUN tar -C tmp -czf "binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_linux_armv7.tar.gz" --owner=0 --group=0 "$(BINARY_NAME)" mediamtx.yml LICENSE
 
 FROM build-base AS build-linux-arm64
 ENV GOOS=linux GOARCH=arm64
-RUN go build -o tmp/$(BINARY_NAME)
-RUN tar -C tmp -czf binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_linux_arm64v8.tar.gz --owner=0 --group=0 $(BINARY_NAME) mediamtx.yml LICENSE
+RUN go build -o "tmp/$(BINARY_NAME)"
+RUN tar -C tmp -czf "binaries/$(BINARY_NAME)_$$(cat internal/core/VERSION)_linux_arm64v8.tar.gz" --owner=0 --group=0 "$(BINARY_NAME)" mediamtx.yml LICENSE
 
 FROM $(BASE_IMAGE)
 COPY --from=build-windows-amd64 /s/binaries /s/binaries
@@ -62,5 +62,5 @@ export DOCKERFILE_BINARIES
 binaries:
 	echo "$$DOCKERFILE_BINARIES" | DOCKER_BUILDKIT=1 docker build . -f - \
 	-t temp
-	docker run --rm -v $(PWD):/out \
+	docker run --rm -v "$(PWD):/out" \
 	temp sh -c "rm -rf /out/binaries && cp -r /s/binaries /out/"

--- a/scripts/dockerhub-legacy.mk
+++ b/scripts/dockerhub-legacy.mk
@@ -6,28 +6,28 @@ dockerhub-legacy:
 	docker login -u $(DOCKER_USER_LEGACY) -p $(DOCKER_PASSWORD_LEGACY)
 
 	docker run --rm \
-	-v $(HOME)/.docker:/.docker:ro \
+	-v "$(HOME)/.docker:/.docker:ro" \
 	quay.io/skopeo/stable:latest copy --all \
 	--authfile /.docker/config.json \
 	docker://docker.io/$(DOCKER_REPOSITORY):$(VERSION)-rpi \
 	docker://docker.io/$(DOCKER_REPOSITORY_LEGACY):v$(VERSION)-rpi
 
 	docker run --rm \
-	-v $(HOME)/.docker:/.docker:ro \
+	-v "$(HOME)/.docker:/.docker:ro" \
 	quay.io/skopeo/stable:latest copy --all \
 	--authfile /.docker/config.json \
 	docker://docker.io/$(DOCKER_REPOSITORY):latest-rpi \
 	docker://docker.io/$(DOCKER_REPOSITORY_LEGACY):latest-rpi
 
 	docker run --rm \
-	-v $(HOME)/.docker:/.docker:ro \
+	-v "$(HOME)/.docker:/.docker:ro" \
 	quay.io/skopeo/stable:latest copy --all \
 	--authfile /.docker/config.json \
 	docker://docker.io/$(DOCKER_REPOSITORY):$(VERSION) \
 	docker://docker.io/$(DOCKER_REPOSITORY_LEGACY):v$(VERSION)
 
 	docker run --rm \
-	-v $(HOME)/.docker:/.docker:ro \
+	-v "$(HOME)/.docker:/.docker:ro" \
 	quay.io/skopeo/stable:latest copy --all \
 	--authfile /.docker/config.json \
 	docker://docker.io/$(DOCKER_REPOSITORY):latest \

--- a/scripts/dockerhub.mk
+++ b/scripts/dockerhub.mk
@@ -60,7 +60,7 @@ dockerhub:
 	cp binaries/*linux_arm64v8.tar.gz tmp/binaries/linux/arm64.tar.gz
 
 	docker buildx rm builder 2>/dev/null || true
-	rm -rf $$HOME/.docker/manifests/*
+	rm -rf "$$HOME/.docker/manifests"/*
 	docker buildx create --name=builder --use
 
 	echo "$$DOCKERFILE_DOCKERHUB_RPI_BASE_32" | docker buildx build . -f - \
@@ -103,4 +103,4 @@ dockerhub:
 	--push
 
 	docker buildx rm builder
-	rm -rf $$HOME/.docker/manifests/*
+	rm -rf "$$HOME/.docker/manifests"/*

--- a/scripts/format.mk
+++ b/scripts/format.mk
@@ -6,5 +6,5 @@ export DOCKERFILE_FORMAT
 
 format:
 	echo "$$DOCKERFILE_FORMAT" | docker build -q . -f - -t temp
-	docker run --rm -it -v $(PWD):/s -w /s temp \
+	docker run --rm -it -v "$(PWD):/s" -w /s temp \
 	sh -c "gofumpt -l -w ."

--- a/scripts/lint.mk
+++ b/scripts/lint.mk
@@ -5,7 +5,7 @@ endef
 export DOCKERFILE_APIDOCS_LINT
 
 lint-golangci:
-	docker run --rm -v $(PWD):/app -w /app \
+	docker run --rm -v "$(PWD):/app" -w /app \
 	$(LINT_IMAGE) \
 	golangci-lint run -v
 
@@ -15,7 +15,7 @@ lint-mod-tidy:
 
 lint-apidocs:
 	echo "$$DOCKERFILE_APIDOCS_LINT" | docker build . -f - -t temp
-	docker run --rm -v $(PWD)/apidocs:/s -w /s temp \
+	docker run --rm -v "$(PWD)/apidocs:/s" -w /s temp \
 	sh -c "openapi lint openapi.yaml"
 
 lint: lint-golangci lint-mod-tidy lint-apidocs

--- a/scripts/mod-tidy.mk
+++ b/scripts/mod-tidy.mk
@@ -1,3 +1,3 @@
 mod-tidy:
-	docker run --rm -it -v $(PWD):/s -w /s $(BASE_IMAGE) \
+	docker run --rm -it -v "$(PWD):/s" -w /s $(BASE_IMAGE) \
 	sh -c "apk add git && GOPROXY=direct go mod tidy"

--- a/scripts/test.mk
+++ b/scripts/test.mk
@@ -25,13 +25,13 @@ export DOCKERFILE_TEST
 test:
 	echo "$$DOCKERFILE_TEST" | docker build -q . -f - -t temp --build-arg ARCH=amd64
 	docker run --rm \
-	-v $(PWD):/s \
+	-v "$(PWD):/s" \
 	temp \
 	make test-nodocker
 
 test32:
 	echo "$$DOCKERFILE_TEST" | docker build -q . -f - -t temp --build-arg ARCH=i386
 	docker run --rm \
-	-v $(PWD):/s \
+	-v "$(PWD):/s" \
 	temp \
 	make test-nodocker


### PR DESCRIPTION
Thank you so incredibly much for creating MediaMTX! It's practically the perfect media server! I'd like to give back by fixing a few bugs and issues here. :)

**fix: improve unsafe path handling:**

Paths containing spaces or dashes were being interpreted as separate options, since the path handling lacked double quotes.

This fixes all unsafe instances of "PWD" and "HOME", along with all other unsafe paths in the scripts.

**readme: explicitly mount the configuration as read-only:**

This clearly shows users that the MediaMTX container will not modify the configuration file.
