### PR TITLE
rtsp: fix authentication when rtspAuthMethods is empty

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -642,6 +642,9 @@ func (conf *Conf) Validate(l logger.Writer) error {
 		l.Log(logger.Warn, "parameter 'serverKey' is deprecated and has been replaced with 'rtspServerKey'")
 		conf.RTSPServerKey = *conf.ServerKey
 	}
+	if len(conf.RTSPAuthMethods) == 0 {
+		return fmt.Errorf("at least one 'rtspAuthMethods' must be provided")
+	}
 
 	// RTMP
 

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -374,6 +374,11 @@ func TestConfErrors(t *testing.T) {
 				"authJWTClaimKey: \"\"",
 			"'authJWTClaimKey' is empty",
 		},
+		{
+			"invalid rtsp auth methods",
+			"rtspAuthMethods: []",
+			"at least one 'rtspAuthMethods' must be provided",
+		},
 	} {
 		t.Run(ca.name, func(t *testing.T) {
 			tmpf, err := createTempFile([]byte(ca.conf))


### PR DESCRIPTION
when rtspAuthMethods is nil, digest+SHA256 gets enabled, resulting in the inability of FFmpeg and most clients to connect due to compatibility issues.