### PR TITLE
Add docker RPi cam without elevated privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,45 @@ paths:
 
 All available parameters are listed in the [sample configuration file](/mediamtx.yml).
 
+If you want to run docker container in a more secure way, then below recommendation
+should give you a good start - read only root filesystem, not needing `privileged` param.
+As so it is required to pass on **all** devices used by mediamtx to the container.
+
+```sh
+docker run --rm -it \
+--read-only \
+--user nobody:video \
+--device=/dev/video0 \
+--device=/dev/video10 \
+--device=/dev/video11 \
+--device=/dev/video12 \
+--device=/dev/video13 \
+--device=/dev/video14 \
+--device=/dev/video15 \
+--device=/dev/video16 \
+--device=/dev/video18 \
+--device=/dev/video19 \
+--device=/dev/video20 \
+--device=/dev/video21 \
+--device=/dev/video22 \
+--device=/dev/video23 \
+--device=/dev/video31 \
+--device=/dev/media0 \
+--device=/dev/media1 \
+--device=/dev/media2 \
+--device=/dev/media3 \
+--device=/dev/media4 \
+--device=/dev/v4l-subdev0 \
+--device=/dev/dma_heap/linux,cma \
+--device=/dev/dma_heap/system \
+--network=host \
+--tmpfs /dev/shm:exec \
+-v /run/udev:/run/udev:ro \
+-e MTX_PATHS_CAM_SOURCE=rpiCamera \
+bluenviron/mediamtx:latest-rpi
+
+```
+
 In order to add audio from a USB microfone, install GStreamer and alsa-utils:
 
 ```sh


### PR DESCRIPTION
Add example command to run docker container on Raspberry Pi with CSI camera without needing privileged mode.
Providing read only root filesystem, user nobody:video to access devices, pass down camera from the host.

Network host was preserved to decrease clutter caused by additional port forwards.

Tested under Debian 12 Bookworm kernel 6.6.62+rpt-rpi-v8 aarch64 and Docker Community edition version 28.0.1, with default config from the within the container.
