### PR TITLE
Feat: Add JWKS rotation API endpoint

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -1364,6 +1364,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /v3/auth/jwks/refresh:
+    post:
+      operationId: authJwksRefresh
+      tags: [Authentication]
+      summary: Manually refreshes the JWKS token.
+      description: all fields are optional.
+      responses:
+        '200':
+          description: the request was successful.
+        '500':
+          description: server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /v3/hlsmuxers/list:
     get:
       operationId: hlsMuxersList

--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -1026,6 +1026,22 @@ components:
             $ref: '#/components/schemas/WebRTCSession'
 
 paths:
+
+  /v3/auth/jwks/refresh:
+    post:
+      operationId: authJwksRefresh
+      tags: [Authentication]
+      summary: Manually refreshes the JWT JWKS.
+      responses:
+        '200':
+          description: the request was successful.
+        '500':
+          description: server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /v3/config/global/get:
     get:
       operationId: configGlobalGet
@@ -1357,22 +1373,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500':
-          description: server error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /v3/auth/jwks/refresh:
-    post:
-      operationId: authJwksRefresh
-      tags: [Authentication]
-      summary: Manually refreshes the JWKS token.
-      description: all fields are optional.
-      responses:
-        '200':
-          description: the request was successful.
         '500':
           description: server error.
           content:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -122,6 +122,8 @@ func (a *API) Initialize() error {
 
 	group := router.Group("/v3")
 
+	group.POST("/auth/jwks/refresh", a.onAuthJwksRefresh)
+
 	group.GET("/config/global/get", a.onConfigGlobalGet)
 	group.PATCH("/config/global/patch", a.onConfigGlobalPatch)
 
@@ -134,8 +136,6 @@ func (a *API) Initialize() error {
 	group.PATCH("/config/paths/patch/*name", a.onConfigPathsPatch)
 	group.POST("/config/paths/replace/*name", a.onConfigPathsReplace)
 	group.DELETE("/config/paths/delete/*name", a.onConfigPathsDelete)
-
-	group.POST("/auth/jwks/refresh", a.onAuthJwksRefresh)
 
 	group.GET("/paths/list", a.onPathsList)
 	group.GET("/paths/get/*name", a.onPathsGet)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -79,7 +79,7 @@ func recordingsOfPath(
 
 type apiAuthManager interface {
 	Authenticate(req *auth.Request) error
-	ForceRefreshJWTJWKS() error
+	RefreshJWTJWKS()
 }
 
 type apiParent interface {
@@ -135,7 +135,7 @@ func (a *API) Initialize() error {
 	group.POST("/config/paths/replace/*name", a.onConfigPathsReplace)
 	group.DELETE("/config/paths/delete/*name", a.onConfigPathsDelete)
 
-	group.POST("/config/auth/jwks/refresh", a.onAuthJwksRefresh)
+	group.POST("/auth/jwks/refresh", a.onAuthJwksRefresh)
 
 	group.GET("/paths/list", a.onPathsList)
 	group.GET("/paths/get/*name", a.onPathsGet)
@@ -540,12 +540,7 @@ func (a *API) onConfigPathsDelete(ctx *gin.Context) {
 }
 
 func (a *API) onAuthJwksRefresh(ctx *gin.Context) {
-	err := a.AuthManager.ForceRefreshJWTJWKS()
-	if err != nil {
-		a.writeError(ctx, http.StatusInternalServerError, err)
-		return
-	}
-
+	a.AuthManager.RefreshJWTJWKS()
 	ctx.Status(http.StatusOK)
 }
 

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -249,6 +249,7 @@ func (m *Manager) pullJWTJWKS() (jwt.Keyfunc, error) {
 	return m.jwtKeyFunc.Keyfunc, nil
 }
 
+// ForceRefreshJWTJWKS force reloads the JWW keys
 func (m *Manager) ForceRefreshJWTJWKS() error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -233,19 +233,38 @@ func (m *Manager) authenticateJWT(req *Request) error {
 func (m *Manager) pullJWTJWKS() (jwt.Keyfunc, error) {
 	now := time.Now()
 
-	m.mutex.RLock()
-	needsRefresh := now.Sub(m.jwtLastRefresh) >= jwtRefreshPeriod
-	m.mutex.RUnlock()
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 
-	if needsRefresh {
-		err := m.ForceRefreshJWTJWKS()
+	if now.Sub(m.jwtLastRefresh) >= jwtRefreshPeriod {
+		if m.jwtHTTPClient == nil {
+			m.jwtHTTPClient = &http.Client{
+				Timeout:   (m.ReadTimeout),
+				Transport: &http.Transport{},
+			}
+		}
+
+		res, err := m.jwtHTTPClient.Get(m.JWTJWKS)
 		if err != nil {
 			return nil, err
 		}
+		defer res.Body.Close()
+
+		var raw json.RawMessage
+		err = json.NewDecoder(res.Body).Decode(&raw)
+		if err != nil {
+			return nil, err
+		}
+
+		tmp, err := keyfunc.NewJWKSetJSON(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		m.jwtKeyFunc = tmp
+		m.jwtLastRefresh = now
 	}
 
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
 	return m.jwtKeyFunc.Keyfunc, nil
 }
 
@@ -254,32 +273,7 @@ func (m *Manager) ForceRefreshJWTJWKS() error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	if m.jwtHTTPClient == nil {
-		m.jwtHTTPClient = &http.Client{
-			Timeout:   (m.ReadTimeout),
-			Transport: &http.Transport{},
-		}
-	}
+	m.jwtLastRefresh = time.Time{}
 
-	res, err := m.jwtHTTPClient.Get(m.JWTJWKS)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	var raw json.RawMessage
-	err = json.NewDecoder(res.Body).Decode(&raw)
-	if err != nil {
-		return err
-	}
-
-	tmp, err := keyfunc.NewJWKSetJSON(raw)
-	if err != nil {
-		return err
-	}
-
-	now := time.Now()
-	m.jwtKeyFunc = tmp
-	m.jwtLastRefresh = now
 	return nil
 }

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -268,12 +268,10 @@ func (m *Manager) pullJWTJWKS() (jwt.Keyfunc, error) {
 	return m.jwtKeyFunc.Keyfunc, nil
 }
 
-// ForceRefreshJWTJWKS force reloads the JWW keys
-func (m *Manager) ForceRefreshJWTJWKS() error {
+// RefreshJWTJWKS refreshes the JWT JWKS.
+func (m *Manager) RefreshJWTJWKS() {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
 	m.jwtLastRefresh = time.Time{}
-
-	return nil
 }

--- a/internal/test/auth_manager.go
+++ b/internal/test/auth_manager.go
@@ -4,26 +4,25 @@ import "github.com/bluenviron/mediamtx/internal/auth"
 
 // AuthManager is a dummy auth manager.
 type AuthManager struct {
-	fnc             func(req *auth.Request) error
-	forceRefreshFnc func() error
+	AuthenticateImpl   func(req *auth.Request) error
+	RefreshJWTJWKSImpl func()
 }
 
 // Authenticate replicates auth.Manager.Replicate
 func (m *AuthManager) Authenticate(req *auth.Request) error {
-	return m.fnc(req)
+	return m.AuthenticateImpl(req)
 }
 
-// ForceRefreshJWTJWKS is a function that simulates a JWKS refresh.
-func (m *AuthManager) ForceRefreshJWTJWKS() error {
-	return m.forceRefreshFnc()
+// RefreshJWTJWKS is a function that simulates a JWKS refresh.
+func (m *AuthManager) RefreshJWTJWKS() {
+	m.RefreshJWTJWKSImpl()
 }
 
 // NilAuthManager is an auth manager that accepts everything.
 var NilAuthManager = &AuthManager{
-	fnc: func(_ *auth.Request) error {
+	AuthenticateImpl: func(_ *auth.Request) error {
 		return nil
 	},
-	forceRefreshFnc: func() error {
-		return nil
+	RefreshJWTJWKSImpl: func() {
 	},
 }

--- a/internal/test/auth_manager.go
+++ b/internal/test/auth_manager.go
@@ -5,6 +5,7 @@ import "github.com/bluenviron/mediamtx/internal/auth"
 // AuthManager is a dummy auth manager.
 type AuthManager struct {
 	fnc func(req *auth.Request) error
+	forceRefreshFnc func() error
 }
 
 // Authenticate replicates auth.Manager.Replicate
@@ -12,9 +13,16 @@ func (m *AuthManager) Authenticate(req *auth.Request) error {
 	return m.fnc(req)
 }
 
+func (m *AuthManager) ForceRefreshJWTJWKS() error {
+	return m.forceRefreshFnc()
+}
+
 // NilAuthManager is an auth manager that accepts everything.
 var NilAuthManager = &AuthManager{
 	fnc: func(_ *auth.Request) error {
+		return nil
+	},
+	forceRefreshFnc: func() error {
 		return nil
 	},
 }

--- a/internal/test/auth_manager.go
+++ b/internal/test/auth_manager.go
@@ -4,7 +4,7 @@ import "github.com/bluenviron/mediamtx/internal/auth"
 
 // AuthManager is a dummy auth manager.
 type AuthManager struct {
-	fnc func(req *auth.Request) error
+	fnc             func(req *auth.Request) error
 	forceRefreshFnc func() error
 }
 
@@ -13,6 +13,7 @@ func (m *AuthManager) Authenticate(req *auth.Request) error {
 	return m.fnc(req)
 }
 
+// ForceRefreshJWTJWKS is a function that simulates a JWKS refresh.
 func (m *AuthManager) ForceRefreshJWTJWKS() error {
 	return m.forceRefreshFnc()
 }


### PR DESCRIPTION
Hi all, this is my first contribution and should addresses #4452. The only blaring issue is that the endpoint still requires a JWT signed with a key from the outdated JWKS, but more than open to feedback.

Changes include:
- Seperating refresh and pulling of JWKS tokens
- Add `/auth/jwks/refresh` endpoint for force refreshing the JWKS token
- Updated OpenAPI Schema definition