### PR TITLE
Add support for setting a `hlsBaseURL`

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -408,6 +408,7 @@ func (conf *Conf) setDefaults() {
 	conf.HLSPartDuration = 200 * Duration(time.Millisecond)
 	conf.HLSSegmentMaxSize = 50 * 1024 * 1024
 	conf.HLSMuxerCloseAfter = 60 * Duration(time.Second)
+	conf.HLSBaseURL = ""
 
 	// WebRTC server
 	conf.WebRTC = true

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -260,6 +260,7 @@ type Conf struct {
 	HLSEncryption      bool       `json:"hlsEncryption"`
 	HLSServerKey       string     `json:"hlsServerKey"`
 	HLSServerCert      string     `json:"hlsServerCert"`
+	HLSBaseURL         string     `json:"hlsBaseURL"`
 	HLSAllowOrigin     string     `json:"hlsAllowOrigin"`
 	HLSTrustedProxies  IPNetworks `json:"hlsTrustedProxies"`
 	HLSAlwaysRemux     bool       `json:"hlsAlwaysRemux"`

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -532,6 +532,7 @@ func (p *Core) createResources(initial bool) error {
 			Directory:       p.conf.HLSDirectory,
 			ReadTimeout:     p.conf.ReadTimeout,
 			MuxerCloseAfter: p.conf.HLSMuxerCloseAfter,
+			BaseURL:         p.conf.HLSBaseURL,
 			Metrics:         p.metrics,
 			PathManager:     p.pathManager,
 			Parent:          p,
@@ -808,6 +809,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.HLSDirectory != p.conf.HLSDirectory ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.HLSMuxerCloseAfter != p.conf.HLSMuxerCloseAfter ||
+		newConf.HLSBaseURL != p.conf.HLSBaseURL ||
 		closePathManager ||
 		closeMetrics ||
 		closeLogger

--- a/internal/servers/hls/muxer.go
+++ b/internal/servers/hls/muxer.go
@@ -54,6 +54,7 @@ type muxer struct {
 	partDuration    conf.Duration
 	segmentMaxSize  conf.StringSize
 	directory       string
+	baseURL         string
 	closeAfter      conf.Duration
 	wg              *sync.WaitGroup
 	pathName        string
@@ -146,6 +147,7 @@ func (m *muxer) runInner() error {
 		partDuration:    m.partDuration,
 		segmentMaxSize:  m.segmentMaxSize,
 		directory:       m.directory,
+		baseURL:         m.baseURL,
 		pathName:        m.pathName,
 		stream:          stream,
 		bytesSent:       m.bytesSent,

--- a/internal/servers/hls/muxer_instance.go
+++ b/internal/servers/hls/muxer_instance.go
@@ -21,6 +21,7 @@ type muxerInstance struct {
 	partDuration    conf.Duration
 	segmentMaxSize  conf.StringSize
 	directory       string
+	baseURL         string
 	pathName        string
 	stream          *stream.Stream
 	bytesSent       *uint64
@@ -43,6 +44,7 @@ func (mi *muxerInstance) initialize() error {
 		PartMinDuration:    time.Duration(mi.partDuration),
 		SegmentMaxSize:     uint64(mi.segmentMaxSize),
 		Directory:          muxerDirectory,
+		BaseURL:            mi.baseURL,
 		OnEncodeError: func(err error) {
 			mi.Log(logger.Warn, err.Error())
 		},

--- a/internal/servers/hls/server.go
+++ b/internal/servers/hls/server.go
@@ -85,6 +85,7 @@ type Server struct {
 	Directory       string
 	ReadTimeout     conf.Duration
 	MuxerCloseAfter conf.Duration
+	BaseURL         string
 	Metrics         serverMetrics
 	PathManager     serverPathManager
 	Parent          serverParent
@@ -259,6 +260,7 @@ func (s *Server) createMuxer(pathName string, remoteAddr string, query string) *
 		partDuration:    s.PartDuration,
 		segmentMaxSize:  s.SegmentMaxSize,
 		directory:       s.Directory,
+		baseURL:         s.BaseURL,
 		wg:              &s.wg,
 		pathName:        pathName,
 		pathManager:     s.PathManager,

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -356,6 +356,10 @@ hlsDirectory: ''
 # The muxer will be closed when there are no
 # reader requests and this amount of time has passed.
 hlsMuxerCloseAfter: 60s
+# The base URL used to prefix every entry in the playlist.
+# Useful to generate playlists with absolute paths.
+# (e.g https://cdn.example.com)
+hlsBaseURL:
 
 ###############################################
 # Global settings -> WebRTC server

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -359,7 +359,7 @@ hlsMuxerCloseAfter: 60s
 # The base URL used to prefix every entry in the playlist.
 # Useful to generate playlists with absolute paths.
 # (e.g https://cdn.example.com)
-hlsBaseURL:
+hlsBaseURL: ""
 
 ###############################################
 # Global settings -> WebRTC server


### PR DESCRIPTION
This PR depends on a PR in `gohlslib` which has not been merged yet.

https://github.com/bluenviron/gohlslib/pull/257

Allows users to specify a base URL that will be used to prefix all the media file URLs in the generated HLS playlist, this is useful for cases in which users may want to host their media at CDN.