### PR TITLE
fix memory leak when reloading the configuration

### DIFF
--- a/internal/staticsources/hls/source_test.go
+++ b/internal/staticsources/hls/source_test.go
@@ -102,14 +102,20 @@ func TestSource(t *testing.T) {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	defer ctxCancel()
 
+	reloadConf := make(chan *conf.Path)
+
 	go func() {
 		so.Run(defs.StaticSourceRunParams{ //nolint:errcheck
 			Context:        ctx,
 			ResolvedSource: "http://localhost:5780/stream.m3u8",
 			Conf:           &conf.Path{},
+			ReloadConf:     reloadConf,
 		})
 		close(done)
 	}()
 
 	<-p.Unit
+
+	// the source must be listening on ReloadConf
+	reloadConf <- nil
 }

--- a/internal/staticsources/mpegts/source.go
+++ b/internal/staticsources/mpegts/source.go
@@ -66,15 +66,19 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 		readerErr <- s.runReader(nc)
 	}()
 
-	select {
-	case err = <-readerErr:
-		nc.Close()
-		return err
+	for {
+		select {
+		case err = <-readerErr:
+			nc.Close()
+			return err
 
-	case <-params.Context.Done():
-		nc.Close()
-		<-readerErr
-		return fmt.Errorf("terminated")
+		case <-params.ReloadConf:
+
+		case <-params.Context.Done():
+			nc.Close()
+			<-readerErr
+			return fmt.Errorf("terminated")
+		}
 	}
 }
 

--- a/internal/staticsources/mpegts/source_test.go
+++ b/internal/staticsources/mpegts/source_test.go
@@ -69,11 +69,14 @@ func TestSourceUDP(t *testing.T) {
 			ctx, ctxCancel := context.WithCancel(context.Background())
 			defer ctxCancel()
 
+			reloadConf := make(chan *conf.Path)
+
 			go func() {
 				so.Run(defs.StaticSourceRunParams{ //nolint:errcheck
 					Context:        ctx,
 					ResolvedSource: src,
 					Conf:           &conf.Path{},
+					ReloadConf:     reloadConf,
 				})
 				close(done)
 			}()
@@ -128,6 +131,9 @@ func TestSourceUDP(t *testing.T) {
 			require.NoError(t, err)
 
 			<-p.Unit
+
+			// the source must be listening on ReloadConf
+			reloadConf <- nil
 		})
 	}
 }

--- a/internal/staticsources/rtp/source.go
+++ b/internal/staticsources/rtp/source.go
@@ -80,15 +80,19 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 		readerErr <- s.runReader(&desc, nc)
 	}()
 
-	select {
-	case err = <-readerErr:
-		nc.Close()
-		return err
+	for {
+		select {
+		case err = <-readerErr:
+			nc.Close()
+			return err
 
-	case <-params.Context.Done():
-		nc.Close()
-		<-readerErr
-		return fmt.Errorf("terminated")
+		case <-params.ReloadConf:
+
+		case <-params.Context.Done():
+			nc.Close()
+			<-readerErr
+			return fmt.Errorf("terminated")
+		}
 	}
 }
 

--- a/internal/staticsources/rtp/source_test.go
+++ b/internal/staticsources/rtp/source_test.go
@@ -69,6 +69,8 @@ func TestSourceUDP(t *testing.T) {
 			ctx, ctxCancel := context.WithCancel(context.Background())
 			defer ctxCancel()
 
+			reloadConf := make(chan *conf.Path)
+
 			go func() {
 				so.Run(defs.StaticSourceRunParams{ //nolint:errcheck
 					Context:        ctx,
@@ -83,6 +85,7 @@ func TestSourceUDP(t *testing.T) {
 							"a=rtpmap:96 H264/90000\n" +
 							"a=fmtp:96 profile-level-id=42e01e;packetization-mode=1\n",
 					},
+					ReloadConf: reloadConf,
 				})
 				close(done)
 			}()
@@ -139,6 +142,9 @@ func TestSourceUDP(t *testing.T) {
 			}
 
 			<-p.Unit
+
+			// the source must be listening on ReloadConf
+			reloadConf <- nil
 		})
 	}
 }

--- a/internal/staticsources/rtsp/source_test.go
+++ b/internal/staticsources/rtsp/source_test.go
@@ -169,16 +169,22 @@ func TestSource(t *testing.T) {
 			ctx, ctxCancel := context.WithCancel(context.Background())
 			defer ctxCancel()
 
+			reloadConf := make(chan *conf.Path)
+
 			go func() {
 				so.Run(defs.StaticSourceRunParams{ //nolint:errcheck
 					Context:        ctx,
 					ResolvedSource: ur,
 					Conf:           cnf,
+					ReloadConf:     reloadConf,
 				})
 				close(done)
 			}()
 
 			<-p.Unit
+
+			// the source must be listening on ReloadConf
+			reloadConf <- nil
 		})
 	}
 }

--- a/internal/staticsources/srt/source_test.go
+++ b/internal/staticsources/srt/source_test.go
@@ -1,7 +1,6 @@
 package srt
 
 import (
-	"bufio"
 	"context"
 	"testing"
 	"time"
@@ -20,42 +19,8 @@ func TestSource(t *testing.T) {
 	require.NoError(t, err)
 	defer ln.Close()
 
-	go func() {
-		req, err2 := ln.Accept2()
-		require.NoError(t, err2)
-
-		require.Equal(t, "sidname", req.StreamId())
-		err2 = req.SetPassphrase("ttest1234567")
-		require.NoError(t, err2)
-
-		conn, err2 := req.Accept()
-		require.NoError(t, err2)
-		defer conn.Close()
-
-		track := &mpegts.Track{
-			Codec: &mpegts.CodecH264{},
-		}
-
-		bw := bufio.NewWriter(conn)
-		w := &mpegts.Writer{W: bw, Tracks: []*mpegts.Track{track}}
-		err2 = w.Initialize()
-		require.NoError(t, err2)
-
-		err2 = w.WriteH264(track, 0, 0, [][]byte{{ // IDR
-			5, 1,
-		}})
-		require.NoError(t, err2)
-
-		err2 = bw.Flush()
-		require.NoError(t, err2)
-
-		// wait for internal SRT queue to be written
-		time.Sleep(500 * time.Millisecond)
-	}()
-
 	p := &test.StaticSourceParent{}
 	p.Initialize()
-	defer p.Close()
 
 	so := &Source{
 		ReadTimeout: conf.Duration(10 * time.Second),
@@ -68,14 +33,50 @@ func TestSource(t *testing.T) {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	defer ctxCancel()
 
+	reloadConf := make(chan *conf.Path)
+
 	go func() {
 		so.Run(defs.StaticSourceRunParams{ //nolint:errcheck
 			Context:        ctx,
 			ResolvedSource: "srt://127.0.0.1:9002?streamid=sidname&passphrase=ttest1234567",
 			Conf:           &conf.Path{},
+			ReloadConf:     reloadConf,
 		})
 		close(done)
 	}()
 
+	req, err2 := ln.Accept2()
+	require.NoError(t, err2)
+
+	require.Equal(t, "sidname", req.StreamId())
+	err2 = req.SetPassphrase("ttest1234567")
+	require.NoError(t, err2)
+
+	conn, err2 := req.Accept()
+	require.NoError(t, err2)
+	defer conn.Close()
+
+	track := &mpegts.Track{Codec: &mpegts.CodecH264{}}
+
+	w := &mpegts.Writer{W: conn, Tracks: []*mpegts.Track{track}}
+	err2 = w.Initialize()
+	require.NoError(t, err2)
+
+	err2 = w.WriteH264(track, 0, 0, [][]byte{{ // IDR
+		5, 1,
+	}})
+	require.NoError(t, err2)
+
+	err = w.WriteH264(track, 0, 0, [][]byte{{ // non-IDR
+		5, 2,
+	}})
+	require.NoError(t, err)
+
 	<-p.Unit
+
+	// the source must be listening on ReloadConf
+	reloadConf <- nil
+
+	// stop test reader before 2nd H264 packet is received to avoid a crash
+	p.Close()
 }

--- a/internal/staticsources/webrtc/source_test.go
+++ b/internal/staticsources/webrtc/source_test.go
@@ -138,14 +138,20 @@ func TestSource(t *testing.T) {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	defer ctxCancel()
 
+	reloadConf := make(chan *conf.Path)
+
 	go func() {
 		so.Run(defs.StaticSourceRunParams{ //nolint:errcheck
 			Context:        ctx,
 			ResolvedSource: "whep://localhost:9003/my/resource",
 			Conf:           &conf.Path{},
+			ReloadConf:     reloadConf,
 		})
 		close(done)
 	}()
 
 	<-p.Unit
+
+	// the source must be listening on ReloadConf
+	reloadConf <- nil
 }


### PR DESCRIPTION
When a path has a MPEG-TS, RTP or WebRTC source and the path configuration is reloaded, a routine was left open because the reload channel was not handled. This fixes the issue.