### PR TITLE
fix: Skips record path validation if not recording

### DIFF
--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -568,30 +568,32 @@ func (pconf *Path) validate(
 		l.Log(logger.Warn, "parameter 'playback' is deprecated and has no effect")
 	}
 
-	if !strings.Contains(pconf.RecordPath, "%path") {
-		return fmt.Errorf("'recordPath' must contain %%path")
-	}
+	if conf.Record {
+		if !strings.Contains(pconf.RecordPath, "%path") {
+			return fmt.Errorf("'recordPath' must contain %%path")
+		}
 
-	if !strings.Contains(pconf.RecordPath, "%s") &&
-		(!strings.Contains(pconf.RecordPath, "%Y") ||
-			!strings.Contains(pconf.RecordPath, "%m") ||
-			!strings.Contains(pconf.RecordPath, "%d") ||
-			!strings.Contains(pconf.RecordPath, "%H") ||
-			!strings.Contains(pconf.RecordPath, "%M") ||
-			!strings.Contains(pconf.RecordPath, "%S")) {
-		return fmt.Errorf("'recordPath' must contain either %%s or %%Y %%m %%d %%H %%M %%S")
-	}
+		if !strings.Contains(pconf.RecordPath, "%s") &&
+			(!strings.Contains(pconf.RecordPath, "%Y") ||
+				!strings.Contains(pconf.RecordPath, "%m") ||
+				!strings.Contains(pconf.RecordPath, "%d") ||
+				!strings.Contains(pconf.RecordPath, "%H") ||
+				!strings.Contains(pconf.RecordPath, "%M") ||
+				!strings.Contains(pconf.RecordPath, "%S")) {
+			return fmt.Errorf("'recordPath' must contain either %%s or %%Y %%m %%d %%H %%M %%S")
+		}
 
-	if conf.Playback && !strings.Contains(pconf.RecordPath, "%f") {
-		return fmt.Errorf("'recordPath' must contain %%f")
-	}
+		if conf.Playback && !strings.Contains(pconf.RecordPath, "%f") {
+			return fmt.Errorf("'recordPath' must contain %%f")
+		}
 
-	if pconf.RecordSegmentDuration > Duration(24*time.Hour) { // avoid overflowing DurationV0 of mvhd
-		return fmt.Errorf("maximum segment duration is 1 day")
-	}
+		if pconf.RecordSegmentDuration > Duration(24*time.Hour) { // avoid overflowing DurationV0 of mvhd
+			return fmt.Errorf("maximum segment duration is 1 day")
+		}
 
-	if pconf.RecordDeleteAfter != 0 && pconf.RecordDeleteAfter < pconf.RecordSegmentDuration {
-		return fmt.Errorf("'recordDeleteAfter' cannot be lower than 'recordSegmentDuration'")
+		if pconf.RecordDeleteAfter != 0 && pconf.RecordDeleteAfter < pconf.RecordSegmentDuration {
+			return fmt.Errorf("'recordDeleteAfter' cannot be lower than 'recordSegmentDuration'")
+		}
 	}
 
 	// Authentication (deprecated)


### PR DESCRIPTION
Prevents validation errors for record path parameters
when recording is not enabled.

Fixes #4481
