### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/internal/protocols/rtmp/chunk/chunk0.go
+++ b/internal/protocols/rtmp/chunk/chunk0.go
@@ -40,10 +40,7 @@ func (c *Chunk0) Read(r io.Reader, maxBodyLen uint32, _ bool) error {
 		c.Timestamp = uint32(header[0])<<24 | uint32(header[1])<<16 | uint32(header[2])<<8 | uint32(header[3])
 	}
 
-	chunkBodyLen := c.BodyLen
-	if chunkBodyLen > maxBodyLen {
-		chunkBodyLen = maxBodyLen
-	}
+	chunkBodyLen := min(c.BodyLen, maxBodyLen)
 
 	c.Body = make([]byte, chunkBodyLen)
 	_, err = io.ReadFull(r, c.Body)

--- a/internal/protocols/rtmp/chunk/chunk1.go
+++ b/internal/protocols/rtmp/chunk/chunk1.go
@@ -40,10 +40,7 @@ func (c *Chunk1) Read(r io.Reader, maxBodyLen uint32, _ bool) error {
 		c.TimestampDelta = uint32(header[0])<<24 | uint32(header[1])<<16 | uint32(header[2])<<8 | uint32(header[3])
 	}
 
-	chunkBodyLen := (c.BodyLen)
-	if chunkBodyLen > maxBodyLen {
-		chunkBodyLen = maxBodyLen
-	}
+	chunkBodyLen := min((c.BodyLen), maxBodyLen)
 
 	c.Body = make([]byte, chunkBodyLen)
 	_, err = io.ReadFull(r, c.Body)

--- a/internal/protocols/rtmp/rawmessage/reader.go
+++ b/internal/protocols/rtmp/rawmessage/reader.go
@@ -148,10 +148,7 @@ func (rc *readerChunkStream) readMessage(typ byte) (*Message, error) {
 			return nil, fmt.Errorf("received type 2 chunk but expected type 3 chunk")
 		}
 
-		chunkBodyLen := rc.curBodyLen
-		if chunkBodyLen > rc.mr.chunkSize {
-			chunkBodyLen = rc.mr.chunkSize
-		}
+		chunkBodyLen := min(rc.curBodyLen, rc.mr.chunkSize)
 
 		err := rc.readChunk(&rc.mr.c2, chunkBodyLen, false)
 		if err != nil {
@@ -178,10 +175,7 @@ func (rc *readerChunkStream) readMessage(typ byte) (*Message, error) {
 
 	default: // 3
 		if rc.curBodyRecv != 0 {
-			chunkBodyLen := rc.curBodyLen - rc.curBodyRecv
-			if chunkBodyLen > rc.mr.chunkSize {
-				chunkBodyLen = rc.mr.chunkSize
-			}
+			chunkBodyLen := min(rc.curBodyLen-rc.curBodyRecv, rc.mr.chunkSize)
 
 			err := rc.readChunk(&rc.mr.c3, chunkBodyLen, rc.hasExtendedTimestamp)
 			if err != nil {
@@ -208,10 +202,7 @@ func (rc *readerChunkStream) readMessage(typ byte) (*Message, error) {
 			return nil, fmt.Errorf("received type 3 chunk without previous chunk")
 		}
 
-		chunkBodyLen := rc.curBodyLen
-		if chunkBodyLen > rc.mr.chunkSize {
-			chunkBodyLen = rc.mr.chunkSize
-		}
+		chunkBodyLen := min(rc.curBodyLen, rc.mr.chunkSize)
 
 		err := rc.readChunk(&rc.mr.c3, chunkBodyLen, rc.hasExtendedTimestamp)
 		if err != nil {

--- a/internal/protocols/rtmp/rawmessage/writer.go
+++ b/internal/protocols/rtmp/rawmessage/writer.go
@@ -63,10 +63,7 @@ func (wc *writerChunkStream) writeMessage(msg *Message) error {
 	}
 
 	for {
-		chunkBodyLen := bodyLen - pos
-		if chunkBodyLen > wc.mw.chunkSize {
-			chunkBodyLen = wc.mw.chunkSize
-		}
+		chunkBodyLen := min(bodyLen-pos, wc.mw.chunkSize)
 
 		if firstChunk {
 			firstChunk = false


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.