### PR TITLE
api: fix crash in rtspsessions/list and /rtspsessions/get (#5030)

### DIFF
--- a/internal/servers/rtsp/session.go
+++ b/internal/servers/rtsp/session.go
@@ -409,7 +409,13 @@ func (s *session) apiItem() *defs.APIRTSPSession {
 				return defs.APIRTSPSessionStateIdle
 			}
 		}(),
-		Path:  s.rsession.Path()[1:],
+		Path: func() string {
+			pa := s.rsession.Path()
+			if len(pa) >= 1 {
+				return pa[1:]
+			}
+			return ""
+		}(),
 		Query: s.rsession.Query(),
 		Transport: func() *string {
 			transport := s.rsession.Transport()


### PR DESCRIPTION
Fixes #5030 

sometimes sessions have an empty associated path, and this caused a crash.