### PR TITLE
Add disablepictureinpicture param

### DIFF
--- a/internal/servers/hls/index.html
+++ b/internal/servers/hls/index.html
@@ -187,6 +187,7 @@ const loadAttributesFromQuery = () => {
 	video.muted = parseBoolString(params.get('muted'), true);
 	video.autoplay = parseBoolString(params.get('autoplay'), true);
 	video.playsInline = parseBoolString(params.get('playsinline'), true);
+	video.disablepictureinpicture = parseBoolString(params.get('disablepictureinpicture'), false);
 	defaultControls = video.controls;
 };
 

--- a/internal/servers/webrtc/read_index.html
+++ b/internal/servers/webrtc/read_index.html
@@ -78,6 +78,7 @@ const loadAttributesFromQuery = () => {
   video.muted = parseBoolString(params.get('muted'), true);
   video.autoplay = parseBoolString(params.get('autoplay'), true);
   video.playsInline = parseBoolString(params.get('playsinline'), true);
+  video.disablepictureinpicture = parseBoolString(params.get('disablepictureinpicture'), false);
   defaultControls = video.controls;
 };
 


### PR DESCRIPTION
Add disablepictureinpicture param to optionally hide the PiP button that floats over video

ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video#disablepictureinpicture

Note that Firefox hides the floating button, but PiP can still be chosen from the context menu, while Chrome disables the floating button and the context menu item.

I did not fully build mediamtx and test this. Only tested using web developer tools to change the running page.
