### PR TITLE
Add authentication method internal-and-jwt

### DIFF
--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -132,8 +132,14 @@ func (m *Manager) Authenticate(req *Request) error {
 	case conf.AuthMethodHTTP:
 		err = m.authenticateHTTP(req)
 
-	default:
+	case conf.AuthMethodJWT:
 		err = m.authenticateJWT(req)
+
+	default:
+		err = m.authenticateInternal(req)
+		if err != nil {
+			err = m.authenticateJWT(req)
+		}
 	}
 
 	if err != nil {

--- a/internal/conf/auth_method.go
+++ b/internal/conf/auth_method.go
@@ -15,6 +15,7 @@ const (
 	AuthMethodInternal AuthMethod = iota
 	AuthMethodHTTP
 	AuthMethodJWT
+	AuthMethodJWTInternal
 )
 
 // MarshalJSON implements json.Marshaler.
@@ -28,8 +29,10 @@ func (d AuthMethod) MarshalJSON() ([]byte, error) {
 	case AuthMethodHTTP:
 		out = "http"
 
-	default:
+	case AuthMethodJWT:
 		out = "jwt"
+	default:
+		out = "internal-and-jwt"
 	}
 
 	return json.Marshal(out)
@@ -51,6 +54,9 @@ func (d *AuthMethod) UnmarshalJSON(b []byte) error {
 
 	case "jwt":
 		*d = AuthMethodJWT
+
+	case "internal-and-jwt":
+		*d = AuthMethodJWTInternal
 
 	default:
 		return fmt.Errorf("invalid authMethod: '%s'", in)

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -591,7 +591,7 @@ func (conf *Conf) Validate(l logger.Writer) error {
 			return fmt.Errorf("'authHTTPAddress' is empty")
 		}
 
-	case AuthMethodJWT:
+	case AuthMethodJWT | AuthMethodJWTInternal:
 		if conf.AuthJWTJWKS == "" {
 			return fmt.Errorf("'authJWTJWKS' is empty")
 		}

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -46,6 +46,7 @@ runOnDisconnect:
 # * internal: users are stored in the configuration file
 # * http: an external HTTP URL is contacted to perform authentication
 # * jwt: an external identity server provides authentication through JWTs
+# * internal-and-jwt: users are stored in the configuration file or JWTs when not found internal users
 authMethod: internal
 
 # Internal authentication.


### PR DESCRIPTION
Added authentication method: `internal-and-jwt`, which allows authentication by internal user in `mediamtx.yml` and JWT. 

Useful if another service in docker compose would like to, for example, modify the configuration in real time.