### PR TITLE
playback: fix fMP4 segment seek when start offset is in the last entry of trun

### DIFF
--- a/internal/playback/segment_fmp4.go
+++ b/internal/playback/segment_fmp4.go
@@ -435,10 +435,6 @@ func segmentFMP4SeekAndMuxParts(
 					break
 				}
 
-				if muxerDTS >= 0 {
-					atLeastOnePartWritten = true
-				}
-
 				sampleOffset := dataOffset
 				sampleSize := e.SampleSize
 
@@ -467,6 +463,10 @@ func segmentFMP4SeekAndMuxParts(
 				atLeastOneSampleWritten = true
 				dataOffset += uint64(e.SampleSize)
 				muxerDTS += int64(e.SampleDuration)
+
+				if muxerDTS >= 0 {
+					atLeastOnePartWritten = true
+				}
 			}
 
 			if atLeastOneSampleWritten {


### PR DESCRIPTION
### Description

This PR is the result of the investigation of the issue [4276](https://github.com/bluenviron/mediamtx/issues/4276).

For example let's say you are recording a source with MediaMTX, and you have on the disk the following files:
- ...
- 2025-05-16_12-27-50-415642.mp4
- 2025-05-16_12-29-50-421186.mp4
- ...

If you try [start=2025-05-16T12:29:50.421186](http://localhost:9996/get?duration=20&path=train_follower_cam&start=2025-05-16T12%3A29%3A50.421186%2B02%3A00) it's working fine.
But if you try 1 microsecond before the start of the MP4 as in the list, [start=2025-05-16T12:29:50.421185](http://localhost:9996/get?duration=20&path=train_follower_cam&start=2025-05-16T12%3A29%3A50.421185%2B02%3A00) you'll receive the error `no recording segments found`.

I cannot reproduce it everytime, but when it fails, applying the fix of this PR solves the problem.

It makes sense because the offset may be present in the last entry of the last `trun` box, and the condition should be check at the end of the loop, not at the beginning.