### PR TITLE
Create ffmpeg-hardware.Dockerfile

### DIFF
--- a/docker/ffmpeg-hardware.Dockerfile
+++ b/docker/ffmpeg-hardware.Dockerfile
@@ -1,0 +1,19 @@
+#################################################################
+FROM --platform=linux/amd64 scratch AS binaries
+
+ADD binaries/mediamtx_*_linux_amd64.tar.gz /linux/amd64
+ADD binaries/mediamtx_*_linux_armv6.tar.gz /linux/arm/v6
+ADD binaries/mediamtx_*_linux_armv7.tar.gz /linux/arm/v7
+ADD binaries/mediamtx_*_linux_arm64.tar.gz /linux/arm64
+
+#################################################################
+FROM debian:trixie-slim
+
+RUN  echo 'deb http://deb.debian.org/debian trixie non-free' > /etc/apt/sources.list.d/debian-non-free.list && \
+     apt-get -y update && apt-get -y install ffmpeg alsa-utils  libasound2-plugins intel-media-va-driver-non-free mesa-va-drivers && \
+     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ARG TARGETPLATFORM
+COPY --from=binaries /$TARGETPLATFORM /
+
+ENTRYPOINT [ "/mediamtx" ]


### PR DESCRIPTION
Docker file that builds an image with ffmpeg hardware encoding with Intel VAAPI / QSV and alsa sound utils

Build image with:

`docker build . -f docker/ffmpeg-hardware.Dockerfile -t mediamtx-hardware`

Example mediamtx.yml:
```
path:
  usb-webcam:
    runOnInit:  ffmpeg  -vaapi_device /dev/dri/renderD128 -f v4l2 -input_format yuyv422 -video_size 1920x1080 -r 25 -i /dev/video0 -maxrate 4000k -b:v 4M -fflags +genpts+igndts -tune zerolatency -vf 'format=nv12,hwupload,scale_vaapi' -c:v h264_vaapi -g 50  -bf 0 -profile:v high -level:v 4.1 -f rtsp -rtsp_transport tcp rtsp://localhost:$RTSP_PORT/$MTX_PATH

```

Example docker compose:
```
services:
  mediamtx-hardware:
    image: mediamtx-hardware
    privileged: true
    container_name: mtx
    restart: unless-stopped
    volumes:
      - /dev:/dev
      - ./server.key:/server.key
      - ./server.crt:/server.crt
      - ./conf:/conf
    #ports:
    #  - 8554:8554
    #  - 8322:8322
    #  - 1935:1935
    #  - 8888:8888
    #  - 8889:8889
    network_mode: host
    command: /conf/mediamtx.yml

```
