### PR TITLE
rename stream decode errors into processing errors

### DIFF
--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -22,10 +22,10 @@ func unitSize(u unit.Unit) uint64 {
 }
 
 type streamFormat struct {
-	UDPMaxPayloadSize  int
-	Format             format.Format
-	GenerateRTPPackets bool
-	DecodeErrors       *counterdumper.CounterDumper
+	udpMaxPayloadSize  int
+	format             format.Format
+	generateRTPPackets bool
+	processingErrors   *counterdumper.CounterDumper
 
 	proc           formatprocessor.Processor
 	pausedReaders  map[*streamReader]ReadFunc
@@ -37,7 +37,7 @@ func (sf *streamFormat) initialize() error {
 	sf.runningReaders = make(map[*streamReader]ReadFunc)
 
 	var err error
-	sf.proc, err = formatprocessor.New(sf.UDPMaxPayloadSize, sf.Format, sf.GenerateRTPPackets)
+	sf.proc, err = formatprocessor.New(sf.udpMaxPayloadSize, sf.format, sf.generateRTPPackets)
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func (sf *streamFormat) startReader(sr *streamReader) {
 func (sf *streamFormat) writeUnit(s *Stream, medi *description.Media, u unit.Unit) {
 	err := sf.proc.ProcessUnit(u)
 	if err != nil {
-		sf.DecodeErrors.Increase()
+		sf.processingErrors.Increase()
 		return
 	}
 
@@ -82,7 +82,7 @@ func (sf *streamFormat) writeRTPPacket(
 
 	u, err := sf.proc.ProcessRTPPacket(pkt, ntp, pts, hasNonRTSPReaders)
 	if err != nil {
-		sf.DecodeErrors.Increase()
+		sf.processingErrors.Increase()
 		return
 	}
 

--- a/internal/stream/stream_media.go
+++ b/internal/stream/stream_media.go
@@ -7,10 +7,10 @@ import (
 )
 
 type streamMedia struct {
-	UDPMaxPayloadSize  int
-	Media              *description.Media
-	GenerateRTPPackets bool
-	DecodeErrors       *counterdumper.CounterDumper
+	udpMaxPayloadSize  int
+	media              *description.Media
+	generateRTPPackets bool
+	processingErrors   *counterdumper.CounterDumper
 
 	formats map[format.Format]*streamFormat
 }
@@ -18,12 +18,12 @@ type streamMedia struct {
 func (sm *streamMedia) initialize() error {
 	sm.formats = make(map[format.Format]*streamFormat)
 
-	for _, forma := range sm.Media.Formats {
+	for _, forma := range sm.media.Formats {
 		sf := &streamFormat{
-			UDPMaxPayloadSize:  sm.UDPMaxPayloadSize,
-			Format:             forma,
-			GenerateRTPPackets: sm.GenerateRTPPackets,
-			DecodeErrors:       sm.DecodeErrors,
+			udpMaxPayloadSize:  sm.udpMaxPayloadSize,
+			format:             forma,
+			generateRTPPackets: sm.generateRTPPackets,
+			processingErrors:   sm.processingErrors,
 		}
 		err := sf.initialize()
 		if err != nil {


### PR DESCRIPTION
Stream errors include both errors from decoding RTP packets into frames, and errors from encoding frames into RTP packets. "processing errors" is more fit.