### PR TITLE
webrtx: fix connectivity regression (#4161)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/matthewhartstonge/argon2 v1.1.1
-	github.com/pion/ice/v4 v4.0.3
+	github.com/pion/ice/v4 v4.0.5
 	github.com/pion/interceptor v0.1.37
 	github.com/pion/logging v0.2.2
 	github.com/pion/rtcp v1.2.15
@@ -101,6 +101,6 @@ require (
 
 replace code.cloudfoundry.org/bytefmt => github.com/cloudfoundry/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 
-replace github.com/pion/ice/v4 => github.com/aler9/ice/v4 v4.0.0-20250113220727-1c0b762897da
+replace github.com/pion/ice/v4 => github.com/aler9/ice/v4 v4.0.0-20250119130956-642d7cd2459f
 
-replace github.com/pion/webrtc/v4 => github.com/aler9/webrtc/v4 v4.0.0-20250113221101-1adc4784368c
+replace github.com/pion/webrtc/v4 => github.com/aler9/webrtc/v4 v4.0.0-20250119122430-da50f500fa8e

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,10 @@ github.com/alecthomas/kong v1.6.1 h1:/7bVimARU3uxPD0hbryPE8qWrS3Oz3kPQoxA/H2NKG8
 github.com/alecthomas/kong v1.6.1/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/aler9/ice/v4 v4.0.0-20250113220727-1c0b762897da h1:klkpv5sJI9CTIwt523Yz66wucbR19M86E3zM+rt35HQ=
-github.com/aler9/ice/v4 v4.0.0-20250113220727-1c0b762897da/go.mod h1:VfHy0beAZ5loDT7BmJ2LtMtC4dbawIkkkejHPRZNB3Y=
-github.com/aler9/webrtc/v4 v4.0.0-20250113221101-1adc4784368c h1:v9JXD18rXO83z8cCArwe9BugCCHUmLciZXCMDekUDGI=
-github.com/aler9/webrtc/v4 v4.0.0-20250113221101-1adc4784368c/go.mod h1:oFVBBVSHU3vAEwSgnk3BuKCwAUwpDwQhko1EDwyZWbU=
+github.com/aler9/ice/v4 v4.0.0-20250119130956-642d7cd2459f h1:1bgnwDe/USxTPKDUCDQzKEKmqRfq4fhChTIPrs82Gfk=
+github.com/aler9/ice/v4 v4.0.0-20250119130956-642d7cd2459f/go.mod h1:VfHy0beAZ5loDT7BmJ2LtMtC4dbawIkkkejHPRZNB3Y=
+github.com/aler9/webrtc/v4 v4.0.0-20250119122430-da50f500fa8e h1:SbgXEClD+GZ80nZrwlHt2jLyFufynZOM5kPGEdcEVuA=
+github.com/aler9/webrtc/v4 v4.0.0-20250119122430-da50f500fa8e/go.mod h1:HHBeUVBAC+j4ZFnYhovEFStF02Arb1EyD4G7e7HBTJw=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=


### PR DESCRIPTION
Fixes #4161

when webrtcLocalTCPAddress is filled, webrtcAdditionalHosts is not empty and webrtcIPsFromInterfaces is false, connectivity was impossible to achieve.