### PR TITLE
main: expose programmatic entrypoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,13 +4,12 @@ package main
 import (
 	"os"
 
-	"github.com/bluenviron/mediamtx/internal/core"
+	mediamtx "github.com/bluenviron/mediamtx/pkg"
 )
 
 func main() {
-	s, ok := core.New(os.Args[1:])
+	ok := mediamtx.Main(os.Args[1:])
 	if !ok {
 		os.Exit(1)
 	}
-	s.Wait()
 }

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -1,0 +1,14 @@
+package mediamtx
+
+import (
+	"github.com/bluenviron/mediamtx/internal/core"
+)
+
+func Main(args []string) bool {
+	s, ok := core.New(args)
+	if !ok {
+		return false
+	}
+	s.Wait()
+	return true
+}


### PR DESCRIPTION
Per #4011 - I absolutely get not wanting to support a stable Go interface for most things, but would you consider something like this? The only interface this exposes is the command-line interface via a `[]string`, not exactly something that will require a lot of refactoring. But it would still allow embedding MediaMTX elsewhere without entirely forking the repo.