### PR TITLE
remove context from webrtc.PeerConnection arguments

### DIFF
--- a/internal/protocols/webrtc/peer_connection_test.go
+++ b/internal/protocols/webrtc/peer_connection_test.go
@@ -1,7 +1,6 @@
 package webrtc
 
 import (
-	"context"
 	"net"
 	"regexp"
 	"sort"
@@ -131,7 +130,7 @@ func TestPeerConnectionCandidates(t *testing.T) {
 			require.NoError(t, err)
 			defer pc.Close()
 
-			answer, err := pc.CreateFullAnswer(context.Background(), &offer)
+			answer, err := pc.CreateFullAnswer(&offer)
 			require.NoError(t, err)
 
 			n := len(regexp.MustCompile("(?m)^a=candidate:.+? udp .+? typ host").FindAllString(answer.SDP, -1))
@@ -250,7 +249,7 @@ func TestPeerConnectionConnectivity(t *testing.T) {
 				offer, err := clientPC.CreatePartialOffer()
 				require.NoError(t, err)
 
-				answer, err := serverPC.CreateFullAnswer(context.Background(), offer)
+				answer, err := serverPC.CreateFullAnswer(offer)
 				require.NoError(t, err)
 
 				require.Equal(t, 2, strings.Count(answer.SDP, "a=candidate:"))
@@ -271,7 +270,7 @@ func TestPeerConnectionConnectivity(t *testing.T) {
 					}
 				}()
 
-				err = serverPC.WaitUntilConnected(context.Background())
+				err = serverPC.WaitUntilConnected()
 				require.NoError(t, err)
 			})
 		}
@@ -325,13 +324,13 @@ func TestPeerConnectionRead(t *testing.T) {
 	err = pub.SetLocalDescription(offer)
 	require.NoError(t, err)
 
-	answer, err := reader.CreateFullAnswer(context.Background(), &offer)
+	answer, err := reader.CreateFullAnswer(&offer)
 	require.NoError(t, err)
 
 	err = pub.SetRemoteDescription(*answer)
 	require.NoError(t, err)
 
-	err = reader.WaitUntilConnected(context.Background())
+	err = reader.WaitUntilConnected()
 	require.NoError(t, err)
 
 	go func() {
@@ -364,7 +363,7 @@ func TestPeerConnectionRead(t *testing.T) {
 		require.NoError(t, err2)
 	}()
 
-	err = reader.GatherIncomingTracks(context.Background())
+	err = reader.GatherIncomingTracks()
 	require.NoError(t, err)
 
 	codecs := gatherCodecs(reader.IncomingTracks())
@@ -470,16 +469,16 @@ func TestPeerConnectionPublishRead(t *testing.T) {
 	offer, err := pc1.CreatePartialOffer()
 	require.NoError(t, err)
 
-	answer, err := pc2.CreateFullAnswer(context.Background(), offer)
+	answer, err := pc2.CreateFullAnswer(offer)
 	require.NoError(t, err)
 
 	err = pc1.SetAnswer(answer)
 	require.NoError(t, err)
 
-	err = pc1.WaitUntilConnected(context.Background())
+	err = pc1.WaitUntilConnected()
 	require.NoError(t, err)
 
-	err = pc2.WaitUntilConnected(context.Background())
+	err = pc2.WaitUntilConnected()
 	require.NoError(t, err)
 
 	for _, track := range pc2.OutgoingTracks {
@@ -497,7 +496,7 @@ func TestPeerConnectionPublishRead(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	err = pc1.GatherIncomingTracks(context.Background())
+	err = pc1.GatherIncomingTracks()
 	require.NoError(t, err)
 
 	codecs := gatherCodecs(pc1.IncomingTracks())
@@ -564,7 +563,7 @@ func TestPeerConnectionFallbackCodecs(t *testing.T) {
 	offer, err := pc1.CreatePartialOffer()
 	require.NoError(t, err)
 
-	answer, err := pc2.CreateFullAnswer(context.Background(), offer)
+	answer, err := pc2.CreateFullAnswer(offer)
 	require.NoError(t, err)
 
 	var s sdp.SessionDescription

--- a/internal/protocols/webrtc/to_stream_test.go
+++ b/internal/protocols/webrtc/to_stream_test.go
@@ -1,7 +1,6 @@
 package webrtc
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -365,7 +364,7 @@ func TestToStream(t *testing.T) {
 			offer, err := pc1.CreatePartialOffer()
 			require.NoError(t, err)
 
-			answer, err := pc2.CreateFullAnswer(context.Background(), offer)
+			answer, err := pc2.CreateFullAnswer(offer)
 			require.NoError(t, err)
 
 			err = pc1.SetAnswer(answer)
@@ -384,10 +383,10 @@ func TestToStream(t *testing.T) {
 				}
 			}()
 
-			err = pc1.WaitUntilConnected(context.Background())
+			err = pc1.WaitUntilConnected()
 			require.NoError(t, err)
 
-			err = pc2.WaitUntilConnected(context.Background())
+			err = pc2.WaitUntilConnected()
 			require.NoError(t, err)
 
 			err = pc1.OutgoingTracks[0].WriteRTP(&rtp.Packet{
@@ -403,7 +402,7 @@ func TestToStream(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			err = pc2.GatherIncomingTracks(context.Background())
+			err = pc2.GatherIncomingTracks()
 			require.NoError(t, err)
 
 			var stream *stream.Stream

--- a/internal/protocols/whip/client_test.go
+++ b/internal/protocols/whip/client_test.go
@@ -105,7 +105,7 @@ func TestClientRead(t *testing.T) {
 						require.NoError(t, err2)
 						offer := whipOffer(body)
 
-						answer, err2 := pc.CreateFullAnswer(context.Background(), offer)
+						answer, err2 := pc.CreateFullAnswer(offer)
 						require.NoError(t, err2)
 
 						w.Header().Set("Content-Type", "application/sdp")
@@ -116,7 +116,7 @@ func TestClientRead(t *testing.T) {
 						w.Write([]byte(answer.SDP))
 
 						go func() {
-							err3 := pc.WaitUntilConnected(context.Background())
+							err3 := pc.WaitUntilConnected()
 							require.NoError(t, err3)
 
 							for _, track := range outgoingTracks {
@@ -277,7 +277,7 @@ func TestClientPublish(t *testing.T) {
 						require.NoError(t, err2)
 						offer := whipOffer(body)
 
-						answer, err2 := pc.CreateFullAnswer(context.Background(), offer)
+						answer, err2 := pc.CreateFullAnswer(offer)
 						require.NoError(t, err2)
 
 						w.Header().Set("Content-Type", "application/sdp")
@@ -288,10 +288,10 @@ func TestClientPublish(t *testing.T) {
 						w.Write([]byte(answer.SDP))
 
 						go func() {
-							err3 := pc.WaitUntilConnected(context.Background())
+							err3 := pc.WaitUntilConnected()
 							require.NoError(t, err3)
 
-							err3 = pc.GatherIncomingTracks(context.Background())
+							err3 = pc.GatherIncomingTracks()
 							require.NoError(t, err3)
 
 							codecs := gatherCodecs(pc.IncomingTracks())

--- a/internal/staticsources/webrtc/source.go
+++ b/internal/staticsources/webrtc/source.go
@@ -2,7 +2,6 @@
 package webrtc
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -62,7 +61,6 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 		URL:                  u,
 		Log:                  s,
 	}
-
 	err = client.Initialize(params.Context)
 	if err != nil {
 		return err
@@ -94,7 +92,7 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 	readErr := make(chan error)
 
 	go func() {
-		readErr <- client.Wait(context.Background())
+		readErr <- client.Wait()
 	}()
 
 	for {

--- a/internal/staticsources/webrtc/source_test.go
+++ b/internal/staticsources/webrtc/source_test.go
@@ -71,7 +71,7 @@ func TestSource(t *testing.T) {
 				require.NoError(t, err2)
 				offer := whipOffer(body)
 
-				answer, err2 := pc.CreateFullAnswer(context.Background(), offer)
+				answer, err2 := pc.CreateFullAnswer(offer)
 				require.NoError(t, err2)
 
 				w.Header().Set("Content-Type", "application/sdp")
@@ -82,7 +82,7 @@ func TestSource(t *testing.T) {
 				w.Write([]byte(answer.SDP))
 
 				go func() {
-					err3 := pc.WaitUntilConnected(context.Background())
+					err3 := pc.WaitUntilConnected()
 					require.NoError(t, err3)
 
 					err3 = outgoingTracks[0].WriteRTP(&rtp.Packet{


### PR DESCRIPTION
contexts are useless since there's already PeerConnection.Close().