### PR TITLE
rtmp: fix connect command when reading

### DIFF
--- a/internal/core/api_test.go
+++ b/internal/core/api_test.go
@@ -439,7 +439,11 @@ func TestAPIProtocolListGet(t *testing.T) {
 				err = conn.Initialize()
 				require.NoError(t, err)
 
-				w, err := rtmp.NewWriter(conn, test.FormatH264, nil)
+				w := &rtmp.Writer{
+					Conn:       conn,
+					VideoTrack: test.FormatH264,
+				}
+				err = w.Initialize()
 				require.NoError(t, err)
 
 				err = w.WriteH264(2*time.Second, 2*time.Second, [][]byte{{5, 2, 3, 4}})
@@ -1022,7 +1026,11 @@ func TestAPIProtocolKick(t *testing.T) {
 				err = conn.Initialize()
 				require.NoError(t, err)
 
-				w, err := rtmp.NewWriter(conn, test.FormatH264, nil)
+				w := &rtmp.Writer{
+					Conn:       conn,
+					VideoTrack: test.FormatH264,
+				}
+				err = w.Initialize()
 				require.NoError(t, err)
 
 				err = w.WriteH264(2*time.Second, 2*time.Second, [][]byte{{5, 2, 3, 4}})

--- a/internal/core/api_test.go
+++ b/internal/core/api_test.go
@@ -430,7 +430,13 @@ func TestAPIProtocolListGet(t *testing.T) {
 				require.NoError(t, err)
 				defer nconn.Close()
 
-				conn, err := rtmp.NewClientConn(nconn, u, true)
+				conn := &rtmp.Conn{
+					RW:      nconn,
+					Client:  true,
+					URL:     u,
+					Publish: true,
+				}
+				err = conn.Initialize()
 				require.NoError(t, err)
 
 				w, err := rtmp.NewWriter(conn, test.FormatH264, nil)
@@ -1007,7 +1013,13 @@ func TestAPIProtocolKick(t *testing.T) {
 				require.NoError(t, err)
 				defer nconn.Close()
 
-				conn, err := rtmp.NewClientConn(nconn, u, true)
+				conn := &rtmp.Conn{
+					RW:      nconn,
+					Client:  true,
+					URL:     u,
+					Publish: true,
+				}
+				err = conn.Initialize()
 				require.NoError(t, err)
 
 				w, err := rtmp.NewWriter(conn, test.FormatH264, nil)

--- a/internal/core/metrics_test.go
+++ b/internal/core/metrics_test.go
@@ -203,7 +203,13 @@ webrtc_sessions_bytes_sent 0
 			require.NoError(t, err)
 			defer nconn.Close()
 
-			conn, err := rtmp.NewClientConn(nconn, u, true)
+			conn := &rtmp.Conn{
+				RW:      nconn,
+				Client:  true,
+				URL:     u,
+				Publish: true,
+			}
+			err = conn.Initialize()
 			require.NoError(t, err)
 
 			w, err := rtmp.NewWriter(conn, test.FormatH264, nil)
@@ -224,7 +230,13 @@ webrtc_sessions_bytes_sent 0
 			require.NoError(t, err)
 			defer nconn.Close() //nolint:errcheck
 
-			conn, err := rtmp.NewClientConn(nconn, u, true)
+			conn := &rtmp.Conn{
+				RW:      nconn,
+				Client:  true,
+				URL:     u,
+				Publish: true,
+			}
+			err = conn.Initialize()
 			require.NoError(t, err)
 
 			w, err := rtmp.NewWriter(conn, test.FormatH264, nil)

--- a/internal/core/metrics_test.go
+++ b/internal/core/metrics_test.go
@@ -212,7 +212,11 @@ webrtc_sessions_bytes_sent 0
 			err = conn.Initialize()
 			require.NoError(t, err)
 
-			w, err := rtmp.NewWriter(conn, test.FormatH264, nil)
+			w := &rtmp.Writer{
+				Conn:       conn,
+				VideoTrack: test.FormatH264,
+			}
+			err = w.Initialize()
 			require.NoError(t, err)
 
 			err = w.WriteH264(2*time.Second, 2*time.Second, [][]byte{{5, 2, 3, 4}})
@@ -239,7 +243,11 @@ webrtc_sessions_bytes_sent 0
 			err = conn.Initialize()
 			require.NoError(t, err)
 
-			w, err := rtmp.NewWriter(conn, test.FormatH264, nil)
+			w := &rtmp.Writer{
+				Conn:       conn,
+				VideoTrack: test.FormatH264,
+			}
+			err = w.Initialize()
 			require.NoError(t, err)
 
 			err = w.WriteH264(2*time.Second, 2*time.Second, [][]byte{{5, 2, 3, 4}})

--- a/internal/core/path_test.go
+++ b/internal/core/path_test.go
@@ -461,7 +461,10 @@ func TestPathRunOnRead(t *testing.T) {
 					err = conn.Initialize()
 					require.NoError(t, err)
 
-					_, err = rtmp.NewReader(conn)
+					r := &rtmp.Reader{
+						Conn: conn,
+					}
+					err = r.Initialize()
 					require.NoError(t, err)
 
 				case "rtmps":
@@ -498,7 +501,10 @@ func TestPathRunOnRead(t *testing.T) {
 						}
 					}()
 
-					_, err = rtmp.NewReader(conn)
+					r := &rtmp.Reader{
+						Conn: conn,
+					}
+					err = r.Initialize()
 					require.NoError(t, err)
 
 				case "srt":

--- a/internal/core/path_test.go
+++ b/internal/core/path_test.go
@@ -217,7 +217,13 @@ func TestPathRunOnConnect(t *testing.T) {
 					require.NoError(t, err)
 					defer nconn.Close()
 
-					_, err = rtmp.NewClientConn(nconn, u, true)
+					conn := &rtmp.Conn{
+						RW:      nconn,
+						Client:  true,
+						URL:     u,
+						Publish: true,
+					}
+					err = conn.Initialize()
 					require.NoError(t, err)
 
 				case "rtmps":
@@ -230,7 +236,13 @@ func TestPathRunOnConnect(t *testing.T) {
 					require.NoError(t, err)
 					defer nconn.Close() //nolint:errcheck
 
-					_, err = rtmp.NewClientConn(nconn, u, true)
+					conn := &rtmp.Conn{
+						RW:      nconn,
+						Client:  true,
+						URL:     u,
+						Publish: true,
+					}
+					err = conn.Initialize()
 					require.NoError(t, err)
 
 				case "srt":
@@ -440,7 +452,13 @@ func TestPathRunOnRead(t *testing.T) {
 					require.NoError(t, err)
 					defer nconn.Close()
 
-					conn, err := rtmp.NewClientConn(nconn, u, false)
+					conn := &rtmp.Conn{
+						RW:      nconn,
+						Client:  true,
+						URL:     u,
+						Publish: false,
+					}
+					err = conn.Initialize()
 					require.NoError(t, err)
 
 					_, err = rtmp.NewReader(conn)
@@ -454,7 +472,13 @@ func TestPathRunOnRead(t *testing.T) {
 					require.NoError(t, err)
 					defer nconn.Close() //nolint:errcheck
 
-					conn, err := rtmp.NewClientConn(nconn, u, false)
+					conn := &rtmp.Conn{
+						RW:      nconn,
+						Client:  true,
+						URL:     u,
+						Publish: false,
+					}
+					err = conn.Initialize()
 					require.NoError(t, err)
 
 					go func() {

--- a/internal/protocols/rtmp/conn_test.go
+++ b/internal/protocols/rtmp/conn_test.go
@@ -57,25 +57,42 @@ func TestNewClientConn(t *testing.T) {
 					Value: 65536,
 				}, msg)
 
-				msg, err2 = mrw.Read()
-				require.NoError(t, err2)
-				require.Equal(t, &message.CommandAMF0{
-					ChunkStreamID: 3,
-					Name:          "connect",
-					CommandID:     1,
-					Arguments: []interface{}{
-						amf0.Object{
-							{Key: "app", Value: "stream"},
-							{Key: "flashVer", Value: "LNX 9,0,124,2"},
-							{Key: "tcUrl", Value: "rtmp://127.0.0.1:9121/stream"},
-							{Key: "fpad", Value: false},
-							{Key: "capabilities", Value: float64(15)},
-							{Key: "audioCodecs", Value: float64(4071)},
-							{Key: "videoCodecs", Value: float64(252)},
-							{Key: "videoFunction", Value: float64(1)},
+				if ca != "publish" {
+					msg, err2 = mrw.Read()
+					require.NoError(t, err2)
+					require.Equal(t, &message.CommandAMF0{
+						ChunkStreamID: 3,
+						Name:          "connect",
+						CommandID:     1,
+						Arguments: []interface{}{
+							amf0.Object{
+								{Key: "app", Value: "stream"},
+								{Key: "flashVer", Value: "LNX 9,0,124,2"},
+								{Key: "tcUrl", Value: "rtmp://127.0.0.1:9121/stream"},
+								{Key: "fpad", Value: false},
+								{Key: "capabilities", Value: float64(15)},
+								{Key: "audioCodecs", Value: float64(4071)},
+								{Key: "videoCodecs", Value: float64(252)},
+								{Key: "videoFunction", Value: float64(1)},
+							},
 						},
-					},
-				}, msg)
+					}, msg)
+				} else {
+					msg, err2 = mrw.Read()
+					require.NoError(t, err2)
+					require.Equal(t, &message.CommandAMF0{
+						ChunkStreamID: 3,
+						Name:          "connect",
+						CommandID:     1,
+						Arguments: []interface{}{
+							amf0.Object{
+								{Key: "app", Value: "stream"},
+								{Key: "flashVer", Value: "LNX 9,0,124,2"},
+								{Key: "tcUrl", Value: "rtmp://127.0.0.1:9121/stream"},
+							},
+						},
+					}, msg)
+				}
 
 				err2 = mrw.Write(&message.CommandAMF0{
 					ChunkStreamID: 3,
@@ -264,7 +281,7 @@ func TestNewClientConn(t *testing.T) {
 
 			case "publish":
 				require.Equal(t, uint64(3427), conn.BytesReceived())
-				require.Equal(t, uint64(3466), conn.BytesSent())
+				require.Equal(t, uint64(0xd27), conn.BytesSent())
 			}
 
 			<-done
@@ -294,7 +311,7 @@ func TestNewServerConn(t *testing.T) {
 					RW:     nconn,
 					Client: false,
 				}
-				err = conn.Initialize()
+				err2 = conn.Initialize()
 				require.NoError(t, err2)
 
 				require.Equal(t, &url.URL{

--- a/internal/protocols/rtmp/from_stream.go
+++ b/internal/protocols/rtmp/from_stream.go
@@ -213,8 +213,12 @@ func FromStream(
 		return errNoSupportedCodecsFrom
 	}
 
-	var err error
-	w, err = NewWriter(conn, videoFormat, audioFormat)
+	w = &Writer{
+		Conn:       conn,
+		VideoTrack: videoFormat,
+		AudioTrack: audioFormat,
+	}
+	err := w.Initialize()
 	if err != nil {
 		return err
 	}

--- a/internal/protocols/rtmp/reader.go
+++ b/internal/protocols/rtmp/reader.go
@@ -272,29 +272,26 @@ func sortedKeys(m map[uint8]format.Format) []int {
 
 // Reader is a wrapper around Conn that provides utilities to demux incoming data.
 type Reader struct {
-	conn        *Conn
+	Conn *Conn
+
 	videoTracks map[uint8]format.Format
 	audioTracks map[uint8]format.Format
 	onVideoData map[uint8]func(message.Message) error
 	onAudioData map[uint8]func(message.Message) error
 }
 
-// NewReader allocates a Reader.
-func NewReader(conn *Conn) (*Reader, error) {
-	r := &Reader{
-		conn: conn,
-	}
-
+// Initialize initializes a reader.
+func (r *Reader) Initialize() error {
 	var err error
 	r.videoTracks, r.audioTracks, err = r.readTracks()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	r.onVideoData = make(map[uint8]func(message.Message) error)
 	r.onAudioData = make(map[uint8]func(message.Message) error)
 
-	return r, nil
+	return nil
 }
 
 func (r *Reader) readTracks() (map[uint8]format.Format, map[uint8]format.Format, error) {
@@ -369,7 +366,7 @@ func (r *Reader) readTracks() (map[uint8]format.Format, map[uint8]format.Format,
 	}
 
 	for {
-		msg, err := r.conn.Read()
+		msg, err := r.Conn.Read()
 		if err != nil {
 			return nil, nil, err
 		}
@@ -762,7 +759,7 @@ func (r *Reader) OnDataLPCM(track *format.LPCM, cb OnDataLPCMFunc) {
 
 // Read reads data.
 func (r *Reader) Read() error {
-	msg, err := r.conn.Read()
+	msg, err := r.Conn.Read()
 	if err != nil {
 		return err
 	}

--- a/internal/protocols/rtmp/reader_test.go
+++ b/internal/protocols/rtmp/reader_test.go
@@ -1637,8 +1637,12 @@ func TestReadTracks(t *testing.T) {
 			err := c.Initialize()
 			require.NoError(t, err)
 
-			r, err := NewReader(c)
+			r := &Reader{
+				Conn: c,
+			}
+			err = r.Initialize()
 			require.NoError(t, err)
+
 			tracks := r.Tracks()
 			require.Equal(t, ca.tracks, tracks)
 		})

--- a/internal/protocols/rtmp/reader_test.go
+++ b/internal/protocols/rtmp/reader_test.go
@@ -1630,7 +1630,12 @@ func TestReadTracks(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			c := newNoHandshakeConn(&buf)
+			c := &Conn{
+				RW:            &buf,
+				skipHandshake: true,
+			}
+			err := c.Initialize()
+			require.NoError(t, err)
 
 			r, err := NewReader(c)
 			require.NoError(t, err)

--- a/internal/protocols/rtmp/writer_test.go
+++ b/internal/protocols/rtmp/writer_test.go
@@ -47,7 +47,12 @@ func TestWriteTracks(t *testing.T) {
 	err := c.Initialize()
 	require.NoError(t, err)
 
-	_, err = NewWriter(c, videoTrack, audioTrack)
+	w := &Writer{
+		Conn:       c,
+		VideoTrack: videoTrack,
+		AudioTrack: audioTrack,
+	}
+	err = w.Initialize()
 	require.NoError(t, err)
 
 	bc := bytecounter.NewReadWriter(&buf)

--- a/internal/protocols/rtmp/writer_test.go
+++ b/internal/protocols/rtmp/writer_test.go
@@ -40,9 +40,14 @@ func TestWriteTracks(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	c := newNoHandshakeConn(&buf)
+	c := &Conn{
+		RW:            &buf,
+		skipHandshake: true,
+	}
+	err := c.Initialize()
+	require.NoError(t, err)
 
-	_, err := NewWriter(c, videoTrack, audioTrack)
+	_, err = NewWriter(c, videoTrack, audioTrack)
 	require.NoError(t, err)
 
 	bc := bytecounter.NewReadWriter(&buf)

--- a/internal/servers/rtmp/conn.go
+++ b/internal/servers/rtmp/conn.go
@@ -255,7 +255,10 @@ func (c *conn) runPublish(conn *rtmp.Conn) error {
 	c.query = rawQuery
 	c.mutex.Unlock()
 
-	r, err := rtmp.NewReader(conn)
+	r := &rtmp.Reader{
+		Conn: conn,
+	}
+	err = r.Initialize()
 	if err != nil {
 		return err
 	}

--- a/internal/servers/rtmp/server_test.go
+++ b/internal/servers/rtmp/server_test.go
@@ -128,7 +128,13 @@ func TestServerPublish(t *testing.T) {
 			require.NoError(t, err)
 			defer nconn.Close()
 
-			conn, err := rtmp.NewClientConn(nconn, u, true)
+			conn := &rtmp.Conn{
+				RW:      nconn,
+				Client:  true,
+				URL:     u,
+				Publish: true,
+			}
+			err = conn.Initialize()
 			require.NoError(t, err)
 
 			w, err := rtmp.NewWriter(conn, test.FormatH264, test.FormatMPEG4Audio)
@@ -281,7 +287,13 @@ func TestServerRead(t *testing.T) {
 				})
 			}()
 
-			conn, err := rtmp.NewClientConn(nconn, u, false)
+			conn := &rtmp.Conn{
+				RW:      nconn,
+				Client:  true,
+				URL:     u,
+				Publish: false,
+			}
+			err = conn.Initialize()
 			require.NoError(t, err)
 
 			r, err := rtmp.NewReader(conn)

--- a/internal/servers/rtmp/server_test.go
+++ b/internal/servers/rtmp/server_test.go
@@ -137,7 +137,12 @@ func TestServerPublish(t *testing.T) {
 			err = conn.Initialize()
 			require.NoError(t, err)
 
-			w, err := rtmp.NewWriter(conn, test.FormatH264, test.FormatMPEG4Audio)
+			w := &rtmp.Writer{
+				Conn:       conn,
+				VideoTrack: test.FormatH264,
+				AudioTrack: test.FormatMPEG4Audio,
+			}
+			err = w.Initialize()
 			require.NoError(t, err)
 
 			err = w.WriteH264(
@@ -296,7 +301,10 @@ func TestServerRead(t *testing.T) {
 			err = conn.Initialize()
 			require.NoError(t, err)
 
-			r, err := rtmp.NewReader(conn)
+			r := &rtmp.Reader{
+				Conn: conn,
+			}
+			err = r.Initialize()
 			require.NoError(t, err)
 
 			tracks := r.Tracks()

--- a/internal/staticsources/rtmp/source.go
+++ b/internal/staticsources/rtmp/source.go
@@ -101,7 +101,10 @@ func (s *Source) runReader(u *url.URL, nconn net.Conn) error {
 		return err
 	}
 
-	r, err := rtmp.NewReader(conn)
+	r := &rtmp.Reader{
+		Conn: conn,
+	}
+	err = r.Initialize()
 	if err != nil {
 		return err
 	}

--- a/internal/staticsources/rtmp/source.go
+++ b/internal/staticsources/rtmp/source.go
@@ -90,7 +90,13 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 func (s *Source) runReader(u *url.URL, nconn net.Conn) error {
 	nconn.SetReadDeadline(time.Now().Add(time.Duration(s.ReadTimeout)))
 	nconn.SetWriteDeadline(time.Now().Add(time.Duration(s.WriteTimeout)))
-	conn, err := rtmp.NewClientConn(nconn, u, false)
+	conn := &rtmp.Conn{
+		RW:      nconn,
+		Client:  true,
+		URL:     u,
+		Publish: false,
+	}
+	err := conn.Initialize()
 	if err != nil {
 		return err
 	}

--- a/internal/staticsources/rtmp/source_test.go
+++ b/internal/staticsources/rtmp/source_test.go
@@ -54,7 +54,12 @@ func TestSource(t *testing.T) {
 				err = conn.Initialize()
 				require.NoError(t, err)
 
-				w, err := rtmp.NewWriter(conn, test.FormatH264, test.FormatMPEG4Audio)
+				w := &rtmp.Writer{
+					Conn:       conn,
+					VideoTrack: test.FormatH264,
+					AudioTrack: test.FormatMPEG4Audio,
+				}
+				err = w.Initialize()
 				require.NoError(t, err)
 
 				err = w.WriteH264(2*time.Second, 2*time.Second, [][]byte{{5, 2, 3, 4}})

--- a/internal/staticsources/rtmp/source_test.go
+++ b/internal/staticsources/rtmp/source_test.go
@@ -48,7 +48,10 @@ func TestSource(t *testing.T) {
 				require.NoError(t, err)
 				defer nconn.Close()
 
-				conn, _, _, err := rtmp.NewServerConn(nconn)
+				conn := &rtmp.Conn{
+					RW: nconn,
+				}
+				err = conn.Initialize()
 				require.NoError(t, err)
 
 				w, err := rtmp.NewWriter(conn, test.FormatH264, test.FormatMPEG4Audio)


### PR DESCRIPTION
when reading, the "connect" command should not contain fpad, capabilities, audioCodecs, videoCodecs, videoFunction.