### PR TITLE
add PlaybackBaseURL config option

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -209,6 +209,7 @@ type Conf struct {
 	// Playback
 	Playback               bool       `json:"playback"`
 	PlaybackAddress        string     `json:"playbackAddress"`
+	PlaybackBaseUrl        string     `json:"playbackBaseUrl"`
 	PlaybackEncryption     bool       `json:"playbackEncryption"`
 	PlaybackServerKey      string     `json:"playbackServerKey"`
 	PlaybackServerCert     string     `json:"playbackServerCert"`
@@ -350,6 +351,7 @@ func (conf *Conf) setDefaults() {
 
 	// Playback server
 	conf.PlaybackAddress = ":9996"
+	conf.PlaybackBaseUrl = ""
 	conf.PlaybackServerKey = "server.key"
 	conf.PlaybackServerCert = "server.crt"
 	conf.PlaybackAllowOrigin = "*"
@@ -639,6 +641,14 @@ func (conf *Conf) Validate(l logger.Writer) error {
 	if conf.ServerKey != nil {
 		l.Log(logger.Warn, "parameter 'serverKey' is deprecated and has been replaced with 'rtspServerKey'")
 		conf.RTSPServerKey = *conf.ServerKey
+	}
+
+	// Playback
+
+	if conf.PlaybackBaseUrl != "" &&
+		!strings.HasPrefix(conf.PlaybackBaseUrl, "http://") &&
+		!strings.HasPrefix(conf.PlaybackBaseUrl, "https://") {
+		return fmt.Errorf("'playbackBaseUrl' must be a HTTP(S) URL")
 	}
 
 	// RTMP

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -318,6 +318,7 @@ func (p *Core) createResources(initial bool) error {
 		p.playbackServer == nil {
 		i := &playback.Server{
 			Address:        p.conf.PlaybackAddress,
+			BaseUrl:        p.conf.PlaybackBaseUrl,
 			Encryption:     p.conf.PlaybackEncryption,
 			ServerKey:      p.conf.PlaybackServerKey,
 			ServerCert:     p.conf.PlaybackServerCert,

--- a/internal/playback/on_list.go
+++ b/internal/playback/on_list.go
@@ -212,12 +212,19 @@ func (s *Server) onList(ctx *gin.Context) {
 		v.Add("path", pathName)
 		v.Add("start", entries[i].Start.Format(time.RFC3339Nano))
 		v.Add("duration", strconv.FormatFloat(time.Duration(entries[i].Duration).Seconds(), 'f', -1, 64))
-		u := &url.URL{
-			Scheme:   scheme,
-			Host:     ctx.Request.Host,
-			Path:     "/get",
-			RawQuery: v.Encode(),
+
+		var u *url.URL
+		if s.BaseUrl != "" {
+			u, _ = url.Parse(s.BaseUrl)
+			u = u.JoinPath("get")
+		} else {
+			u = &url.URL{
+				Scheme: scheme,
+				Host:   ctx.Request.Host,
+				Path:   "/get",
+			}
 		}
+		u.RawQuery = v.Encode()
 		entries[i].URL = u.String()
 	}
 

--- a/internal/playback/server.go
+++ b/internal/playback/server.go
@@ -22,6 +22,7 @@ type serverAuthManager interface {
 // Server is the playback server.
 type Server struct {
 	Address        string
+	BaseUrl        string
 	Encryption     bool
 	ServerKey      string
 	ServerCert     string


### PR DESCRIPTION
Resolves #4104 in a simplistic way.  I would still encourage a generalized mechanism for assigning base/root URLs for each of the various services within mediamtx, but for starters this is functional for our use case.

Note - I did not update the example config file (`mediamtx.yml` ).  The default value preserves existing behavior.