### PR TITLE
h264/h265: log packet sizes if they exceed UDPMaxPayloadSize

### DIFF
--- a/internal/stream/sub_stream_format.go
+++ b/internal/stream/sub_stream_format.go
@@ -139,7 +139,9 @@ func (ssf *subStreamFormat) writeUnitInner(u *unit.Unit) error {
 
 					ssf.streamFormat.rtpTimeOffset = pkt.Timestamp - uint32(u.PTS)
 
-					ssf.streamFormat.parent.Log(logger.Info, "RTP packets are too big, remuxing them into smaller ones")
+					ssf.streamFormat.parent.Log(logger.Info,
+						"RTP packets are too big (%d > %d), remuxing them into smaller ones",
+						len(pkt.Payload), ssf.streamFormat.rtpMaxPayloadSize)
 					break
 				}
 			}


### PR DESCRIPTION
This can be helpful for knowing how to tune upstream sources to avoid the need for remuxing.