### PR TITLE
srt: Set path state to "not ready" when SRT static source exits

### DIFF
--- a/internal/staticsources/srt/source.go
+++ b/internal/staticsources/srt/source.go
@@ -111,6 +111,8 @@ func (s *Source) runReader(sconn srt.Conn) error {
 		return res.Err
 	}
 
+	defer s.Parent.SetNotReady(defs.PathSourceStaticSetNotReadyReq{})
+
 	stream = res.Stream
 
 	for {


### PR DESCRIPTION
### Description
Currently, when using an SRT source, subscriber sessions are not terminated when the SRT source ends. This can cause subscribers to can hang and prevents automatically re-establishing connections when the SRT source becomes available again. This change mirrors what exists in the rtsp, udp, and webrtc static sources. 

### Example
Settings:
```
paths:
  test:
    source: srt://localhost:5005
```
Test source stream:
```
ffmpeg -re -f lavfi -i testsrc=size=1280x720:rate=30 -c:v libx264 -pix_fmt yuv420p \
-preset ultrafast -b:v 600k -f mpegts "srt://:5005?mode=listener"
```

Open a WebRTC stream in the browser: `http://localhost:8889/test`

Then kill the ffmpeg source stream process.

#### Existing behavior when source becomes unavailable
```
2025/04/26 18:15:32 INF [path test] [SRT source] ready: 1 track (H264)
2025/04/26 18:15:42 INF [WebRTC] [session 3c4b6ffe] created by [::1]:48590
2025/04/26 18:15:42 INF [WebRTC] [session 3c4b6ffe] peer connection established, local candidate: host/udp/172.16.100.10/8189, remote candidate: prflx/udp/127.0.0.1/37092
2025/04/26 18:15:42 INF [WebRTC] [session 3c4b6ffe] is reading from path 'test', 1 track (H264)
2025/04/26 18:15:55 ERR [path test] [SRT source] astits: no more packets
2025/04/26 18:16:03 ERR [path test] [SRT source] connection timeout. server didn't respond
```
#### New behavior when source becomes unavailable
Note WebRTC session termination 
```
2025/04/26 18:18:39 INF [path test] [SRT source] ready: 1 track (H264)
2025/04/26 18:18:56 INF [WebRTC] [session ddf51d70] created by [::1]:34952
2025/04/26 18:18:56 INF [WebRTC] [session ddf51d70] peer connection established, local candidate: host/udp/127.0.0.1/8189, remote candidate: prflx/udp/127.0.0.1/57171
2025/04/26 18:18:56 INF [WebRTC] [session ddf51d70] is reading from path 'test', 1 track (H264)
2025/04/26 18:19:05 ERR [path test] [SRT source] astits: no more packets
2025/04/26 18:19:05 INF [WebRTC] [session ddf51d70] closed: terminated
2025/04/26 18:19:13 ERR [path test] [SRT source] connection timeout. server didn't respond
```