### PR TITLE
Add a `make` target for local `mediamtx`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ help:
 	@echo "  apidocs          generate api docs HTML"
 	@echo "  binaries         build binaries for all platforms"
 	@echo "  dockerhub        build and push images to Docker Hub"
+	@echo "  mediamtx         build mediamtx for local platform"
 	@echo ""
 
 blank :=

--- a/scripts/mediamtx.mk
+++ b/scripts/mediamtx.mk
@@ -1,0 +1,3 @@
+mediamtx:
+	go generate ./...
+	CGO_ENABLED=0 go build .


### PR DESCRIPTION
Minor tweak just to make it easier to build for people who want to type `make X` instead of finding the build instructions in the middle of `README.md`.

(prompted by https://www.jwz.org/blog/2025/05/rtmp-hls-segment-corruption/#comment-259721 )