### PR TITLE
chore(image): Upgrade Raspberry pi images to newest versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ BASE_IMAGE = golang:1.23-alpine3.20
 LINT_IMAGE = golangci/golangci-lint:v1.64.5
 NODE_IMAGE = node:20-alpine3.20
 ALPINE_IMAGE = alpine:3.20
-RPI32_IMAGE = balenalib/raspberry-pi:bullseye-run-20240508
-RPI64_IMAGE = balenalib/raspberrypi3-64:bullseye-run-20240429
+RPI32_IMAGE = balenalib/raspberry-pi:bullseye-run-20250401
+RPI64_IMAGE = balenalib/raspberrypi3-64:bullseye-run-20250401
 
 .PHONY: $(shell ls)
 


### PR DESCRIPTION
Bump the Raspberry pi images to the newest versions.

Sources:
- https://hub.docker.com/layers/balenalib/raspberry-pi/bullseye-run-20250401/images/sha256-cf37c8ad39b3509d230482663f3dff5474839e549b3bdb4615c92cb170ecfc68
- https://hub.docker.com/layers/balenalib/raspberrypi3-64/bullseye-run-20250401/images/sha256-3aad00a3bf4caa504329e5d8d2a789c88f6136c2422e238f1d78410312c1992c