### PR TITLE
stop accepting JWTs from query parameters unless allowed in conf

### DIFF
--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -27,21 +27,6 @@ const (
 	jwksRefreshPeriod = 60 * 60 * time.Second
 )
 
-func isHTTPRequest(r *Request) bool {
-	switch r.Action {
-	case conf.AuthActionPlayback, conf.AuthActionAPI,
-		conf.AuthActionMetrics, conf.AuthActionPprof:
-		return true
-	}
-
-	switch r.Protocol {
-	case ProtocolHLS, ProtocolWebRTC:
-		return true
-	}
-
-	return false
-}
-
 func matchesPermission(perms []conf.AuthInternalUserPermission, req *Request) bool {
 	for _, perm := range perms {
 		if perm.Action == req.Action {
@@ -223,7 +208,7 @@ func (m *Manager) authenticateJWT(req *Request) error {
 	case req.Credentials.Pass != "":
 		encodedJWT = req.Credentials.Pass
 
-	case (!isHTTPRequest(req) || m.JWTInHTTPQuery):
+	case m.JWTInHTTPQuery:
 		var v url.Values
 		v, err = url.ParseQuery(req.Query)
 		if err != nil {

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -119,7 +119,7 @@ authHTTPExclude:
 #     }
 #   ]
 # }
-# Users are expected to pass the JWT in the Authorization header, password or query parameter.
+# Users are expected to pass the JWT in the Authorization header or as password.
 # This is the JWKS URL that will be used to pull (once) the public key that allows
 # to validate JWTs.
 authJWTJWKS:
@@ -135,7 +135,7 @@ authJWTClaimKey: mediamtx_permissions
 # Format is the same as the one of user permissions.
 authJWTExclude: []
 # allow passing the JWT through query parameters of HTTP requests (i.e. ?jwt=JWT).
-# This is a security risk.
+# This is a security risk and will be disabled by default in the future.
 authJWTInHTTPQuery: true
 
 ###############################################


### PR DESCRIPTION
This is the first step into removing support for passing JWTs through query parameters, which is a security flaw.