### PR TITLE
fix reading JWT when it is passed through the password field

### DIFF
--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -113,7 +113,7 @@ func (m *Manager) Authenticate(req *Request) *Error {
 	if err != nil {
 		return &Error{
 			Wrapped:        err,
-			AskCredentials: m.Method != conf.AuthMethodJWT && req.Credentials.User == "" && req.Credentials.Pass == "",
+			AskCredentials: (req.Credentials.User == "" && req.Credentials.Pass == "" && req.Credentials.Token == ""),
 		}
 	}
 


### PR DESCRIPTION
Usernames and passwords must be requested explicitly to clients, but they were not in case of JWTs. This fixes the issue.