### PR TITLE
make RTP packet size compatible with RTSP/SRTP

### DIFF
--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -70,7 +70,7 @@ type path struct {
 	readTimeout       conf.Duration
 	writeTimeout      conf.Duration
 	writeQueueSize    int
-	udpMaxPayloadSize int
+	rtpMaxPayloadSize int
 	conf              *conf.Path
 	name              string
 	matches           []string
@@ -178,7 +178,7 @@ func (pa *path) run() {
 			ReadTimeout:       pa.readTimeout,
 			WriteTimeout:      pa.writeTimeout,
 			WriteQueueSize:    pa.writeQueueSize,
-			UDPMaxPayloadSize: pa.udpMaxPayloadSize,
+			RTPMaxPayloadSize: pa.rtpMaxPayloadSize,
 			Matches:           pa.matches,
 			PathManager:       pa.parent,
 			Parent:            pa,
@@ -705,7 +705,7 @@ func (pa *path) onDemandPublisherStop(reason string) {
 func (pa *path) setReady(desc *description.Session, allocateEncoder bool) error {
 	pa.stream = &stream.Stream{
 		WriteQueueSize:     pa.writeQueueSize,
-		UDPMaxPayloadSize:  pa.udpMaxPayloadSize,
+		RTPMaxPayloadSize:  pa.rtpMaxPayloadSize,
 		Desc:               desc,
 		GenerateRTPPackets: allocateEncoder,
 		Parent:             pa.source,

--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -70,7 +70,7 @@ type pathManager struct {
 	readTimeout       conf.Duration
 	writeTimeout      conf.Duration
 	writeQueueSize    int
-	udpMaxPayloadSize int
+	rtpMaxPayloadSize int
 	pathConfs         map[string]*conf.Path
 	externalCmdPool   *externalcmd.Pool
 	metrics           *metrics.Metrics
@@ -428,7 +428,7 @@ func (pm *pathManager) createPath(
 		readTimeout:       pm.readTimeout,
 		writeTimeout:      pm.writeTimeout,
 		writeQueueSize:    pm.writeQueueSize,
-		udpMaxPayloadSize: pm.udpMaxPayloadSize,
+		rtpMaxPayloadSize: pm.rtpMaxPayloadSize,
 		conf:              pathConf,
 		name:              name,
 		matches:           matches,

--- a/internal/formatprocessor/ac3.go
+++ b/internal/formatprocessor/ac3.go
@@ -14,7 +14,7 @@ import (
 )
 
 type ac3 struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.AC3
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -81,9 +81,9 @@ func (t *ac3) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/av1.go
+++ b/internal/formatprocessor/av1.go
@@ -21,7 +21,7 @@ var (
 )
 
 type av1 struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.AV1
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -49,7 +49,7 @@ func (t *av1) initialize() error {
 
 func (t *av1) createEncoder() error {
 	t.encoder = &rtpav1.Encoder{
-		PayloadMaxSize: t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: t.RTPMaxPayloadSize,
 		PayloadType:    t.Format.PayloadTyp,
 	}
 	return t.encoder.Init()
@@ -89,9 +89,9 @@ func (t *av1) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/g711.go
+++ b/internal/formatprocessor/g711.go
@@ -13,7 +13,7 @@ import (
 )
 
 type g711 struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.G711
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -41,7 +41,7 @@ func (t *g711) initialize() error {
 
 func (t *g711) createEncoder() error {
 	t.encoder = &rtplpcm.Encoder{
-		PayloadMaxSize: t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: t.RTPMaxPayloadSize,
 		PayloadType:    t.Format.PayloadType(),
 		BitDepth:       8,
 		ChannelCount:   t.Format.ChannelCount,
@@ -83,9 +83,9 @@ func (t *g711) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/g711_test.go
+++ b/internal/formatprocessor/g711_test.go
@@ -18,7 +18,7 @@ func TestG711Encode(t *testing.T) {
 			ChannelCount: 1,
 		}
 
-		p, err := New(1472, forma, true, nil)
+		p, err := New(1450, forma, true, nil)
 		require.NoError(t, err)
 
 		unit := &unit.G711{
@@ -47,7 +47,7 @@ func TestG711Encode(t *testing.T) {
 			ChannelCount: 1,
 		}
 
-		p, err := New(1472, forma, true, nil)
+		p, err := New(1450, forma, true, nil)
 		require.NoError(t, err)
 
 		unit := &unit.G711{

--- a/internal/formatprocessor/generic.go
+++ b/internal/formatprocessor/generic.go
@@ -12,7 +12,7 @@ import (
 )
 
 type generic struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             format.Format
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -48,9 +48,9 @@ func (t *generic) ProcessRTPPacket(
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	return u, nil

--- a/internal/formatprocessor/generic_test.go
+++ b/internal/formatprocessor/generic_test.go
@@ -17,7 +17,7 @@ func TestGenericRemovePadding(t *testing.T) {
 	err := forma.Init()
 	require.NoError(t, err)
 
-	p, err := New(1472, forma, false, nil)
+	p, err := New(1450, forma, false, nil)
 	require.NoError(t, err)
 
 	pkt := &rtp.Packet{

--- a/internal/formatprocessor/h264.go
+++ b/internal/formatprocessor/h264.go
@@ -83,7 +83,7 @@ func rtpH264ExtractParams(payload []byte) ([]byte, []byte) {
 }
 
 type h264 struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.H264
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -114,7 +114,7 @@ func (t *h264) createEncoder(
 	initialSequenceNumber *uint16,
 ) error {
 	t.encoder = &rtph264.Encoder{
-		PayloadMaxSize:        t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize:        t.RTPMaxPayloadSize,
 		PayloadType:           t.Format.PayloadTyp,
 		SSRC:                  ssrc,
 		InitialSequenceNumber: initialSequenceNumber,
@@ -267,7 +267,7 @@ func (t *h264) ProcessRTPPacket( //nolint:dupl
 		pkt.PaddingSize = 0
 
 		// RTP packets exceed maximum size: start re-encoding them
-		if pkt.MarshalSize() > t.UDPMaxPayloadSize {
+		if len(pkt.Payload) > t.RTPMaxPayloadSize {
 			t.Parent.Log(logger.Info, "RTP packets are too big, remuxing them into smaller ones")
 
 			v1 := pkt.SSRC

--- a/internal/formatprocessor/h264_test.go
+++ b/internal/formatprocessor/h264_test.go
@@ -36,7 +36,7 @@ func TestH264DynamicParams(t *testing.T) {
 				PacketizationMode: 1,
 			}
 
-			p, err := New(1472, forma, false, nil)
+			p, err := New(1450, forma, false, nil)
 			require.NoError(t, err)
 
 			enc, err := forma.CreateEncoder()
@@ -103,7 +103,7 @@ func TestH264OversizedPackets(t *testing.T) {
 
 	logged := false
 
-	p, err := New(1472, forma, false,
+	p, err := New(1460, forma, false,
 		Logger(func(_ logger.Level, s string, i ...interface{}) {
 			require.Equal(t, "RTP packets are too big, remuxing them into smaller ones", fmt.Sprintf(s, i...))
 			logged = true
@@ -207,7 +207,7 @@ func TestH264EmptyPacket(t *testing.T) {
 		PacketizationMode: 1,
 	}
 
-	p, err := New(1472, forma, true, nil)
+	p, err := New(1450, forma, true, nil)
 	require.NoError(t, err)
 
 	unit := &unit.H264{

--- a/internal/formatprocessor/h265.go
+++ b/internal/formatprocessor/h265.go
@@ -103,7 +103,7 @@ func rtpH265ExtractParams(payload []byte) ([]byte, []byte, []byte) {
 }
 
 type h265 struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.H265
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -134,7 +134,7 @@ func (t *h265) createEncoder(
 	initialSequenceNumber *uint16,
 ) error {
 	t.encoder = &rtph265.Encoder{
-		PayloadMaxSize:        t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize:        t.RTPMaxPayloadSize,
 		PayloadType:           t.Format.PayloadTyp,
 		SSRC:                  ssrc,
 		InitialSequenceNumber: initialSequenceNumber,
@@ -299,7 +299,7 @@ func (t *h265) ProcessRTPPacket( //nolint:dupl
 		pkt.PaddingSize = 0
 
 		// RTP packets exceed maximum size: start re-encoding them
-		if pkt.MarshalSize() > t.UDPMaxPayloadSize {
+		if len(pkt.Payload) > t.RTPMaxPayloadSize {
 			t.Parent.Log(logger.Info, "RTP packets are too big, remuxing them into smaller ones")
 
 			v1 := pkt.SSRC

--- a/internal/formatprocessor/h265_test.go
+++ b/internal/formatprocessor/h265_test.go
@@ -22,7 +22,7 @@ func TestH265DynamicParams(t *testing.T) {
 				PayloadTyp: 96,
 			}
 
-			p, err := New(1472, forma, false, nil)
+			p, err := New(1450, forma, false, nil)
 			require.NoError(t, err)
 
 			enc, err := forma.CreateEncoder()
@@ -98,7 +98,7 @@ func TestH265OversizedPackets(t *testing.T) {
 
 	logged := false
 
-	p, err := New(1472, forma, false,
+	p, err := New(1460, forma, false,
 		Logger(func(_ logger.Level, s string, i ...interface{}) {
 			require.Equal(t, "RTP packets are too big, remuxing them into smaller ones", fmt.Sprintf(s, i...))
 			logged = true
@@ -189,7 +189,7 @@ func TestH265EmptyPacket(t *testing.T) {
 		PayloadTyp: 96,
 	}
 
-	p, err := New(1472, forma, true, nil)
+	p, err := New(1450, forma, true, nil)
 	require.NoError(t, err)
 
 	unit := &unit.H265{

--- a/internal/formatprocessor/lpcm.go
+++ b/internal/formatprocessor/lpcm.go
@@ -13,7 +13,7 @@ import (
 )
 
 type lpcm struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.LPCM
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -41,7 +41,7 @@ func (t *lpcm) initialize() error {
 
 func (t *lpcm) createEncoder() error {
 	t.encoder = &rtplpcm.Encoder{
-		PayloadMaxSize: t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: t.RTPMaxPayloadSize,
 		PayloadType:    t.Format.PayloadTyp,
 		BitDepth:       t.Format.BitDepth,
 		ChannelCount:   t.Format.ChannelCount,
@@ -83,9 +83,9 @@ func (t *lpcm) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/lpcm_test.go
+++ b/internal/formatprocessor/lpcm_test.go
@@ -17,7 +17,7 @@ func TestLPCMEncode(t *testing.T) {
 		ChannelCount: 2,
 	}
 
-	p, err := New(1472, forma, true, nil)
+	p, err := New(1450, forma, true, nil)
 	require.NoError(t, err)
 
 	unit := &unit.LPCM{

--- a/internal/formatprocessor/mjpeg.go
+++ b/internal/formatprocessor/mjpeg.go
@@ -14,7 +14,7 @@ import (
 )
 
 type mjpeg struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.MJPEG
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -42,7 +42,7 @@ func (t *mjpeg) initialize() error {
 
 func (t *mjpeg) createEncoder() error {
 	t.encoder = &rtpmjpeg.Encoder{
-		PayloadMaxSize: t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: t.RTPMaxPayloadSize,
 	}
 	return t.encoder.Init()
 }
@@ -82,9 +82,9 @@ func (t *mjpeg) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/mpeg1_audio.go
+++ b/internal/formatprocessor/mpeg1_audio.go
@@ -14,7 +14,7 @@ import (
 )
 
 type mpeg1Audio struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.MPEG1Audio
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -42,7 +42,7 @@ func (t *mpeg1Audio) initialize() error {
 
 func (t *mpeg1Audio) createEncoder() error {
 	t.encoder = &rtpmpeg1audio.Encoder{
-		PayloadMaxSize: t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: t.RTPMaxPayloadSize,
 	}
 	return t.encoder.Init()
 }
@@ -81,9 +81,9 @@ func (t *mpeg1Audio) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/mpeg1_video.go
+++ b/internal/formatprocessor/mpeg1_video.go
@@ -23,7 +23,7 @@ var (
 )
 
 type mpeg1Video struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.MPEG1Video
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -51,7 +51,7 @@ func (t *mpeg1Video) initialize() error {
 
 func (t *mpeg1Video) createEncoder() error {
 	t.encoder = &rtpmpeg1video.Encoder{
-		PayloadMaxSize: t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: t.RTPMaxPayloadSize,
 	}
 	return t.encoder.Init()
 }
@@ -91,9 +91,9 @@ func (t *mpeg1Video) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/mpeg4_audio.go
+++ b/internal/formatprocessor/mpeg4_audio.go
@@ -14,7 +14,7 @@ import (
 )
 
 type mpeg4Audio struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.MPEG4Audio
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -42,7 +42,7 @@ func (t *mpeg4Audio) initialize() error {
 
 func (t *mpeg4Audio) createEncoder() error {
 	t.encoder = &rtpmpeg4audio.Encoder{
-		PayloadMaxSize:   t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize:   t.RTPMaxPayloadSize,
 		PayloadType:      t.Format.PayloadTyp,
 		SizeLength:       t.Format.SizeLength,
 		IndexLength:      t.Format.IndexLength,
@@ -85,9 +85,9 @@ func (t *mpeg4Audio) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/mpeg4_video.go
+++ b/internal/formatprocessor/mpeg4_video.go
@@ -28,7 +28,7 @@ var (
 )
 
 type mpeg4Video struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.MPEG4Video
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -56,7 +56,7 @@ func (t *mpeg4Video) initialize() error {
 
 func (t *mpeg4Video) createEncoder() error {
 	t.encoder = &rtpmpeg4video.Encoder{
-		PayloadMaxSize: t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: t.RTPMaxPayloadSize,
 		PayloadType:    t.Format.PayloadTyp,
 	}
 	return t.encoder.Init()
@@ -136,9 +136,9 @@ func (t *mpeg4Video) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/opus.go
+++ b/internal/formatprocessor/opus.go
@@ -14,7 +14,7 @@ import (
 )
 
 type opus struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.Opus
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -42,7 +42,7 @@ func (t *opus) initialize() error {
 
 func (t *opus) createEncoder() error {
 	t.encoder = &rtpsimpleaudio.Encoder{
-		PayloadMaxSize: t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: t.RTPMaxPayloadSize,
 		PayloadType:    t.Format.PayloadTyp,
 	}
 	return t.encoder.Init()
@@ -89,9 +89,9 @@ func (t *opus) ProcessRTPPacket(
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/opus_test.go
+++ b/internal/formatprocessor/opus_test.go
@@ -15,7 +15,7 @@ func TestOpusEncode(t *testing.T) {
 		ChannelCount: 2,
 	}
 
-	p, err := New(1472, forma, true, nil)
+	p, err := New(1450, forma, true, nil)
 	require.NoError(t, err)
 
 	unit := &unit.Opus{

--- a/internal/formatprocessor/processor.go
+++ b/internal/formatprocessor/processor.go
@@ -39,7 +39,7 @@ type Processor interface {
 
 // New allocates a Processor.
 func New(
-	udpMaxPayloadSize int,
+	rtpMaxPayloadSize int,
 	forma format.Format,
 	generateRTPPackets bool,
 	parent logger.Writer,
@@ -49,7 +49,7 @@ func New(
 	switch forma := forma.(type) {
 	case *format.AV1:
 		proc = &av1{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -57,7 +57,7 @@ func New(
 
 	case *format.VP9:
 		proc = &vp9{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -65,7 +65,7 @@ func New(
 
 	case *format.VP8:
 		proc = &vp8{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -73,7 +73,7 @@ func New(
 
 	case *format.H265:
 		proc = &h265{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -81,7 +81,7 @@ func New(
 
 	case *format.H264:
 		proc = &h264{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -89,7 +89,7 @@ func New(
 
 	case *format.MPEG4Video:
 		proc = &mpeg4Video{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -97,7 +97,7 @@ func New(
 
 	case *format.MPEG1Video:
 		proc = &mpeg1Video{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -105,7 +105,7 @@ func New(
 
 	case *format.MJPEG:
 		proc = &mjpeg{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -113,7 +113,7 @@ func New(
 
 	case *format.Opus:
 		proc = &opus{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -121,7 +121,7 @@ func New(
 
 	case *format.MPEG4Audio:
 		proc = &mpeg4Audio{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -129,7 +129,7 @@ func New(
 
 	case *format.MPEG1Audio:
 		proc = &mpeg1Audio{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -137,7 +137,7 @@ func New(
 
 	case *format.AC3:
 		proc = &ac3{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -145,7 +145,7 @@ func New(
 
 	case *format.G711:
 		proc = &g711{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -153,7 +153,7 @@ func New(
 
 	case *format.LPCM:
 		proc = &lpcm{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,
@@ -161,7 +161,7 @@ func New(
 
 	default:
 		proc = &generic{
-			UDPMaxPayloadSize:  udpMaxPayloadSize,
+			RTPMaxPayloadSize:  rtpMaxPayloadSize,
 			Format:             forma,
 			GenerateRTPPackets: generateRTPPackets,
 			Parent:             parent,

--- a/internal/formatprocessor/processor_test.go
+++ b/internal/formatprocessor/processor_test.go
@@ -90,7 +90,7 @@ func TestNew(t *testing.T) {
 		},
 	} {
 		t.Run(ca.name, func(t *testing.T) {
-			p, err := New(1472, ca.in, false, nil)
+			p, err := New(1450, ca.in, false, nil)
 			require.NoError(t, err)
 			require.IsType(t, ca.out, p)
 		})

--- a/internal/formatprocessor/vp8.go
+++ b/internal/formatprocessor/vp8.go
@@ -14,7 +14,7 @@ import (
 )
 
 type vp8 struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.VP8
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -42,7 +42,7 @@ func (t *vp8) initialize() error {
 
 func (t *vp8) createEncoder() error {
 	t.encoder = &rtpvp8.Encoder{
-		PayloadMaxSize: t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: t.RTPMaxPayloadSize,
 		PayloadType:    t.Format.PayloadTyp,
 	}
 	return t.encoder.Init()
@@ -82,9 +82,9 @@ func (t *vp8) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/formatprocessor/vp9.go
+++ b/internal/formatprocessor/vp9.go
@@ -14,7 +14,7 @@ import (
 )
 
 type vp9 struct {
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Format             *format.VP9
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -42,7 +42,7 @@ func (t *vp9) initialize() error {
 
 func (t *vp9) createEncoder() error {
 	t.encoder = &rtpvp9.Encoder{
-		PayloadMaxSize: t.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: t.RTPMaxPayloadSize,
 		PayloadType:    t.Format.PayloadTyp,
 	}
 	return t.encoder.Init()
@@ -82,9 +82,9 @@ func (t *vp9) ProcessRTPPacket( //nolint:dupl
 	pkt.Padding = false
 	pkt.PaddingSize = 0
 
-	if pkt.MarshalSize() > t.UDPMaxPayloadSize {
-		return nil, fmt.Errorf("payload size (%d) is greater than maximum allowed (%d)",
-			pkt.MarshalSize(), t.UDPMaxPayloadSize)
+	if len(pkt.Payload) > t.RTPMaxPayloadSize {
+		return nil, fmt.Errorf("RTP payload size (%d) is greater than maximum allowed (%d)",
+			len(pkt.Payload), t.RTPMaxPayloadSize)
 	}
 
 	// decode from RTP

--- a/internal/protocols/hls/from_stream_test.go
+++ b/internal/protocols/hls/from_stream_test.go
@@ -16,7 +16,7 @@ import (
 func TestFromStreamNoSupportedCodecs(t *testing.T) {
 	strm := &stream.Stream{
 		WriteQueueSize:    512,
-		UDPMaxPayloadSize: 1472,
+		RTPMaxPayloadSize: 1450,
 		Desc: &description.Session{Medias: []*description.Media{{
 			Type:    description.MediaTypeVideo,
 			Formats: []format.Format{&format.VP8{}},
@@ -40,7 +40,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 	strm := &stream.Stream{
 		WriteQueueSize:    512,
-		UDPMaxPayloadSize: 1472,
+		RTPMaxPayloadSize: 1450,
 		Desc: &description.Session{Medias: []*description.Media{
 			{
 				Type:    description.MediaTypeVideo,

--- a/internal/protocols/hls/to_stream_test.go
+++ b/internal/protocols/hls/to_stream_test.go
@@ -104,7 +104,7 @@ func TestToStream(t *testing.T) {
 
 			strm = &stream.Stream{
 				WriteQueueSize:     512,
-				UDPMaxPayloadSize:  1472,
+				RTPMaxPayloadSize:  1450,
 				Desc:               &description.Session{Medias: medias},
 				GenerateRTPPackets: true,
 				Parent:             test.NilLogger,

--- a/internal/protocols/mpegts/from_stream_test.go
+++ b/internal/protocols/mpegts/from_stream_test.go
@@ -15,7 +15,7 @@ import (
 func TestFromStreamNoSupportedCodecs(t *testing.T) {
 	strm := &stream.Stream{
 		WriteQueueSize:    512,
-		UDPMaxPayloadSize: 1472,
+		RTPMaxPayloadSize: 1450,
 		Desc: &description.Session{Medias: []*description.Media{{
 			Type:    description.MediaTypeVideo,
 			Formats: []format.Format{&format.VP8{}},
@@ -37,7 +37,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 	strm := &stream.Stream{
 		WriteQueueSize:    512,
-		UDPMaxPayloadSize: 1472,
+		RTPMaxPayloadSize: 1450,
 		Desc: &description.Session{Medias: []*description.Media{
 			{
 				Type:    description.MediaTypeVideo,

--- a/internal/protocols/rtmp/from_stream_test.go
+++ b/internal/protocols/rtmp/from_stream_test.go
@@ -16,7 +16,7 @@ import (
 func TestFromStreamNoSupportedCodecs(t *testing.T) {
 	strm := &stream.Stream{
 		WriteQueueSize:    512,
-		UDPMaxPayloadSize: 1472,
+		RTPMaxPayloadSize: 1450,
 		Desc: &description.Session{Medias: []*description.Media{{
 			Type:    description.MediaTypeVideo,
 			Formats: []format.Format{&format.VP8{}},
@@ -38,7 +38,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 	strm := &stream.Stream{
 		WriteQueueSize:    512,
-		UDPMaxPayloadSize: 1472,
+		RTPMaxPayloadSize: 1450,
 		Desc: &description.Session{Medias: []*description.Media{
 			{
 				Type:    description.MediaTypeVideo,

--- a/internal/protocols/webrtc/from_stream_test.go
+++ b/internal/protocols/webrtc/from_stream_test.go
@@ -15,7 +15,7 @@ import (
 func TestFromStreamNoSupportedCodecs(t *testing.T) {
 	strm := &stream.Stream{
 		WriteQueueSize:    512,
-		UDPMaxPayloadSize: 1472,
+		RTPMaxPayloadSize: 1450,
 		Desc: &description.Session{Medias: []*description.Media{{
 			Type:    description.MediaTypeVideo,
 			Formats: []format.Format{&format.MJPEG{}},
@@ -37,7 +37,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 	strm := &stream.Stream{
 		WriteQueueSize:    512,
-		UDPMaxPayloadSize: 1472,
+		RTPMaxPayloadSize: 1450,
 		Desc: &description.Session{Medias: []*description.Media{
 			{
 				Type:    description.MediaTypeVideo,
@@ -78,7 +78,7 @@ func TestFromStream(t *testing.T) {
 		t.Run(ca.name, func(t *testing.T) {
 			strm := &stream.Stream{
 				WriteQueueSize:    512,
-				UDPMaxPayloadSize: 1472,
+				RTPMaxPayloadSize: 1450,
 				Desc: &description.Session{
 					Medias: []*description.Media{{
 						Formats: []format.Format{ca.in},

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -127,7 +127,7 @@ func TestRecorder(t *testing.T) {
 		t.Run(ca, func(t *testing.T) {
 			strm := &stream.Stream{
 				WriteQueueSize:     512,
-				UDPMaxPayloadSize:  1472,
+				RTPMaxPayloadSize:  1450,
 				Desc:               desc,
 				GenerateRTPPackets: true,
 				Parent:             test.NilLogger,
@@ -341,7 +341,7 @@ func TestRecorderFMP4NegativeDTS(t *testing.T) {
 
 	strm := &stream.Stream{
 		WriteQueueSize:     512,
-		UDPMaxPayloadSize:  1472,
+		RTPMaxPayloadSize:  1450,
 		Desc:               desc,
 		GenerateRTPPackets: true,
 		Parent:             test.NilLogger,
@@ -429,7 +429,7 @@ func TestRecorderSkipTracksPartial(t *testing.T) {
 
 			strm := &stream.Stream{
 				WriteQueueSize:     512,
-				UDPMaxPayloadSize:  1472,
+				RTPMaxPayloadSize:  1450,
 				Desc:               desc,
 				GenerateRTPPackets: true,
 				Parent:             test.NilLogger,
@@ -490,7 +490,7 @@ func TestRecorderSkipTracksFull(t *testing.T) {
 
 			strm := &stream.Stream{
 				WriteQueueSize:     512,
-				UDPMaxPayloadSize:  1472,
+				RTPMaxPayloadSize:  1450,
 				Desc:               desc,
 				GenerateRTPPackets: true,
 				Parent:             test.NilLogger,
@@ -553,7 +553,7 @@ func TestRecorderFMP4SegmentSwitch(t *testing.T) {
 
 	strm := &stream.Stream{
 		WriteQueueSize:     512,
-		UDPMaxPayloadSize:  1472,
+		RTPMaxPayloadSize:  1450,
 		Desc:               desc,
 		GenerateRTPPackets: true,
 		Parent:             test.NilLogger,

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -186,7 +186,7 @@ func TestServerRead(t *testing.T) {
 
 			strm := &stream.Stream{
 				WriteQueueSize:     512,
-				UDPMaxPayloadSize:  1472,
+				RTPMaxPayloadSize:  1450,
 				Desc:               desc,
 				GenerateRTPPackets: true,
 				Parent:             test.NilLogger,
@@ -413,7 +413,7 @@ func TestServerDirectory(t *testing.T) {
 
 	strm := &stream.Stream{
 		WriteQueueSize:     512,
-		UDPMaxPayloadSize:  1472,
+		RTPMaxPayloadSize:  1450,
 		Desc:               desc,
 		GenerateRTPPackets: true,
 		Parent:             test.NilLogger,
@@ -462,7 +462,7 @@ func TestServerDynamicAlwaysRemux(t *testing.T) {
 
 	strm := &stream.Stream{
 		WriteQueueSize:     512,
-		UDPMaxPayloadSize:  1472,
+		RTPMaxPayloadSize:  1450,
 		Desc:               desc,
 		GenerateRTPPackets: true,
 		Parent:             test.NilLogger,

--- a/internal/servers/rtmp/server_test.go
+++ b/internal/servers/rtmp/server_test.go
@@ -40,7 +40,7 @@ func (p *dummyPath) ExternalCmdEnv() externalcmd.Environment {
 func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stream, error) {
 	p.stream = &stream.Stream{
 		WriteQueueSize:     512,
-		UDPMaxPayloadSize:  1472,
+		RTPMaxPayloadSize:  1450,
 		Desc:               req.Desc,
 		GenerateRTPPackets: true,
 		Parent:             test.NilLogger,
@@ -209,7 +209,7 @@ func TestServerRead(t *testing.T) {
 
 			strm := &stream.Stream{
 				WriteQueueSize:     512,
-				UDPMaxPayloadSize:  1472,
+				RTPMaxPayloadSize:  1450,
 				Desc:               desc,
 				GenerateRTPPackets: true,
 				Parent:             test.NilLogger,

--- a/internal/servers/rtsp/server_test.go
+++ b/internal/servers/rtsp/server_test.go
@@ -40,7 +40,7 @@ func (p *dummyPath) ExternalCmdEnv() externalcmd.Environment {
 func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stream, error) {
 	p.stream = &stream.Stream{
 		WriteQueueSize:     512,
-		UDPMaxPayloadSize:  1472,
+		RTPMaxPayloadSize:  1450,
 		Desc:               req.Desc,
 		GenerateRTPPackets: true,
 		Parent:             test.NilLogger,
@@ -177,7 +177,7 @@ func TestServerRead(t *testing.T) {
 
 			strm := &stream.Stream{
 				WriteQueueSize:     512,
-				UDPMaxPayloadSize:  1472,
+				RTPMaxPayloadSize:  1450,
 				Desc:               desc,
 				GenerateRTPPackets: true,
 				Parent:             test.NilLogger,
@@ -319,7 +319,7 @@ func TestServerRedirect(t *testing.T) {
 
 			strm := &stream.Stream{
 				WriteQueueSize:     512,
-				UDPMaxPayloadSize:  1472,
+				RTPMaxPayloadSize:  1450,
 				Desc:               desc,
 				GenerateRTPPackets: true,
 				Parent:             test.NilLogger,

--- a/internal/servers/srt/server_test.go
+++ b/internal/servers/srt/server_test.go
@@ -37,7 +37,7 @@ func (p *dummyPath) ExternalCmdEnv() externalcmd.Environment {
 func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stream, error) {
 	p.stream = &stream.Stream{
 		WriteQueueSize:     512,
-		UDPMaxPayloadSize:  1472,
+		RTPMaxPayloadSize:  1450,
 		Desc:               req.Desc,
 		GenerateRTPPackets: true,
 		Parent:             test.NilLogger,
@@ -171,7 +171,7 @@ func TestServerRead(t *testing.T) {
 
 	strm := &stream.Stream{
 		WriteQueueSize:     512,
-		UDPMaxPayloadSize:  1472,
+		RTPMaxPayloadSize:  1450,
 		Desc:               desc,
 		GenerateRTPPackets: true,
 		Parent:             test.NilLogger,

--- a/internal/servers/webrtc/server_test.go
+++ b/internal/servers/webrtc/server_test.go
@@ -54,7 +54,7 @@ func (p *dummyPath) ExternalCmdEnv() externalcmd.Environment {
 func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stream, error) {
 	p.stream = &stream.Stream{
 		WriteQueueSize:     512,
-		UDPMaxPayloadSize:  1472,
+		RTPMaxPayloadSize:  1450,
 		Desc:               req.Desc,
 		GenerateRTPPackets: true,
 		Parent:             test.NilLogger,
@@ -508,7 +508,7 @@ func TestServerRead(t *testing.T) {
 
 			strm := &stream.Stream{
 				WriteQueueSize:     512,
-				UDPMaxPayloadSize:  1472,
+				RTPMaxPayloadSize:  1450,
 				Desc:               desc,
 				GenerateRTPPackets: reflect.TypeOf(ca.unit) != reflect.TypeOf(&unit.Generic{}),
 				Parent:             test.NilLogger,

--- a/internal/staticsources/handler.go
+++ b/internal/staticsources/handler.go
@@ -60,7 +60,7 @@ type Handler struct {
 	ReadTimeout       conf.Duration
 	WriteTimeout      conf.Duration
 	WriteQueueSize    int
-	UDPMaxPayloadSize int
+	RTPMaxPayloadSize int
 	Matches           []string
 	PathManager       handlerPathManager
 	Parent            handlerParent
@@ -132,7 +132,7 @@ func (s *Handler) Initialize() {
 
 	case s.Conf.Source == "rpiCamera":
 		s.instance = &ssrpicamera.Source{
-			UDPMaxPayloadSize: s.UDPMaxPayloadSize,
+			RTPMaxPayloadSize: s.RTPMaxPayloadSize,
 			LogLevel:          s.LogLevel,
 			Parent:            s,
 		}

--- a/internal/staticsources/rpicamera/source.go
+++ b/internal/staticsources/rpicamera/source.go
@@ -105,7 +105,7 @@ type parent interface {
 
 // Source is a Raspberry Pi Camera static source.
 type Source struct {
-	UDPMaxPayloadSize int
+	RTPMaxPayloadSize int
 	LogLevel          conf.LogLevel
 	Parent            parent
 }
@@ -167,7 +167,7 @@ func (s *Source) runPrimary(params defs.StaticSourceRunParams) error {
 
 	encH264 := &rtph264.Encoder{
 		PayloadType:    96,
-		PayloadMaxSize: s.UDPMaxPayloadSize - 12,
+		PayloadMaxSize: s.RTPMaxPayloadSize,
 	}
 	err := encH264.Init()
 	if err != nil {
@@ -193,7 +193,7 @@ func (s *Source) runPrimary(params defs.StaticSourceRunParams) error {
 
 	if params.Conf.RPICameraSecondaryWidth != 0 {
 		encJpeg := &rtpmjpeg.Encoder{
-			PayloadMaxSize: s.UDPMaxPayloadSize - 12,
+			PayloadMaxSize: s.RTPMaxPayloadSize,
 		}
 		err = encJpeg.Init()
 		if err != nil {

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -28,7 +28,7 @@ type ReadFunc func(unit.Unit) error
 // It stores tracks, readers and allows to write data to readers, converting it when needed.
 type Stream struct {
 	WriteQueueSize     int
-	UDPMaxPayloadSize  int
+	RTPMaxPayloadSize  int
 	Desc               *description.Session
 	GenerateRTPPackets bool
 	Parent             logger.Writer
@@ -69,7 +69,7 @@ func (s *Stream) Initialize() error {
 
 	for _, media := range s.Desc.Medias {
 		s.streamMedias[media] = &streamMedia{
-			udpMaxPayloadSize:  s.UDPMaxPayloadSize,
+			rtpMaxPayloadSize:  s.RTPMaxPayloadSize,
 			media:              media,
 			generateRTPPackets: s.GenerateRTPPackets,
 			processingErrors:   s.processingErrors,

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -23,7 +23,7 @@ func unitSize(u unit.Unit) uint64 {
 }
 
 type streamFormat struct {
-	udpMaxPayloadSize  int
+	rtpMaxPayloadSize  int
 	format             format.Format
 	generateRTPPackets bool
 	processingErrors   *counterdumper.CounterDumper
@@ -39,7 +39,7 @@ func (sf *streamFormat) initialize() error {
 	sf.runningReaders = make(map[*streamReader]ReadFunc)
 
 	var err error
-	sf.proc, err = formatprocessor.New(sf.udpMaxPayloadSize, sf.format, sf.generateRTPPackets, sf.parent)
+	sf.proc, err = formatprocessor.New(sf.rtpMaxPayloadSize, sf.format, sf.generateRTPPackets, sf.parent)
 	if err != nil {
 		return err
 	}

--- a/internal/stream/stream_media.go
+++ b/internal/stream/stream_media.go
@@ -8,7 +8,7 @@ import (
 )
 
 type streamMedia struct {
-	udpMaxPayloadSize  int
+	rtpMaxPayloadSize  int
 	media              *description.Media
 	generateRTPPackets bool
 	processingErrors   *counterdumper.CounterDumper
@@ -22,7 +22,7 @@ func (sm *streamMedia) initialize() error {
 
 	for _, forma := range sm.media.Formats {
 		sf := &streamFormat{
-			udpMaxPayloadSize:  sm.udpMaxPayloadSize,
+			rtpMaxPayloadSize:  sm.rtpMaxPayloadSize,
 			format:             forma,
 			generateRTPPackets: sm.generateRTPPackets,
 			processingErrors:   sm.processingErrors,

--- a/internal/test/source_tester.go
+++ b/internal/test/source_tester.go
@@ -66,7 +66,7 @@ func (t *SourceTester) Log(_ logger.Level, _ string, _ ...interface{}) {
 func (t *SourceTester) SetReady(req defs.PathSourceStaticSetReadyReq) defs.PathSourceStaticSetReadyRes {
 	t.stream = &stream.Stream{
 		WriteQueueSize:     512,
-		UDPMaxPayloadSize:  1472,
+		RTPMaxPayloadSize:  1450,
 		Desc:               req.Desc,
 		GenerateRTPPackets: req.GenerateRTPPackets,
 		Parent:             t,


### PR DESCRIPTION
when RTSP encryption is enabled, maximum RTP packet size is slightly decreased to make room for SRTP.