### PR TITLE
go.mod: include .0 in version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluenviron/mediamtx
 
-go 1.23
+go 1.23.0
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0


### PR DESCRIPTION
Fixes "toolchain not available" error.

Before:

```
rtsp-simple-server$ go mod tidy
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
```