### PR TITLE
Feature/mediamtx gop cache

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -71,6 +71,8 @@ components:
           type: boolean
         runOnDisconnect:
           type: string
+        gopCache:
+          type: boolean
 
         # Authentication
         authMethod:

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -169,6 +169,7 @@ type Conf struct {
 	RunOnConnect        string          `json:"runOnConnect"`
 	RunOnConnectRestart bool            `json:"runOnConnectRestart"`
 	RunOnDisconnect     string          `json:"runOnDisconnect"`
+	GopCache            bool            `json:"gopCache"`
 
 	// Authentication
 	AuthMethod                AuthMethod                  `json:"authMethod"`

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -356,6 +356,7 @@ func (p *Core) createResources(initial bool) error {
 			pathConfs:         p.conf.Paths,
 			externalCmdPool:   p.externalCmdPool,
 			parent:            p,
+			gopCache:          p.conf.GopCache,
 		}
 		p.pathManager.initialize()
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -711,6 +711,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.WriteTimeout != p.conf.WriteTimeout ||
 		newConf.WriteQueueSize != p.conf.WriteQueueSize ||
 		newConf.UDPMaxPayloadSize != p.conf.UDPMaxPayloadSize ||
+		newConf.GopCache != p.conf.GopCache ||
 		closeMetrics ||
 		closeAuthManager ||
 		closeLogger

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -75,6 +75,7 @@ type path struct {
 	wg                *sync.WaitGroup
 	externalCmdPool   *externalcmd.Pool
 	parent            pathParent
+	gopCache          bool
 
 	ctx                            context.Context
 	ctxCancel                      func()
@@ -702,6 +703,7 @@ func (pa *path) setReady(desc *description.Session, allocateEncoder bool) error 
 		desc,
 		allocateEncoder,
 		logger.NewLimitedLogger(pa.source),
+		pa.gopCache,
 	)
 	if err != nil {
 		return err

--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -59,6 +59,7 @@ type pathManager struct {
 	pathConfs         map[string]*conf.Path
 	externalCmdPool   *externalcmd.Pool
 	parent            pathManagerParent
+	gopCache          bool
 
 	ctx         context.Context
 	ctxCancel   func()
@@ -352,6 +353,7 @@ func (pm *pathManager) createPath(
 		wg:                &pm.wg,
 		externalCmdPool:   pm.externalCmdPool,
 		parent:            pm,
+		gopCache:          pm.gopCache,
 	}
 	pa.initialize()
 

--- a/internal/protocols/hls/from_stream_test.go
+++ b/internal/protocols/hls/from_stream_test.go
@@ -23,6 +23,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 		}}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -56,6 +57,7 @@ func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 		}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/protocols/mpegts/from_stream_test.go
+++ b/internal/protocols/mpegts/from_stream_test.go
@@ -22,6 +22,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 		}}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -49,6 +50,7 @@ func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 		}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/protocols/rtmp/from_stream_test.go
+++ b/internal/protocols/rtmp/from_stream_test.go
@@ -25,6 +25,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 		}}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -56,6 +57,7 @@ func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 		}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/protocols/webrtc/from_stream_test.go
+++ b/internal/protocols/webrtc/from_stream_test.go
@@ -22,6 +22,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 		}}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -49,6 +50,7 @@ func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 		}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -84,6 +86,7 @@ func TestFromStream(t *testing.T) {
 				},
 				false,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 			defer stream.Close()

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -130,6 +130,7 @@ func TestRecorder(t *testing.T) {
 				desc,
 				true,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 			defer stream.Close()
@@ -343,6 +344,7 @@ func TestRecorderFMP4NegativeDTS(t *testing.T) {
 		desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 	defer stream.Close()
@@ -430,6 +432,7 @@ func TestRecorderSkipTracksPartial(t *testing.T) {
 				desc,
 				true,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 			defer stream.Close()
@@ -490,6 +493,7 @@ func TestRecorderSkipTracksFull(t *testing.T) {
 				desc,
 				true,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 			defer stream.Close()

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -160,6 +160,7 @@ func TestServerRead(t *testing.T) {
 			desc,
 			true,
 			test.NilLogger,
+			false,
 		)
 		require.NoError(t, err)
 
@@ -259,6 +260,7 @@ func TestServerRead(t *testing.T) {
 			desc,
 			true,
 			test.NilLogger,
+			false,
 		)
 		require.NoError(t, err)
 
@@ -363,6 +365,7 @@ func TestDirectory(t *testing.T) {
 		desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/servers/rtmp/server_test.go
+++ b/internal/servers/rtmp/server_test.go
@@ -45,6 +45,7 @@ func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stre
 		req.Desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -200,6 +201,7 @@ func TestServerRead(t *testing.T) {
 				desc,
 				true,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 

--- a/internal/servers/rtsp/server_test.go
+++ b/internal/servers/rtsp/server_test.go
@@ -45,6 +45,7 @@ func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stre
 		req.Desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -154,6 +155,7 @@ func TestServerRead(t *testing.T) {
 		desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/servers/rtsp/server_test.go
+++ b/internal/servers/rtsp/server_test.go
@@ -265,6 +265,7 @@ func TestServerRedirect(t *testing.T) {
 				desc,
 				true,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 

--- a/internal/servers/rtsp/session.go
+++ b/internal/servers/rtsp/session.go
@@ -252,11 +252,11 @@ func (s *session) onPlay(_ *gortsplib.ServerHandlerOnPlayCtx) (*base.Response, e
 		s.transport = s.rsession.SetuppedTransport()
 		s.mutex.Unlock()
 
-		if len(s.stream.CachedUnits) > 0 {
-			lastTimestamp := s.stream.CachedUnits[len(s.stream.CachedUnits)-1].GetRTPPackets()[0].Timestamp
+		if s.stream.Cached > 0 {
+			lastTimestamp := s.stream.CachedUnits[s.stream.Cached-1].GetRTPPackets()[0].Timestamp
 			for _, medi := range s.stream.Desc().Medias {
 				if medi.Type == description.MediaTypeVideo {
-					for _, u := range s.stream.CachedUnits {
+					for _, u := range s.stream.CachedUnits[:Cached] {
 						for _, pkt := range u.GetRTPPackets() {
 							pkt.Timestamp = lastTimestamp
 							err := s.rsession.WritePacketRTP(medi, pkt)

--- a/internal/servers/rtsp/session.go
+++ b/internal/servers/rtsp/session.go
@@ -252,19 +252,22 @@ func (s *session) onPlay(_ *gortsplib.ServerHandlerOnPlayCtx) (*base.Response, e
 		s.transport = s.rsession.SetuppedTransport()
 		s.mutex.Unlock()
 
-		for _, medi := range s.stream.Desc().Medias {
-			if medi.Type == description.MediaTypeVideo {
-				for _, u := range s.stream.CachedUnits {
-					for _, pkt := range u.GetRTPPackets() {
-						err := s.rsession.WritePacketRTP(medi, pkt)
-						if err != nil {
-							break
+		if len(s.stream.CachedUnits) > 0 {
+			lastTimestamp := s.stream.CachedUnits[len(s.stream.CachedUnits)-1].GetRTPPackets()[0].Timestamp
+			for _, medi := range s.stream.Desc().Medias {
+				if medi.Type == description.MediaTypeVideo {
+					for _, u := range s.stream.CachedUnits {
+						for _, pkt := range u.GetRTPPackets() {
+							pkt.Timestamp = lastTimestamp
+							err := s.rsession.WritePacketRTP(medi, pkt)
+							if err != nil {
+								break
+							}
 						}
 					}
 				}
 			}
 		}
-	}
 
 	return &base.Response{
 		StatusCode: base.StatusOK,

--- a/internal/servers/rtsp/session.go
+++ b/internal/servers/rtsp/session.go
@@ -256,7 +256,7 @@ func (s *session) onPlay(_ *gortsplib.ServerHandlerOnPlayCtx) (*base.Response, e
 			lastTimestamp := s.stream.CachedUnits[s.stream.Cached-1].GetRTPPackets()[0].Timestamp
 			for _, medi := range s.stream.Desc().Medias {
 				if medi.Type == description.MediaTypeVideo {
-					for _, u := range s.stream.CachedUnits[:Cached] {
+					for _, u := range s.stream.CachedUnits[:s.stream.Cached] {
 						for _, pkt := range u.GetRTPPackets() {
 							pkt.Timestamp = lastTimestamp
 							err := s.rsession.WritePacketRTP(medi, pkt)

--- a/internal/servers/rtsp/session.go
+++ b/internal/servers/rtsp/session.go
@@ -268,6 +268,7 @@ func (s *session) onPlay(_ *gortsplib.ServerHandlerOnPlayCtx) (*base.Response, e
 				}
 			}
 		}
+	}
 
 	return &base.Response{
 		StatusCode: base.StatusOK,

--- a/internal/servers/srt/server_test.go
+++ b/internal/servers/srt/server_test.go
@@ -42,6 +42,7 @@ func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stre
 		req.Desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -171,6 +172,7 @@ func TestServerRead(t *testing.T) {
 		desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/servers/webrtc/server_test.go
+++ b/internal/servers/webrtc/server_test.go
@@ -59,6 +59,7 @@ func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stre
 		req.Desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -356,8 +357,9 @@ func TestServerRead(t *testing.T) {
 	for _, ca := range []struct {
 		name          string
 		medias        []*description.Media
-		unit          unit.Unit
+		unit          []unit.Unit
 		outRTPPayload []byte
+		gopCache      bool
 	}{
 		{
 			"av1",
@@ -367,10 +369,13 @@ func TestServerRead(t *testing.T) {
 					PayloadTyp: 96,
 				}},
 			}},
-			&unit.AV1{
-				TU: [][]byte{{1, 2}},
+			[]unit.Unit{
+				&unit.AV1{
+					TU: [][]byte{{1, 2}},
+				},
 			},
 			[]byte{0, 2, 1, 2},
+			false,
 		},
 		{
 			"vp9",
@@ -380,14 +385,17 @@ func TestServerRead(t *testing.T) {
 					PayloadTyp: 96,
 				}},
 			}},
-			&unit.VP9{
-				Frame: []byte{0x82, 0x49, 0x83, 0x42, 0x0, 0x77, 0xf0, 0x32, 0x34},
+			[]unit.Unit{
+				&unit.VP9{
+					Frame: []byte{0x82, 0x49, 0x83, 0x42, 0x0, 0x77, 0xf0, 0x32, 0x34},
+				},
 			},
 			[]byte{
 				0x8f, 0xa0, 0xfd, 0x18, 0x07, 0x80, 0x03, 0x24,
 				0x01, 0x14, 0x01, 0x82, 0x49, 0x83, 0x42, 0x00,
 				0x77, 0xf0, 0x32, 0x34,
 			},
+			false,
 		},
 		{
 			"vp8",
@@ -397,17 +405,22 @@ func TestServerRead(t *testing.T) {
 					PayloadTyp: 96,
 				}},
 			}},
-			&unit.VP8{
-				Frame: []byte{1, 2},
+			[]unit.Unit{
+				&unit.VP8{
+					Frame: []byte{1, 2},
+				},
 			},
 			[]byte{0x10, 1, 2},
+			false,
 		},
 		{
 			"h264",
 			[]*description.Media{test.MediaH264},
-			&unit.H264{
-				AU: [][]byte{
-					{5, 1},
+			[]unit.Unit{
+				&unit.H264{
+					AU: [][]byte{
+						{5, 1},
+					},
 				},
 			},
 			[]byte{
@@ -417,6 +430,145 @@ func TestServerRead(t *testing.T) {
 				0x3c, 0x60, 0xc9, 0x20, 0x00, 0x04, 0x08, 0x06,
 				0x07, 0x08, 0x00, 0x02, 0x05, 0x01,
 			},
+			false,
+		},
+		{
+			"h264 with gop cache",
+			[]*description.Media{test.MediaH264},
+			[]unit.Unit{
+				// ffmpeg -f lavfi -i color=blue:s=2x2 -vframes 10 -c:v libx264 out.264
+				&unit.H264{
+					AU: [][]byte{
+						{
+							0x65, 0x88, 0x84, 0x00, 0x37, 0xff, 0xfe, 0xe1,
+							0x03, 0xf8, 0x14, 0xd7, 0x4d, 0xfe, 0x63, 0x8f,
+							0x43, 0xd9, 0x01, 0x68, 0xc1,
+						},
+					},
+				},
+				&unit.H264{
+					AU: [][]byte{
+						{0x41, 0x9a, 0x24, 0x6c, 0x43, 0x7f, 0xfe, 0xe0},
+					},
+				},
+				&unit.H264{
+					AU: [][]byte{
+						{0x41, 0x9e, 0x42, 0x78, 0x85, 0xff, 0xc1, 0x81},
+					},
+				},
+				&unit.H264{
+					AU: [][]byte{
+						{0x01, 0x9e, 0x61, 0x74, 0x42, 0xbf, 0xc4, 0x80},
+					},
+				},
+				&unit.H264{
+					AU: [][]byte{
+						{0x01, 0x9e, 0x63, 0x6a, 0x42, 0xbf, 0xc4, 0x81},
+					},
+				},
+				&unit.H264{
+					AU: [][]byte{
+						{0x41, 0x9a, 0x68, 0x49, 0xa8, 0x41, 0x68, 0x99, 0x4c, 0x08, 0x5f, 0xff, 0xfe, 0xe1},
+					},
+				},
+				&unit.H264{
+					AU: [][]byte{
+						{0x41, 0x9e, 0x86, 0x45, 0x11, 0x2c, 0x2f, 0xff, 0xc1, 0x81},
+					},
+				},
+				&unit.H264{
+					AU: [][]byte{
+						{0x01, 0x9e, 0xa5, 0x74, 0x42, 0xbf, 0xc4, 0x81},
+					},
+				},
+				&unit.H264{
+					AU: [][]byte{
+						{0x01, 0x9e, 0xa7, 0x6a, 0x42, 0xbf, 0xc4, 0x80},
+					},
+				},
+				&unit.H264{
+					AU: [][]byte{
+						{0x41, 0x9a, 0xa9, 0x49, 0xa8, 0x41, 0x6c, 0x99, 0x4c, 0x08, 0x57, 0xff, 0xfe, 0xc0},
+					},
+				},
+			},
+			[]byte{
+				0x18, 0x00, 0x19, 0x67, 0x42, 0xc0, 0x28, 0xd9, 0x00, 0x78, 0x02, 0x27, 0xe5, 0x84, 0x00, 0x00,
+				0x03, 0x00, 0x04, 0x00, 0x00, 0x03, 0x00, 0xf0, 0x3c, 0x60, 0xc9, 0x20, 0x00, 0x04, 0x08, 0x06,
+				0x07, 0x08, 0x00, 0x15, 0x65, 0x88, 0x84, 0x00, 0x37, 0xff, 0xfe, 0xe1, 0x03, 0xf8, 0x14, 0xd7,
+				0x4d, 0xfe, 0x63, 0x8f, 0x43, 0xd9, 0x01, 0x68, 0xc1,
+			},
+			true,
+		},
+		{
+			"h265 with gop cache",
+			[]*description.Media{test.MediaH265},
+			[]unit.Unit{
+				// ffmpeg -f lavfi -i color=blue:s=16x16 -vframes 10 -c:v libx265 out.265
+				&unit.H265{
+					AU: [][]byte{
+						{
+							0x28, 0x01, 0xaf, 0x1d, 0x80, 0xf0, 0x0e, 0x9e, 0x0f, 0xfd, 0x7d, 0x3a, 0x39, 0xb1,
+							0xc7, 0x6f, 0x98,
+						},
+					},
+				},
+				&unit.H265{
+					AU: [][]byte{
+						{0x02, 0x01, 0xd0, 0x29, 0x4b, 0xe1, 0x0c, 0x63, 0x90, 0xfa, 0x84},
+					},
+				},
+				&unit.H265{
+					AU: [][]byte{
+						{0x02, 0x01, 0xe0, 0x64, 0x9d, 0x78, 0x61, 0x24, 0xc5, 0x60},
+					},
+				},
+				&unit.H265{
+					AU: [][]byte{
+						{0x00, 0x01, 0xe0, 0x24, 0xf5, 0x5f, 0xa2, 0xc2, 0x98, 0xc8, 0x20},
+					},
+				},
+				&unit.H265{
+					AU: [][]byte{
+						{0x00, 0x01, 0xe0, 0x44, 0xd7, 0x5f, 0xa2, 0xc2, 0x88, 0xc8, 0x20},
+					},
+				},
+				&unit.H265{
+					AU: [][]byte{
+						{0x00, 0x01, 0xe0, 0x86, 0xb7, 0xfd, 0x46, 0x14, 0xc0, 0xc8, 0x20},
+					},
+				},
+				&unit.H265{
+					AU: [][]byte{
+						{0x02, 0x01, 0xd0, 0x48, 0x92, 0x55, 0xfd, 0xc4, 0x30, 0x18, 0xec, 0xfa, 0x84},
+					},
+				},
+				&unit.H265{
+					AU: [][]byte{
+						{0x02, 0x01, 0xe0, 0xe2, 0x25, 0x57, 0x5f, 0x71, 0x84, 0x90, 0xc5, 0x60},
+					},
+				},
+				&unit.H265{
+					AU: [][]byte{
+						{0x00, 0x01, 0xe0, 0xc6, 0xf5, 0xd7, 0xd2, 0x2c, 0x29, 0x80, 0xc8, 0x20},
+					},
+				},
+				&unit.H265{
+					AU: [][]byte{
+						{0x00, 0x01, 0xe1, 0x02, 0x2d, 0x57, 0xf7, 0x18, 0x51, 0xc8, 0x20},
+					},
+				},
+			},
+			[]byte{
+				0x60, 0x0, 0x0, 0x18, 0x40, 0x1, 0xc, 0x1, 0xff, 0xff, 0x2, 0x20, 0x0, 0x0, 0x3, 0x0, 0xb0, 0x0,
+				0x0, 0x3, 0x0, 0x0, 0x3, 0x0, 0x7b, 0x18, 0xb0, 0x24, 0x0, 0x3c, 0x42, 0x1, 0x1, 0x2, 0x20, 0x0,
+				0x0, 0x3, 0x0, 0xb0, 0x0, 0x0, 0x3, 0x0, 0x0, 0x3, 0x0, 0x7b, 0xa0, 0x7, 0x82, 0x0, 0x88, 0x7d,
+				0xb6, 0x71, 0x8b, 0x92, 0x44, 0x80, 0x53, 0x88, 0x88, 0x92, 0xcf, 0x24, 0xa6, 0x92, 0x72, 0xc9,
+				0x12, 0x49, 0x22, 0xdc, 0x91, 0xaa, 0x48, 0xfc, 0xa2, 0x23, 0xff, 0x0, 0x1, 0x0, 0x1, 0x6a, 0x2,
+				0x2, 0x2, 0x1, 0x0, 0x8, 0x44, 0x1, 0xc0, 0x25, 0x2f, 0x5, 0x32, 0x40, 0x0, 0x11, 0x28, 0x1, 0xaf,
+				0x1d, 0x80, 0xf0, 0xe, 0x9e, 0xf, 0xfd, 0x7d, 0x3a, 0x39, 0xb1, 0xc7, 0x6f, 0x98,
+			},
+			true,
 		},
 		{
 			"opus",
@@ -427,10 +579,13 @@ func TestServerRead(t *testing.T) {
 					ChannelCount: 2,
 				}},
 			}},
-			&unit.Opus{
-				Packets: [][]byte{{1, 2}},
+			[]unit.Unit{
+				&unit.Opus{
+					Packets: [][]byte{{1, 2}},
+				},
 			},
 			[]byte{1, 2},
+			false,
 		},
 		{
 			"g722",
@@ -438,22 +593,25 @@ func TestServerRead(t *testing.T) {
 				Type:    description.MediaTypeAudio,
 				Formats: []format.Format{&format.G722{}},
 			}},
-			&unit.Generic{
-				Base: unit.Base{
-					RTPPackets: []*rtp.Packet{{
-						Header: rtp.Header{
-							Version:        2,
-							Marker:         true,
-							PayloadType:    9,
-							SequenceNumber: 1123,
-							Timestamp:      45343,
-							SSRC:           563423,
-						},
-						Payload: []byte{1, 2},
-					}},
+			[]unit.Unit{
+				&unit.Generic{
+					Base: unit.Base{
+						RTPPackets: []*rtp.Packet{{
+							Header: rtp.Header{
+								Version:        2,
+								Marker:         true,
+								PayloadType:    9,
+								SequenceNumber: 1123,
+								Timestamp:      45343,
+								SSRC:           563423,
+							},
+							Payload: []byte{1, 2},
+						}},
+					},
 				},
 			},
 			[]byte{1, 2},
+			false,
 		},
 		{
 			"g711 8khz mono",
@@ -465,10 +623,13 @@ func TestServerRead(t *testing.T) {
 					ChannelCount: 1,
 				}},
 			}},
-			&unit.G711{
-				Samples: []byte{1, 2, 3},
+			[]unit.Unit{
+				&unit.G711{
+					Samples: []byte{1, 2, 3},
+				},
 			},
 			[]byte{1, 2, 3},
+			false,
 		},
 		{
 			"g711 16khz stereo",
@@ -480,10 +641,13 @@ func TestServerRead(t *testing.T) {
 					ChannelCount: 2,
 				}},
 			}},
-			&unit.G711{
-				Samples: []byte{1, 2, 3, 4},
+			[]unit.Unit{
+				&unit.G711{
+					Samples: []byte{1, 2, 3, 4},
+				},
 			},
 			[]byte{0x86, 0x84, 0x8a, 0x84, 0x8e, 0x84, 0x92, 0x84},
+			false,
 		},
 		{
 			"lpcm",
@@ -496,10 +660,13 @@ func TestServerRead(t *testing.T) {
 					ChannelCount: 2,
 				}},
 			}},
-			&unit.LPCM{
-				Samples: []byte{1, 2, 3, 4},
+			[]unit.Unit{
+				&unit.LPCM{
+					Samples: []byte{1, 2, 3, 4},
+				},
 			},
 			[]byte{1, 2, 3, 4},
+			false,
 		},
 	} {
 		t.Run(ca.name, func(t *testing.T) {
@@ -509,8 +676,9 @@ func TestServerRead(t *testing.T) {
 				512,
 				1460,
 				desc,
-				reflect.TypeOf(ca.unit) != reflect.TypeOf(&unit.Generic{}),
+				reflect.TypeOf(ca.unit[0]) != reflect.TypeOf(&unit.Generic{}),
 				test.NilLogger,
+				ca.gopCache,
 			)
 			require.NoError(t, err)
 
@@ -576,16 +744,26 @@ func TestServerRead(t *testing.T) {
 			go func() {
 				defer close(writerDone)
 
-				str.WaitRunningReader()
+				// When testing for gopCache, start pushing packets before the client connects
+				if !ca.gopCache {
+					str.WaitRunningReader()
+				}
 
-				r := reflect.New(reflect.TypeOf(ca.unit).Elem())
-				r.Elem().Set(reflect.ValueOf(ca.unit).Elem())
+				for i, u := range ca.unit {
+					r := reflect.New(reflect.TypeOf(u).Elem())
+					r.Elem().Set(reflect.ValueOf(u).Elem())
 
-				if g, ok := r.Interface().(*unit.Generic); ok {
-					clone := *g.RTPPackets[0]
-					str.WriteRTPPacket(desc.Medias[0], desc.Medias[0].Formats[0], &clone, time.Time{}, 0)
-				} else {
-					str.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], r.Interface().(unit.Unit))
+					// When testing for gopCache, wait until half-way before pushing the rest of segments.
+					if i == len(ca.unit)/2 && ca.gopCache {
+						str.WaitRunningReader()
+					}
+
+					if g, ok := r.Interface().(*unit.Generic); ok {
+						clone := *g.RTPPackets[0]
+						str.WriteRTPPacket(desc.Medias[0], desc.Medias[0].Formats[0], &clone, time.Time{}, 0)
+					} else {
+						str.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], r.Interface().(unit.Unit))
+					}
 				}
 			}()
 

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -41,7 +41,7 @@ type Stream struct {
 
 	CachedUnits []unit.Unit
 	CacheLength int
-	Cached int
+	Cached      int
 }
 
 // New allocates a Stream.

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -206,16 +206,18 @@ func (s *Stream) StartReader(reader Reader) {
 				// We must update the PTS of the p-frames to have them played back real quick, but not instantly.
 				// If we do not update the PTS, the client will pause by an amount equal to the time between the p-frames.
 				// This is an issue because we want to send the p-frames as fast as possible.
-				playbackFPS := int64(100)
+				playbackFPS := 100
 				msPerFrame := 1000 / playbackFPS
-				ticksPerMs := int64(90000 / 1000)
-				pts := s.CachedUnits[len(s.CachedUnits)-1].GetPTS() - ticksPerMs*int64(framesWithAU)*msPerFrame
+				ticksPerMs := 90000 / 1000
+				lastTimestamp := s.CachedUnits[len(s.CachedUnits)-1].GetRTPPackets()[0].Timestamp
+				lastPts := s.CachedUnits[len(s.CachedUnits)-1].GetPTS()
+				delta := -ticksPerMs * framesWithAU * msPerFrame
 				start := time.Now()
 				for _, u := range s.CachedUnits {
 					if isEmptyAU(u) {
 						continue
 					}
-					pts += ticksPerMs * msPerFrame
+					delta += ticksPerMs * msPerFrame
 					start = start.Add(time.Millisecond * time.Duration(msPerFrame))
 
 					var clonedU unit.Unit
@@ -226,11 +228,11 @@ func (s *Stream) StartReader(reader Reader) {
 								RTPPackets: []*rtp.Packet{
 									{
 										Header: rtp.Header{
-											Timestamp: uint32(pts),
+											Timestamp: lastTimestamp + uint32(delta),
 										},
 									},
 								},
-								PTS: pts,
+								PTS: lastPts + int64(delta),
 							},
 							AU: tunit.AU,
 						}
@@ -240,11 +242,11 @@ func (s *Stream) StartReader(reader Reader) {
 								RTPPackets: []*rtp.Packet{
 									{
 										Header: rtp.Header{
-											Timestamp: uint32(pts),
+											Timestamp: lastTimestamp + uint32(delta),
 										},
 									},
 								},
-								PTS: pts,
+								PTS: lastPts + int64(delta),
 							},
 							AU: tunit.AU,
 						}

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -252,6 +252,20 @@ func (s *Stream) StartReader(reader Reader) {
 							},
 							AU: tunit.AU,
 						}
+					case *unit.AV1:
+						clonedU = &unit.AV1{
+							Base: unit.Base{
+								RTPPackets: []*rtp.Packet{
+									{
+										Header: rtp.Header{
+											Timestamp: lastTimestamp + uint32(delta),
+										},
+									},
+								},
+								PTS: lastPts + int64(delta),
+							},
+							TU: tunit.TU,
+						}
 					}
 					until := start
 					sr.push(func() error {

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -38,6 +38,8 @@ type Stream struct {
 	streamReaders map[Reader]*streamReader
 
 	readerRunning chan struct{}
+
+	CachedUnits []unit.Unit
 }
 
 // New allocates a Stream.
@@ -47,6 +49,7 @@ func New(
 	desc *description.Session,
 	generateRTPPackets bool,
 	decodeErrLogger logger.Writer,
+	gopCache bool,
 ) (*Stream, error) {
 	s := &Stream{
 		writeQueueSize: writeQueueSize,
@@ -61,7 +64,7 @@ func New(
 
 	for _, media := range desc.Medias {
 		var err error
-		s.streamMedias[media], err = newStreamMedia(udpMaxPayloadSize, media, generateRTPPackets, decodeErrLogger)
+		s.streamMedias[media], err = newStreamMedia(udpMaxPayloadSize, media, generateRTPPackets, decodeErrLogger, gopCache)
 		if err != nil {
 			return nil, err
 		}
@@ -180,9 +183,82 @@ func (s *Stream) StartReader(reader Reader) {
 
 	sr.start()
 
-	for _, sm := range s.streamMedias {
+	for m, sm := range s.streamMedias {
 		for _, sf := range sm.formats {
 			sf.startReader(sr)
+			if m.Type == description.MediaTypeVideo {
+				cb := sf.runningReaders[sr]
+				if cb == nil {
+					continue
+				}
+
+				framesWithAU := 0
+				for _, u := range s.CachedUnits {
+					if !isEmptyAU(u) {
+						framesWithAU++
+					}
+				}
+				if framesWithAU == 0 {
+					continue
+				}
+
+				// The previous p-frames must be sent at a certain speed to avoid the video freezing.
+				// We must update the PTS of the p-frames to have them played back real quick, but not instantly.
+				// If we do not update the PTS, the client will pause by an amount equal to the time between the p-frames.
+				// This is an issue because we want to send the p-frames as fast as possible.
+				playbackFPS := int64(100)
+				msPerFrame := 1000 / playbackFPS
+				ticksPerMs := int64(90000 / 1000)
+				pts := s.CachedUnits[len(s.CachedUnits)-1].GetPTS() - ticksPerMs*int64(framesWithAU)*msPerFrame
+				start := time.Now()
+				for _, u := range s.CachedUnits {
+					if isEmptyAU(u) {
+						continue
+					}
+					pts += ticksPerMs * msPerFrame
+					start = start.Add(time.Millisecond * time.Duration(msPerFrame))
+
+					var clonedU unit.Unit
+					switch tunit := u.(type) {
+					case *unit.H264:
+						clonedU = &unit.H264{
+							Base: unit.Base{
+								RTPPackets: []*rtp.Packet{
+									{
+										Header: rtp.Header{
+											Timestamp: uint32(pts),
+										},
+									},
+								},
+								PTS: pts,
+							},
+							AU: tunit.AU,
+						}
+					case *unit.H265:
+						clonedU = &unit.H265{
+							Base: unit.Base{
+								RTPPackets: []*rtp.Packet{
+									{
+										Header: rtp.Header{
+											Timestamp: uint32(pts),
+										},
+									},
+								},
+								PTS: pts,
+							},
+							AU: tunit.AU,
+						}
+					}
+					until := start
+					sr.push(func() error {
+						size := unitSize(clonedU)
+						atomic.AddUint64(s.bytesSent, size)
+						err := cb(clonedU)
+						time.Sleep(time.Until(until))
+						return err
+					})
+				}
+			}
 		}
 	}
 

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -40,6 +40,8 @@ type Stream struct {
 	readerRunning chan struct{}
 
 	CachedUnits []unit.Unit
+	CacheLength int
+	Cached int
 }
 
 // New allocates a Stream.
@@ -193,7 +195,7 @@ func (s *Stream) StartReader(reader Reader) {
 				}
 
 				framesWithAU := 0
-				for _, u := range s.CachedUnits {
+				for _, u := range s.CachedUnits[:s.Cached] {
 					if !isEmptyAU(u) {
 						framesWithAU++
 					}
@@ -209,11 +211,11 @@ func (s *Stream) StartReader(reader Reader) {
 				playbackFPS := 100
 				msPerFrame := 1000 / playbackFPS
 				ticksPerMs := 90000 / 1000
-				lastTimestamp := s.CachedUnits[len(s.CachedUnits)-1].GetRTPPackets()[0].Timestamp
-				lastPts := s.CachedUnits[len(s.CachedUnits)-1].GetPTS()
+				lastTimestamp := s.CachedUnits[s.Cached-1].GetRTPPackets()[0].Timestamp
+				lastPts := s.CachedUnits[ls.Cached-1].GetPTS()
 				delta := -ticksPerMs * framesWithAU * msPerFrame
 				start := time.Now()
-				for _, u := range s.CachedUnits {
+				for _, u := range s.CachedUnits[:s.Cached] {
 					if isEmptyAU(u) {
 						continue
 					}

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -212,7 +212,7 @@ func (s *Stream) StartReader(reader Reader) {
 				msPerFrame := 1000 / playbackFPS
 				ticksPerMs := 90000 / 1000
 				lastTimestamp := s.CachedUnits[s.Cached-1].GetRTPPackets()[0].Timestamp
-				lastPts := s.CachedUnits[ls.Cached-1].GetPTS()
+				lastPts := s.CachedUnits[s.Cached-1].GetPTS()
 				delta := -ticksPerMs * framesWithAU * msPerFrame
 				start := time.Now()
 				for _, u := range s.CachedUnits[:s.Cached] {

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -6,11 +6,17 @@ import (
 
 	"github.com/bluenviron/gortsplib/v4/pkg/description"
 	"github.com/bluenviron/gortsplib/v4/pkg/format"
+	"github.com/bluenviron/mediacommon/pkg/codecs/h264"
+	"github.com/bluenviron/mediacommon/pkg/codecs/h265"
 	"github.com/pion/rtp"
 
 	"github.com/bluenviron/mediamtx/internal/formatprocessor"
 	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/unit"
+)
+
+const (
+	maxCachedGOPSize int = 512
 )
 
 func unitSize(u unit.Unit) uint64 {
@@ -19,6 +25,26 @@ func unitSize(u unit.Unit) uint64 {
 		n += uint64(pkt.MarshalSize())
 	}
 	return n
+}
+
+func isKeyFrame(u unit.Unit) bool {
+	switch tunit := u.(type) {
+	case *unit.H264:
+		return h264.IDRPresent(tunit.AU)
+	case *unit.H265:
+		return h265.IsRandomAccess(tunit.AU)
+	}
+	return false
+}
+
+func isEmptyAU(u unit.Unit) bool {
+	switch tunit := u.(type) {
+	case *unit.H264:
+		return len(tunit.AU) == 0
+	case *unit.H265:
+		return len(tunit.AU) == 0
+	}
+	return true
 }
 
 type streamFormat struct {
@@ -30,6 +56,7 @@ type streamFormat struct {
 	proc           formatprocessor.Processor
 	pausedReaders  map[*streamReader]ReadFunc
 	runningReaders map[*streamReader]ReadFunc
+	gopCache       bool
 }
 
 func (sf *streamFormat) initialize() error {
@@ -78,7 +105,7 @@ func (sf *streamFormat) writeRTPPacket(
 	ntp time.Time,
 	pts int64,
 ) {
-	hasNonRTSPReaders := len(sf.pausedReaders) > 0 || len(sf.runningReaders) > 0
+	hasNonRTSPReaders := len(sf.pausedReaders) > 0 || len(sf.runningReaders) > 0 || sf.gopCache
 
 	u, err := sf.proc.ProcessRTPPacket(pkt, ntp, pts, hasNonRTSPReaders)
 	if err != nil {
@@ -93,6 +120,32 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 	size := unitSize(u)
 
 	atomic.AddUint64(s.bytesReceived, size)
+
+	if sf.gopCache && medi.Type == description.MediaTypeVideo {
+		if isKeyFrame(u) {
+			if s.CachedUnits == nil {
+				// Initialize the cache and enable caching
+				s.CachedUnits = make([]unit.Unit, 0, maxCachedGOPSize)
+			} else {
+				// Keep the last packets that were used to generate the key frame.
+				// This is to send a full key frame in the RTSP stream.
+				i := len(s.CachedUnits)
+				for ; i > 0; i-- {
+					if !isEmptyAU(s.CachedUnits[i-1]) {
+						break
+					}
+				}
+				s.CachedUnits = s.CachedUnits[i:]
+			}
+		}
+		if s.CachedUnits != nil {
+			s.CachedUnits = append(s.CachedUnits, u)
+		}
+		l := len(s.CachedUnits)
+		if l > maxCachedGOPSize {
+			s.CachedUnits = s.CachedUnits[l-maxCachedGOPSize:]
+		}
+	}
 
 	if s.rtspStream != nil {
 		for _, pkt := range u.GetRTPPackets() {

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -144,6 +144,7 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 		l := len(s.CachedUnits)
 		if l > maxCachedGOPSize {
 			s.CachedUnits = s.CachedUnits[l-maxCachedGOPSize:]
+			sf.decodeErrLogger.Log(logger.Warn, "GOP cache is full, dropping packets")
 		}
 	}
 

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -35,7 +35,8 @@ func isKeyFrame(u unit.Unit) bool {
 	case *unit.H265:
 		return h265.IsRandomAccess(tunit.AU)
 	case *unit.AV1:
-		var isRandomAccess, _ = av1.IsRandomAccess(tunit.TU)
+		var isRandomAccess bool
+		isRandomAccess, _ = av1.IsRandomAccess(tunit.TU)
 		return isRandomAccess
 	}
 	return false
@@ -138,7 +139,8 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 				lastFrame := s.CachedUnits[s.CacheLength - 1]
 				if s.CacheLength == 0 {
 					s.CacheLength = s.Cached
-					var newCachedUnits = make([]unit.Unit, s.CacheLength + 1, maxCachedGOPSize)
+					var newCachedUnits []unit.Unit
+					newCachedUnits = make([]unit.Unit, s.CacheLength + 1, maxCachedGOPSize)
 					copy(newCachedUnits, s.CachedUnits)
 					s.CachedUnits = newCachedUnits
 				}

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -35,7 +35,7 @@ func isKeyFrame(u unit.Unit) bool {
 	case *unit.H265:
 		return h265.IsRandomAccess(tunit.AU)
 	case *unit.AV1:
-		isRandomAccess, err := av1.IsRandomAccess(tunit.TU)
+		isRandomAccess, _ = av1.IsRandomAccess(tunit.TU)
 		return isRandomAccess
 	}
 	return false

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -35,7 +35,7 @@ func isKeyFrame(u unit.Unit) bool {
 	case *unit.H265:
 		return h265.IsRandomAccess(tunit.AU)
 	case *unit.AV1:
-		isRandomAccess, _ = av1.IsRandomAccess(tunit.TU)
+		var isRandomAccess, _ = av1.IsRandomAccess(tunit.TU)
 		return isRandomAccess
 	}
 	return false

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -150,7 +150,7 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 			s.CachedUnits[s.Cached] = u
 			s.Cached ++
 		} else if s.CachedUnits != nil {
-			s.CachedUnits = xappend(s.CachedUnits, u)
+			s.CachedUnits = append(s.CachedUnits, u)
 			s.Cached ++
 		}
 	}

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -138,7 +138,9 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 				lastFrame := s.CachedUnits[s.CacheLength - 1]
 				if s.CacheLength == 0 {
 					s.CacheLength = s.Cached
-					s.CachedUnits = copy(make([]unit.Unit, s.CacheLength + 1, maxCachedGOPSize), s.CachedUnits)
+					var newCachedUnits = make([]unit.Unit, s.CacheLength + 1, maxCachedGOPSize)
+					copy(newCachedUnits, s.CachedUnits)
+					s.CachedUnits = newCachedUnits
 				}
 				s.CachedUnits[0] = lastFrame
 				s.Cached = 1
@@ -148,7 +150,7 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 			s.CachedUnits[s.Cached] = u
 			s.Cached ++
 		} else if s.CachedUnits != nil {
-			s.CachedUnits = append(s.CachedUnits, u)
+			s.CachedUnits = xappend(s.CachedUnits, u)
 			s.Cached ++
 		}
 	}

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -35,7 +35,8 @@ func isKeyFrame(u unit.Unit) bool {
 	case *unit.H265:
 		return h265.IsRandomAccess(tunit.AU)
 	case *unit.AV1:
-		return av1.IsRandomAccess2(tunit.TU)
+		isRandomAccess, err := av1.IsRandomAccess(tunit.TU)
+		return isRandomAccess
 	}
 	return false
 }
@@ -131,12 +132,12 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 			if s.CachedUnits == nil {
 				// Initialize the cache and enable caching
 				s.CachedUnits = make([]unit.Unit, 0, maxCachedGOPSize)
-				s.CachedLength == 0
+				s.CacheLength = 0
 				s.Cached = 0
 			} else {
-				lastFrame = s.CachedUnits[s.CachedLength - 1]
+				lastFrame := s.CachedUnits[s.CacheLength - 1]
 				if s.CacheLength == 0 {
-					s.CachedLength = len(s.CachedUnits)
+					s.CacheLength = len(s.CachedUnits)
 					s.CachedUnits = make([]unit.Unit, 0, s.CacheLength + 1)
 				}
 				s.CachedUnits[0] = lastFrame

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -137,15 +137,18 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 			} else {
 				lastFrame := s.CachedUnits[s.CacheLength - 1]
 				if s.CacheLength == 0 {
-					s.CacheLength = len(s.CachedUnits)
-					s.CachedUnits = make([]unit.Unit, 0, s.CacheLength + 1)
+					s.CacheLength = s.Cached
+					s.CachedUnits = copy(make([]unit.Unit, s.CacheLength + 1, maxCachedGOPSize), s.CachedUnits)
 				}
 				s.CachedUnits[0] = lastFrame
 				s.Cached = 1
 			}
 		}
-		if s.CachedUnits != nil {
+		if s.CacheLength != 0 {
 			s.CachedUnits[s.Cached] = u
+			s.Cached ++
+		} else if s.CachedUnits != nil {
+			s.CachedUnits = append(s.CachedUnits, u)
 			s.Cached ++
 		}
 	}

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/bluenviron/gortsplib/v4/pkg/description"
 	"github.com/bluenviron/gortsplib/v4/pkg/format"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/av1"
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h265"
-	"github.com/bluenviron/mediacommon/v2/pkg/codecs/av1"
 	"github.com/pion/rtp"
 
 	"github.com/bluenviron/mediamtx/internal/formatprocessor"
@@ -129,18 +129,17 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 	atomic.AddUint64(s.bytesReceived, size)
 
 	if sf.gopCache && medi.Type == description.MediaTypeVideo {
-		if isKeyFrame(u){
+		if isKeyFrame(u) {
 			if s.CachedUnits == nil {
 				// Initialize the cache and enable caching
 				s.CachedUnits = make([]unit.Unit, 0, maxCachedGOPSize)
 				s.CacheLength = 0
 				s.Cached = 0
 			} else {
-				lastFrame := s.CachedUnits[s.CacheLength - 1]
+				lastFrame := s.CachedUnits[s.CacheLength-1]
 				if s.CacheLength == 0 {
 					s.CacheLength = s.Cached
-					var newCachedUnits []unit.Unit
-					newCachedUnits = make([]unit.Unit, s.CacheLength + 1, maxCachedGOPSize)
+					var newCachedUnits []unit.Unit = make([]unit.Unit, s.CacheLength+1, maxCachedGOPSize)
 					copy(newCachedUnits, s.CachedUnits)
 					s.CachedUnits = newCachedUnits
 				}
@@ -150,10 +149,10 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 		}
 		if s.CacheLength != 0 {
 			s.CachedUnits[s.Cached] = u
-			s.Cached ++
+			s.Cached++
 		} else if s.CachedUnits != nil {
 			s.CachedUnits = append(s.CachedUnits, u)
-			s.Cached ++
+			s.Cached++
 		}
 	}
 

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/bluenviron/gortsplib/v4/pkg/description"
 	"github.com/bluenviron/gortsplib/v4/pkg/format"
-	"github.com/bluenviron/mediacommon/pkg/codecs/h264"
-	"github.com/bluenviron/mediacommon/pkg/codecs/h265"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h265"
 	"github.com/pion/rtp"
 
 	"github.com/bluenviron/mediamtx/internal/formatprocessor"
@@ -30,7 +30,7 @@ func unitSize(u unit.Unit) uint64 {
 func isKeyFrame(u unit.Unit) bool {
 	switch tunit := u.(type) {
 	case *unit.H264:
-		return h264.IDRPresent(tunit.AU)
+		return h264.IsRandomAccess(tunit.AU)
 	case *unit.H265:
 		return h265.IsRandomAccess(tunit.AU)
 	}

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bluenviron/gortsplib/v4/pkg/format"
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h265"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/av1"
 	"github.com/pion/rtp"
 
 	"github.com/bluenviron/mediamtx/internal/formatprocessor"
@@ -33,6 +34,8 @@ func isKeyFrame(u unit.Unit) bool {
 		return h264.IsRandomAccess(tunit.AU)
 	case *unit.H265:
 		return h265.IsRandomAccess(tunit.AU)
+	case *unit.AV1:
+		return av1.IsRandomAccess2(tunit.TU)
 	}
 	return false
 }
@@ -43,6 +46,8 @@ func isEmptyAU(u unit.Unit) bool {
 		return len(tunit.AU) == 0
 	case *unit.H265:
 		return len(tunit.AU) == 0
+	case *unit.AV1:
+		return len(tunit.TU) == 0
 	}
 	return true
 }

--- a/internal/stream/stream_media.go
+++ b/internal/stream/stream_media.go
@@ -15,6 +15,7 @@ func newStreamMedia(udpMaxPayloadSize int,
 	medi *description.Media,
 	generateRTPPackets bool,
 	decodeErrLogger logger.Writer,
+	gopCache bool,
 ) (*streamMedia, error) {
 	sm := &streamMedia{
 		formats: make(map[format.Format]*streamFormat),
@@ -26,6 +27,7 @@ func newStreamMedia(udpMaxPayloadSize int,
 			format:             forma,
 			generateRTPPackets: generateRTPPackets,
 			decodeErrLogger:    decodeErrLogger,
+			gopCache:           gopCache,
 		}
 		err := sf.initialize()
 		if err != nil {

--- a/internal/test/medias.go
+++ b/internal/test/medias.go
@@ -8,6 +8,9 @@ import (
 // MediaH264 is a dummy H264 media.
 var MediaH264 = UniqueMediaH264()
 
+// MediaH265 is a dummy H265 media.
+var MediaH265 = UniqueMediaH265()
+
 // MediaMPEG4Audio is a dummy MPEG-4 audio media.
 var MediaMPEG4Audio = UniqueMediaMPEG4Audio()
 
@@ -16,6 +19,14 @@ func UniqueMediaH264() *description.Media {
 	return &description.Media{
 		Type:    description.MediaTypeVideo,
 		Formats: []format.Format{FormatH264},
+	}
+}
+
+// UniqueMediaH265 is a dummy H265 media.
+func UniqueMediaH265() *description.Media {
+	return &description.Media{
+		Type:    description.MediaTypeVideo,
+		Formats: []format.Format{FormatH265},
 	}
 }
 

--- a/internal/test/source_tester.go
+++ b/internal/test/source_tester.go
@@ -70,6 +70,7 @@ func (t *SourceTester) SetReady(req defs.PathSourceStaticSetReadyReq) defs.PathS
 		req.Desc,
 		req.GenerateRTPPackets,
 		t,
+		false,
 	)
 
 	t.reader = NilLogger

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -23,6 +23,9 @@ writeQueueSize: 512
 # Maximum size of outgoing UDP packets.
 # This can be decreased to avoid fragmentation on networks with a low UDP MTU.
 udpMaxPayloadSize: 1472
+# Enable GOP cache to improve initial playback experience for new clients.
+# Note: will increase memory usage.
+gopCache: false
 
 # Command to run when a client connects to the server.
 # This is terminated with SIGINT when a client disconnects from the server.


### PR DESCRIPTION
a fork of https://github.com/bluenviron/mediamtx/pull/4189

> GOP Cache
> This PR introduces Group of Pictures (GOP) caching to MediaMTX, enhancing its performance and reducing latency in streaming scenarios. By caching the last GOP for each stream, new subscribers can immediately receive the latest video data without waiting for the next keyframe, improving the user experience, especially for streams with long keyframe intervals.
> 
> This works for both H264 and H265, as well as for RTSP and WebRTC.
> 
> Configurable Cache Settings:
> Introduced a new configuration parameter gopCache in mediamtx.yml for enabling/disabling GOP caching.
> 
> Fix: https://github.com/bluenviron/mediamtx/issues/1209 @jean343 

> The feature does work in the following scenarios:
> 
> Protocol:
> 
> * WebRTC
> * RTSP
> 
> Codecs:
> 
> * H.264
> * H.265
> 
> I have only tried videos without b-frames as WebRTC does not support b-frames. There might be adjustments to make when dealing with b-frames over RTSP.
> 
> In order to reduce RAM exhaustion, we do not cache anything until we get a key frame, this will prevent unsupported codecs from storing anything, and will save a little bit for supported codecs. In case the GOP is really long, we trim at `512 packets`, conserving memory. In this case, clients will need to wait until the next key frame before video playback.
> 
> As per additional codecs, I could not find a reliable way to detect their keyframes.
> 
> In the WebRTC playback scenario, the PTS and Timestamp needs to be modified to prevent gaps. WebRTC will pause and stop playback if set incorrectly.
> 
> For example, incorrect Timestamp will look like:
> 
>  Untitled.mov 
> Correct timestamp will look like:
> 
>  Screen.Recording.2025-01-23.at.1.40.16.PM.mov


[ ] Fixed Compatibility with mediacommon v2
[ ] Added Support for AV1