### PR TITLE
feat: Allow multiple paths in JWT permissions

### DIFF
--- a/internal/auth/jwt_claims.go
+++ b/internal/auth/jwt_claims.go
@@ -46,5 +46,12 @@ func (c *jwtClaims) UnmarshalJSON(b []byte) error {
 		}
 	}
 
+	for i, p := range c.permissions {
+		err = p.Validate()
+		if err != nil {
+			return fmt.Errorf("permission at index %d is invalid: %w", i, err)
+		}
+	}
+
 	return nil
 }

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -109,8 +109,10 @@ authHTTPExclude:
 
 # JWT-based authentication.
 # Users have to login through an external identity server and obtain a JWT.
-# This JWT must contain the claim "mediamtx_permissions" with permissions,
-# for instance:
+# This JWT must contain the claim "mediamtx_permissions" with permissions.
+# For example:
+#
+# Using a single path:
 # {
 #  "mediamtx_permissions": [
 #     {
@@ -119,6 +121,22 @@ authHTTPExclude:
 #     }
 #   ]
 # }
+#
+# Or using multiple paths:
+# {
+#  "mediamtx_permissions": [
+#     {
+#       "action": "publish",
+#       "paths": ["somepath", "somepath2", "~^anotherpathprefix.*$"]
+#     },
+#     {
+#       "action": "read",
+#       "path": "specificreadpath"
+#     }
+#   ]
+# }
+# Note: For a given permission entry, use either "path" or "paths", not both.
+# Regular expressions can be used by prefixing the path string with a tilde (~).
 # Users are expected to pass the JWT in the Authorization header, password or query parameter.
 # This is the JWKS URL that will be used to pull (once) the public key that allows
 # to validate JWTs.


### PR DESCRIPTION
This commit introduces a more flexible way to define path permissions in JWT claims for MediaMTX.

Previously, each permission entry in the `mediamtx_permissions` JWT claim could only specify a single `path`. This could lead to verbose claims when multiple paths needed the same action permission.

This change introduces a new optional `paths` field in the permission object, which accepts an array of path strings. If `paths` is provided, it will be used instead of the `path` field for that permission entry. The existing `path` field is retained for backward compatibility and single-path permissions.

Key changes:
- Modified `AuthInternalUserPermission` in `internal/conf/auth_internal_users.go` to include `Paths []string` and changed `Path` to `*string`. Validation ensures `path` and `paths` are not used simultaneously for the same permission entry.
- Updated JWT unmarshaling in `internal/auth/jwt_claims.go` to correctly parse both `path` and `paths` fields.
- Modified `matchesPermission` in `internal/auth/manager.go` to check against the `paths` array if present, otherwise fallback to `path`. This includes support for regular expressions (prefixed with `~`) and empty strings (for "any path") in both fields.
- Added comprehensive unit tests in `internal/auth/manager_test.go` to cover the new functionality and ensure backward compatibility.
- Updated `mediamtx.yml` with examples of the new `paths` format in the JWT authentication section.

Example of new format in JWT:
```json
{
  "mediamtx_permissions": [
    {
      "action": "publish",
      "paths": ["somepath", "somepath2", "~^anotherprefix.*$"]
    },
    {
      "action": "read",
      "path": "specificreadpath"
    }
  ]
}
```