### PR TITLE
webrtc: switch to recvonly transceivers (#4059)

### DIFF
--- a/internal/core/metrics_test.go
+++ b/internal/core/metrics_test.go
@@ -313,7 +313,7 @@ webrtc_sessions_bytes_sent 0
 			<-terminate
 		}()
 
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(500*time.Millisecond + 2*time.Second)
 
 		bo := httpPullFile(t, hc, "http://localhost:9998/metrics")
 

--- a/internal/protocols/webrtc/peer_connection.go
+++ b/internal/protocols/webrtc/peer_connection.go
@@ -131,15 +131,31 @@ func (co *PeerConnection) Start() error {
 	if co.Publish {
 		videoSetupped := false
 		audioSetupped := false
+		for _, tr := range co.OutgoingTracks {
+			if tr.isVideo() {
+				videoSetupped = true
+			} else {
+				audioSetupped = true
+			}
+		}
+
+		// When audio is not used, a track has to be present anyway,
+		// otherwise video is not displayed on Firefox and Chrome.
+		if !audioSetupped {
+			co.OutgoingTracks = append(co.OutgoingTracks, &OutgoingTrack{
+				Caps: webrtc.RTPCodecCapability{
+					MimeType:  webrtc.MimeTypePCMU,
+					ClockRate: 8000,
+				},
+			})
+		}
 
 		for _, tr := range co.OutgoingTracks {
 			var codecType webrtc.RTPCodecType
 			if tr.isVideo() {
 				codecType = webrtc.RTPCodecTypeVideo
-				videoSetupped = true
 			} else {
 				codecType = webrtc.RTPCodecTypeAudio
-				audioSetupped = true
 			}
 
 			err := mediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
@@ -151,8 +167,8 @@ func (co *PeerConnection) Start() error {
 			}
 		}
 
-		// always register at least a video and a audio codec
-		// otherwise handshake will fail or audio will be muted on some clients (like Firefox)
+		// When video is not used, a track must not be added but a codec has to present.
+		// Otherwise audio is muted on Firefox and Chrome.
 		if !videoSetupped {
 			err := mediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
 				RTPCodecCapability: webrtc.RTPCodecCapability{
@@ -161,18 +177,6 @@ func (co *PeerConnection) Start() error {
 				},
 				PayloadType: 96,
 			}, webrtc.RTPCodecTypeVideo)
-			if err != nil {
-				return err
-			}
-		}
-		if !audioSetupped {
-			err := mediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
-				RTPCodecCapability: webrtc.RTPCodecCapability{
-					MimeType:  webrtc.MimeTypePCMU,
-					ClockRate: 8000,
-				},
-				PayloadType: 0,
-			}, webrtc.RTPCodecTypeAudio)
 			if err != nil {
 				return err
 			}

--- a/internal/servers/webrtc/reader.js
+++ b/internal/servers/webrtc/reader.js
@@ -366,7 +366,7 @@
         sdpSemantics: 'unified-plan',
       });
 
-      const direction = 'sendrecv';
+      const direction = 'recvonly';
       this.pc.addTransceiver('video', { direction });
       this.pc.addTransceiver('audio', { direction });
 


### PR DESCRIPTION
Fixes #4059

This fixes compatibility with devices that support decoding AV1 but doesn't support encoding it.

This was previously impossible to achieve due to a bug that prevented video from being displayed when recvonly transceivers were in use and audio was not present.