### PR TITLE
feat(docker): Add tzdata package to non rpi images

### DIFF
--- a/scripts/dockerhub.mk
+++ b/scripts/dockerhub.mk
@@ -1,7 +1,8 @@
 DOCKER_REPOSITORY = bluenviron/mediamtx
 
 define DOCKERFILE_DOCKERHUB
-FROM scratch
+FROM $(ALPINE_IMAGE)
+RUN apk add --no-cache tzdata
 ARG TARGETPLATFORM
 ADD tmp/binaries/$$TARGETPLATFORM.tar.gz /
 ENTRYPOINT [ "/mediamtx" ]
@@ -11,6 +12,7 @@ export DOCKERFILE_DOCKERHUB
 define DOCKERFILE_DOCKERHUB_FFMPEG
 FROM $(ALPINE_IMAGE)
 RUN apk add --no-cache ffmpeg
+RUN apk add --no-cache tzdata
 ARG TARGETPLATFORM
 ADD tmp/binaries/$$TARGETPLATFORM.tar.gz /
 ENTRYPOINT [ "/mediamtx" ]


### PR DESCRIPTION
# Problem

When using the non-RPI images, the timezone is not changeable. This behavior leads to a deviation in recording timestamps if the host uses a different timezone. 

# Solution

By adding the `tzdata` package, the timezone is adjustable through an environment variable.

## Example Docker (from Documentation)
```
docker run --rm -it \
-e TZ=Europe/Berlin
-e MTX_RTSPTRANSPORTS=tcp \
-e MTX_WEBRTCADDITIONALHOSTS=192.168.x.x \
-p 8554:8554 \
-p 1935:1935 \
-p 8888:8888 \
-p 8889:8889 \
-p 8890:8890/udp \
-p 8189:8189/udp \
bluenviron/mediamtx
```

## Example Docker-Compose
```
name: stream

services:
  media-server:
    image: bluenviron/mediamtx:1.12.0
    environment:
      TZ:Europe/Berlin
      MTX_RTSPTRANSPORTS: tcp
      MTX_WEBRTCADDITIONALHOSTS: "192.168.x.x"
    ports:
      - "8554:8554"
      - "1935:1935"
      - "8888:8888"
      - "8889:8889"
      - "8890:8890/udp"
      - "8189:8189/udp"
```

### Example Kubernetes
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: media-server
  namespace: stream
  labels:
    app.kubernetes.io/name: media-server
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: media-server
  template:
    metadata:
      labels:
        app.kubernetes.io/name: media-server
    spec:
      containers:
        - name: media-server
          image: bluenviron/mediamtx:1.12.0
          env:
            - name: TZ
              value: "Europe/Berlin"
            - name: MTX_RTSPTRANSPORTS
              value: "tcp"
            - name: MTX_WEBRTCADDITIONALHOSTS
              value: "192.168.x.x"
```
