### PR TITLE
fix recording timestamp with some audio codecs (#3969) (#4041)

### DIFF
--- a/internal/recorder/format_fmp4.go
+++ b/internal/recorder/format_fmp4.go
@@ -611,7 +611,7 @@ func (f *formatFMP4) initialize() bool {
 									Payload: packet,
 								},
 								dts: pts,
-								ntp: tunit.NTP.Add(timestampToDuration(pts, clockRate)),
+								ntp: tunit.NTP.Add(timestampToDuration(pts-tunit.PTS, clockRate)),
 							})
 							if err != nil {
 								return err
@@ -649,7 +649,7 @@ func (f *formatFMP4) initialize() bool {
 										Payload: au,
 									},
 									dts: pts,
-									ntp: tunit.NTP.Add(timestampToDuration(pts, clockRate)),
+									ntp: tunit.NTP.Add(timestampToDuration(pts-tunit.PTS, clockRate)),
 								})
 								if err != nil {
 									return err
@@ -771,7 +771,7 @@ func (f *formatFMP4) initialize() bool {
 									Payload: frame,
 								},
 								dts: pts,
-								ntp: tunit.NTP.Add(timestampToDuration(pts, clockRate)),
+								ntp: tunit.NTP.Add(timestampToDuration(pts-tunit.PTS, clockRate)),
 							})
 							if err != nil {
 								return err


### PR DESCRIPTION
Fixes #3969 
Fixes #4041

When a stream contained an Opus, MPEG-4 audio or AC3 track, timestamp in the segment file name was increasing at twice the speed.