### PR TITLE
change error message when stream is not found

### DIFF
--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -440,7 +440,7 @@ func (pa *path) doDescribe(req defs.PathDescribeReq) {
 		return
 	}
 
-	req.Res <- defs.PathDescribeRes{Err: defs.PathNoOnePublishingError{PathName: pa.name}}
+	req.Res <- defs.PathDescribeRes{Err: defs.PathNoStreamAvailableError{PathName: pa.name}}
 }
 
 func (pa *path) doRemovePublisher(req defs.PathRemovePublisherReq) {
@@ -531,7 +531,7 @@ func (pa *path) doAddReader(req defs.PathAddReaderReq) {
 		return
 	}
 
-	req.Res <- defs.PathAddReaderRes{Err: defs.PathNoOnePublishingError{PathName: pa.name}}
+	req.Res <- defs.PathAddReaderRes{Err: defs.PathNoStreamAvailableError{PathName: pa.name}}
 }
 
 func (pa *path) doRemoveReader(req defs.PathRemoveReaderReq) {

--- a/internal/defs/path.go
+++ b/internal/defs/path.go
@@ -10,14 +10,14 @@ import (
 	"github.com/bluenviron/mediamtx/internal/stream"
 )
 
-// PathNoOnePublishingError is returned when no one is publishing.
-type PathNoOnePublishingError struct {
+// PathNoStreamAvailableError is returned when no one is publishing.
+type PathNoStreamAvailableError struct {
 	PathName string
 }
 
 // Error implements the error interface.
-func (e PathNoOnePublishingError) Error() string {
-	return fmt.Sprintf("no one is publishing to path '%s'", e.PathName)
+func (e PathNoStreamAvailableError) Error() string {
+	return fmt.Sprintf("no stream is available on path '%s'", e.PathName)
 }
 
 // Path is a path.

--- a/internal/servers/rtsp/conn.go
+++ b/internal/servers/rtsp/conn.go
@@ -160,7 +160,7 @@ func (c *conn) onDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx,
 			return res, nil, err2
 		}
 
-		var terr2 defs.PathNoOnePublishingError
+		var terr2 defs.PathNoStreamAvailableError
 		if errors.As(res.Err, &terr2) {
 			return &base.Response{
 				StatusCode: base.StatusNotFound,

--- a/internal/servers/rtsp/session.go
+++ b/internal/servers/rtsp/session.go
@@ -188,7 +188,7 @@ func (s *session) onSetup(c *conn, ctx *gortsplib.ServerHandlerOnSetupCtx,
 				return res, nil, err2
 			}
 
-			var terr2 defs.PathNoOnePublishingError
+			var terr2 defs.PathNoStreamAvailableError
 			if errors.As(err, &terr2) {
 				return &base.Response{
 					StatusCode: base.StatusNotFound,

--- a/internal/servers/webrtc/server_test.go
+++ b/internal/servers/webrtc/server_test.go
@@ -618,7 +618,7 @@ func TestServerReadNotFound(t *testing.T) {
 			return &conf.Path{}, nil
 		},
 		AddReaderImpl: func(_ defs.PathAddReaderReq) (defs.Path, *stream.Stream, error) {
-			return nil, nil, defs.PathNoOnePublishingError{}
+			return nil, nil, defs.PathNoStreamAvailableError{}
 		},
 	}
 

--- a/internal/servers/webrtc/session.go
+++ b/internal/servers/webrtc/session.go
@@ -253,7 +253,7 @@ func (s *session) runRead() (int, error) {
 		AccessRequest: req,
 	})
 	if err != nil {
-		var terr2 defs.PathNoOnePublishingError
+		var terr2 defs.PathNoStreamAvailableError
 		if errors.As(err, &terr2) {
 			return http.StatusNotFound, err
 		}


### PR DESCRIPTION
Switch from 'no one is publishing to path' to 'no stream is available on path' since the stream might be provided from a static source too.