### PR TITLE
fix for build failure caused by deprecated h264.AnnexBUnmarshal

### DIFF
--- a/internal/staticsources/rpicamera/camera.go
+++ b/internal/staticsources/rpicamera/camera.go
@@ -166,7 +166,8 @@ outer:
 				uint64(buf[4])<<24 | uint64(buf[3])<<16 | uint64(buf[2])<<8 | uint64(buf[1])
 			dts := time.Duration(tmp) * time.Microsecond
 
-			nalus, err := h264.AnnexBUnmarshal(buf[9:])
+			var nalus h264.AnnexB
+			err = nalus.Unmarshal(buf[9:])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
```
38.61 # github.com/bluenviron/mediamtx/internal/staticsources/rpicamera
38.61 internal/staticsources/rpicamera/camera.go:169:23: undefined: h264.AnnexBUnmarshal
```

Build failed because rpicamera imported mediacommon v2 package, which deprecated and removed h264.AnnexBUnmarshal function.