### PR TITLE
chore(image/rpi): update base images to latest versions for ARM archs

### DIFF
--- a/docker/ffmpeg-rpi.Dockerfile
+++ b/docker/ffmpeg-rpi.Dockerfile
@@ -7,9 +7,9 @@ ADD binaries/mediamtx_*_linux_arm64.tar.gz /linux/arm64
 
 #################################################################
 
-FROM --platform=linux/arm/v6 balenalib/raspberry-pi:bullseye-run-20240508 AS base-arm-v6
-FROM --platform=linux/arm/v7 balenalib/raspberry-pi:bullseye-run-20240508 AS base-arm-v7
-FROM --platform=linux/arm64 balenalib/raspberrypi3-64:bullseye-run-20240429 AS base-arm64
+FROM --platform=linux/arm/v6 balenalib/raspberry-pi:bullseye-run-20250501 AS base-arm-v6
+FROM --platform=linux/arm/v7 balenalib/raspberry-pi:bullseye-run-20250501 AS base-arm-v7
+FROM --platform=linux/arm64 balenalib/raspberrypi3-64:bullseye-run-20250401 AS base-arm64
 
 #################################################################
 FROM --platform=linux/amd64 scratch AS base

--- a/docker/rpi.Dockerfile
+++ b/docker/rpi.Dockerfile
@@ -7,9 +7,9 @@ ADD binaries/mediamtx_*_linux_arm64.tar.gz /linux/arm64
 
 #################################################################
 
-FROM --platform=linux/arm/v6 balenalib/raspberry-pi:bullseye-run-20240508 AS base-arm-v6
-FROM --platform=linux/arm/v7 balenalib/raspberry-pi:bullseye-run-20240508 AS base-arm-v7
-FROM --platform=linux/arm64 balenalib/raspberrypi3-64:bullseye-run-20240429 AS base-arm64
+FROM --platform=linux/arm/v6 balenalib/raspberry-pi:bullseye-run-20250501 AS base-arm-v6
+FROM --platform=linux/arm/v7 balenalib/raspberry-pi:bullseye-run-20250501 AS base-arm-v7
+FROM --platform=linux/arm64 balenalib/raspberrypi3-64:bullseye-run-20250401 AS base-arm64
 
 #################################################################
 FROM --platform=linux/amd64 scratch AS base


### PR DESCRIPTION
Bump the Raspberry pi images to the newest versions.

Sources:

- <https://hub.docker.com/layers/balenalib/raspberry-pi/bullseye-run-20250501/images/sha256-415949e4f375c9efec7c2298bddfe0904748c16624a728f4c3a9fa4b0212af62>
- <https://hub.docker.com/layers/balenalib/raspberrypi3-64/bullseye-run-20250401/images/sha256-3aad00a3bf4caa504329e5d8d2a789c88f6136c2422e238f1d78410312c1992c> (newest at the time of PR)