### PR TITLE
on connection close, force the immediate session close (triggering the Unread hook).

### DIFF
--- a/internal/servers/rtsp/server.go
+++ b/internal/servers/rtsp/server.go
@@ -216,6 +216,10 @@ func (s *Server) OnConnClose(ctx *gortsplib.ServerHandlerOnConnCloseCtx) {
 	c := s.conns[ctx.Conn]
 	delete(s.conns, ctx.Conn)
 	s.mutex.Unlock()
+	sx := ctx.Conn.Session()
+	if sx != nil {
+		sx.Close()
+	}
 	c.onClose(ctx.Error)
 }
 


### PR DESCRIPTION
on connection close, force the immediate session close (triggering the Unread hook).