### PR TITLE
record: fix crash when recordDeleteAfter is 0 and API is called (#4250)

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -686,7 +686,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 	closeRecorderCleaner := newConf == nil ||
 		atLeastOneRecordDeleteAfter(newConf.Paths) != atLeastOneRecordDeleteAfter(p.conf.Paths) ||
 		closeLogger
-	if !closeRecorderCleaner && !reflect.DeepEqual(newConf.Paths, p.conf.Paths) {
+	if !closeRecorderCleaner && p.recordCleaner != nil && !reflect.DeepEqual(newConf.Paths, p.conf.Paths) {
 		p.recordCleaner.ReloadPathConfs(newConf.Paths)
 	}
 


### PR DESCRIPTION
Fixes #4250