### PR TITLE
Fix: gracefully handle fMP4 segments with missing or partial moof/mdat

### DIFF
--- a/internal/playback/segment_fmp4.go
+++ b/internal/playback/segment_fmp4.go
@@ -194,6 +194,9 @@ func segmentFMP4ReadDurationFromParts(
 		}
 
 		if !bytes.Equal(buf[4:], []byte{'m', 'o', 'o', 'f'}) {
+			if lastMoofPos > 0 {
+				break
+			}
 			return 0, fmt.Errorf("moof box not found")
 		}
 


### PR DESCRIPTION
When we want to list recordings, if there is a corrupted file in the range we are trying to fetch, we are getting the 'moof box not found' error.
I have faced with the issue when my machine is restarted. I have found the corrupted file and checked the boxes in it with a script;

.
.
.
Box: moof | Size: 652 | Offset: 12610949
Box: mdat | Size: 265381 | Offset: 12611601
Box: moof | Size: 652 | Offset: 12876982
Box: mdat | Size: 265588 | Offset: 12877634
Box:  | Size: 0 | Offset: 13143222

The box at the end causing the error. the if statement that i have added is handling this incomplete file situation.
Instead of throwing an error we break the loop with the last valid moof box position, if any.

http://localhost:9996/list?path=test&start=2025-05-10T06:18:34Z&end=2025-05-10T06:23:02Z

[
  {
    "start": "2025-05-10T09:18:34.150729+03:00",
    "duration": 169.786435,
    "url": "http://localhost:9996/get?duration=169.786435&path=test&start=2025-05-10T09%3A18%3A34.150729%2B03%3A00"
  },
  {
    "start": "2025-05-10T09:23:01.999513+03:00",
    "duration": 0.000487,
    "url": "http://localhost:9996/get?duration=0.000487&path=test&start=2025-05-10T09%3A23%3A01.999513%2B03%3A00"
  }
]