### PR TITLE
add read and write timeouts in HTTP servers

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -97,6 +97,7 @@ type API struct {
 	AllowOrigin    string
 	TrustedProxies conf.IPNetworks
 	ReadTimeout    conf.Duration
+	WriteTimeout   conf.Duration
 	Conf           *conf.Conf
 	AuthManager    apiAuthManager
 	PathManager    defs.APIPathManager
@@ -193,13 +194,14 @@ func (a *API) Initialize() error {
 	group.DELETE("/recordings/deletesegment", a.onRecordingDeleteSegment)
 
 	a.httpServer = &httpp.Server{
-		Address:     a.Address,
-		ReadTimeout: time.Duration(a.ReadTimeout),
-		Encryption:  a.Encryption,
-		ServerCert:  a.ServerCert,
-		ServerKey:   a.ServerKey,
-		Handler:     router,
-		Parent:      a,
+		Address:      a.Address,
+		ReadTimeout:  time.Duration(a.ReadTimeout),
+		WriteTimeout: time.Duration(a.WriteTimeout),
+		Encryption:   a.Encryption,
+		ServerCert:   a.ServerCert,
+		ServerKey:    a.ServerKey,
+		Handler:      router,
+		Parent:       a,
 	}
 	err := a.httpServer.Initialize()
 	if err != nil {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -82,11 +82,12 @@ func checkError(t *testing.T, msg string, body io.Reader) {
 
 func TestPreflightRequest(t *testing.T) {
 	api := API{
-		Address:     "localhost:9997",
-		AllowOrigin: "*",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		AllowOrigin:  "*",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -121,13 +122,14 @@ func TestInfo(t *testing.T) {
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Version:     "v1.2.3",
-		Started:     time.Date(2008, 11, 7, 11, 22, 0, 0, time.Local),
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Version:      "v1.2.3",
+		Started:      time.Date(2008, 11, 7, 11, 22, 0, 0, time.Local),
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -150,9 +152,10 @@ func TestConfigGlobalGet(t *testing.T) {
 	checked := false
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
 		AuthManager: &test.AuthManager{
 			AuthenticateImpl: func(req *auth.Request) *auth.Error {
 				require.Equal(t, conf.AuthActionAPI, req.Action)
@@ -183,11 +186,12 @@ func TestConfigGlobalPatch(t *testing.T) {
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -219,11 +223,12 @@ func TestConfigGlobalPatchUnknownField(t *testing.T) { //nolint:dupl
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -256,11 +261,12 @@ func TestConfigPathDefaultsGet(t *testing.T) {
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -279,11 +285,12 @@ func TestConfigPathDefaultsPatch(t *testing.T) {
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -316,11 +323,12 @@ func TestConfigPathsList(t *testing.T) {
 		"    readPass: mypass2\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -358,11 +366,12 @@ func TestConfigPathsGet(t *testing.T) {
 		"    readPass: mypass\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -382,11 +391,12 @@ func TestConfigPathsAdd(t *testing.T) {
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -416,11 +426,12 @@ func TestConfigPathsAddUnknownField(t *testing.T) { //nolint:dupl
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -453,11 +464,12 @@ func TestConfigPathsPatch(t *testing.T) { //nolint:dupl
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -493,11 +505,12 @@ func TestConfigPathsReplace(t *testing.T) { //nolint:dupl
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -533,11 +546,12 @@ func TestConfigPathsReplaceNonExisting(t *testing.T) { //nolint:dupl
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -565,11 +579,12 @@ func TestConfigPathsDelete(t *testing.T) {
 	cnf := tempConf(t, "api: yes\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -610,11 +625,12 @@ func TestRecordingsList(t *testing.T) {
 		"  all_others:\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err = api.Initialize()
 	require.NoError(t, err)
@@ -679,11 +695,12 @@ func TestRecordingsGet(t *testing.T) {
 		"  all_others:\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err = api.Initialize()
 	require.NoError(t, err)
@@ -728,11 +745,12 @@ func TestRecordingsDeleteSegment(t *testing.T) {
 		"  all_others:\n")
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
-		AuthManager: test.NilAuthManager,
-		Parent:      &testParent{},
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
+		AuthManager:  test.NilAuthManager,
+		Parent:       &testParent{},
 	}
 	err = api.Initialize()
 	require.NoError(t, err)
@@ -769,8 +787,9 @@ func TestAuthJWKSRefresh(t *testing.T) {
 	ok := false
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager: &test.AuthManager{
 			AuthenticateImpl: func(_ *auth.Request) *auth.Error {
 				return nil
@@ -808,9 +827,10 @@ func TestAuthError(t *testing.T) {
 	n := 0
 
 	api := API{
-		Address:     "localhost:9997",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Conf:        cnf,
+		Address:      "localhost:9997",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Conf:         cnf,
 		AuthManager: &test.AuthManager{
 			AuthenticateImpl: func(req *auth.Request) *auth.Error {
 				if req.Credentials.User == "" {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -316,6 +316,7 @@ func (p *Core) createResources(initial bool) error {
 			AllowOrigin:    p.conf.MetricsAllowOrigin,
 			TrustedProxies: p.conf.MetricsTrustedProxies,
 			ReadTimeout:    p.conf.ReadTimeout,
+			WriteTimeout:   p.conf.WriteTimeout,
 			AuthManager:    p.authManager,
 			Parent:         p,
 		}
@@ -336,6 +337,7 @@ func (p *Core) createResources(initial bool) error {
 			AllowOrigin:    p.conf.PPROFAllowOrigin,
 			TrustedProxies: p.conf.PPROFTrustedProxies,
 			ReadTimeout:    p.conf.ReadTimeout,
+			WriteTimeout:   p.conf.WriteTimeout,
 			AuthManager:    p.authManager,
 			Parent:         p,
 		}
@@ -365,6 +367,7 @@ func (p *Core) createResources(initial bool) error {
 			AllowOrigin:    p.conf.PlaybackAllowOrigin,
 			TrustedProxies: p.conf.PlaybackTrustedProxies,
 			ReadTimeout:    p.conf.ReadTimeout,
+			WriteTimeout:   p.conf.WriteTimeout,
 			PathConfs:      p.conf.Paths,
 			AuthManager:    p.authManager,
 			Parent:         p,
@@ -548,6 +551,7 @@ func (p *Core) createResources(initial bool) error {
 			SegmentMaxSize:  p.conf.HLSSegmentMaxSize,
 			Directory:       p.conf.HLSDirectory,
 			ReadTimeout:     p.conf.ReadTimeout,
+			WriteTimeout:    p.conf.WriteTimeout,
 			MuxerCloseAfter: p.conf.HLSMuxerCloseAfter,
 			Metrics:         p.metrics,
 			PathManager:     p.pathManager,
@@ -570,6 +574,7 @@ func (p *Core) createResources(initial bool) error {
 			AllowOrigin:           p.conf.WebRTCAllowOrigin,
 			TrustedProxies:        p.conf.WebRTCTrustedProxies,
 			ReadTimeout:           p.conf.ReadTimeout,
+			WriteTimeout:          p.conf.WriteTimeout,
 			LocalUDPAddress:       p.conf.WebRTCLocalUDPAddress,
 			LocalTCPAddress:       p.conf.WebRTCLocalTCPAddress,
 			IPsFromInterfaces:     p.conf.WebRTCIPsFromInterfaces,
@@ -626,6 +631,7 @@ func (p *Core) createResources(initial bool) error {
 			AllowOrigin:    p.conf.APIAllowOrigin,
 			TrustedProxies: p.conf.APITrustedProxies,
 			ReadTimeout:    p.conf.ReadTimeout,
+			WriteTimeout:   p.conf.WriteTimeout,
 			Conf:           p.conf,
 			AuthManager:    p.authManager,
 			PathManager:    p.pathManager,
@@ -687,6 +693,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.MetricsAllowOrigin != p.conf.MetricsAllowOrigin ||
 		!reflect.DeepEqual(newConf.MetricsTrustedProxies, p.conf.MetricsTrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
+		newConf.WriteTimeout != p.conf.WriteTimeout ||
 		closeAuthManager ||
 		closeLogger
 
@@ -699,6 +706,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.PPROFAllowOrigin != p.conf.PPROFAllowOrigin ||
 		!reflect.DeepEqual(newConf.PPROFTrustedProxies, p.conf.PPROFTrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
+		newConf.WriteTimeout != p.conf.WriteTimeout ||
 		closeAuthManager ||
 		closeLogger
 
@@ -718,6 +726,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.PlaybackAllowOrigin != p.conf.PlaybackAllowOrigin ||
 		!reflect.DeepEqual(newConf.PlaybackTrustedProxies, p.conf.PlaybackTrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
+		newConf.WriteTimeout != p.conf.WriteTimeout ||
 		closeAuthManager ||
 		closeLogger
 	if !closePlaybackServer && p.playbackServer != nil && !reflect.DeepEqual(newConf.Paths, p.conf.Paths) {
@@ -828,6 +837,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.HLSSegmentMaxSize != p.conf.HLSSegmentMaxSize ||
 		newConf.HLSDirectory != p.conf.HLSDirectory ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
+		newConf.WriteTimeout != p.conf.WriteTimeout ||
 		newConf.HLSMuxerCloseAfter != p.conf.HLSMuxerCloseAfter ||
 		closePathManager ||
 		closeMetrics ||
@@ -842,6 +852,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.WebRTCAllowOrigin != p.conf.WebRTCAllowOrigin ||
 		!reflect.DeepEqual(newConf.WebRTCTrustedProxies, p.conf.WebRTCTrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
+		newConf.WriteTimeout != p.conf.WriteTimeout ||
 		newConf.WebRTCLocalUDPAddress != p.conf.WebRTCLocalUDPAddress ||
 		newConf.WebRTCLocalTCPAddress != p.conf.WebRTCLocalTCPAddress ||
 		newConf.WebRTCIPsFromInterfaces != p.conf.WebRTCIPsFromInterfaces ||
@@ -877,6 +888,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.APIAllowOrigin != p.conf.APIAllowOrigin ||
 		!reflect.DeepEqual(newConf.APITrustedProxies, p.conf.APITrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
+		newConf.WriteTimeout != p.conf.WriteTimeout ||
 		closeAuthManager ||
 		closePathManager ||
 		closeRTSPServer ||

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -77,6 +77,7 @@ type Metrics struct {
 	AllowOrigin    string
 	TrustedProxies conf.IPNetworks
 	ReadTimeout    conf.Duration
+	WriteTimeout   conf.Duration
 	AuthManager    metricsAuthManager
 	Parent         metricsParent
 
@@ -103,13 +104,14 @@ func (m *Metrics) Initialize() error {
 	router.GET("/metrics", m.onMetrics)
 
 	m.httpServer = &httpp.Server{
-		Address:     m.Address,
-		ReadTimeout: time.Duration(m.ReadTimeout),
-		Encryption:  m.Encryption,
-		ServerCert:  m.ServerCert,
-		ServerKey:   m.ServerKey,
-		Handler:     router,
-		Parent:      m,
+		Address:      m.Address,
+		ReadTimeout:  time.Duration(m.ReadTimeout),
+		WriteTimeout: time.Duration(m.WriteTimeout),
+		Encryption:   m.Encryption,
+		ServerCert:   m.ServerCert,
+		ServerKey:    m.ServerKey,
+		Handler:      router,
+		Parent:       m,
 	}
 	err := m.httpServer.Initialize()
 	if err != nil {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -191,11 +191,12 @@ func (dummyWebRTCServer) APISessionsKick(uuid.UUID) error {
 
 func TestPreflightRequest(t *testing.T) {
 	m := Metrics{
-		Address:     "localhost:9998",
-		AllowOrigin: "*",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		AuthManager: test.NilAuthManager,
-		Parent:      test.NilLogger,
+		Address:      "localhost:9998",
+		AllowOrigin:  "*",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		AuthManager:  test.NilAuthManager,
+		Parent:       test.NilLogger,
 	}
 	err := m.Initialize()
 	require.NoError(t, err)
@@ -230,9 +231,10 @@ func TestMetrics(t *testing.T) {
 	checked := false
 
 	m := Metrics{
-		Address:     "localhost:9998",
-		AllowOrigin: "*",
-		ReadTimeout: conf.Duration(10 * time.Second),
+		Address:      "localhost:9998",
+		AllowOrigin:  "*",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager: &test.AuthManager{
 			AuthenticateImpl: func(req *auth.Request) *auth.Error {
 				require.Equal(t, conf.AuthActionMetrics, req.Action)
@@ -365,9 +367,10 @@ func TestAuthError(t *testing.T) {
 	n := 0
 
 	m := Metrics{
-		Address:     "localhost:9998",
-		AllowOrigin: "*",
-		ReadTimeout: conf.Duration(10 * time.Second),
+		Address:      "localhost:9998",
+		AllowOrigin:  "*",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager: &test.AuthManager{
 			AuthenticateImpl: func(req *auth.Request) *auth.Error {
 				if req.Credentials.User == "" {
@@ -424,11 +427,12 @@ func TestFilter(t *testing.T) {
 	} {
 		t.Run(ca, func(t *testing.T) {
 			m := Metrics{
-				Address:     "localhost:9998",
-				AllowOrigin: "*",
-				ReadTimeout: conf.Duration(10 * time.Second),
-				AuthManager: test.NilAuthManager,
-				Parent:      test.NilLogger,
+				Address:      "localhost:9998",
+				AllowOrigin:  "*",
+				ReadTimeout:  conf.Duration(10 * time.Second),
+				WriteTimeout: conf.Duration(10 * time.Second),
+				AuthManager:  test.NilAuthManager,
+				Parent:       test.NilLogger,
 			}
 			err := m.Initialize()
 			require.NoError(t, err)

--- a/internal/playback/on_get_test.go
+++ b/internal/playback/on_get_test.go
@@ -244,8 +244,9 @@ func TestOnGet(t *testing.T) {
 			writeSegment2(t, filepath.Join(dir, "mypath", "2008-11-07_11-23-04-500000.mp4"))
 
 			s := &Server{
-				Address:     "127.0.0.1:9996",
-				ReadTimeout: conf.Duration(10 * time.Second),
+				Address:      "127.0.0.1:9996",
+				ReadTimeout:  conf.Duration(10 * time.Second),
+				WriteTimeout: conf.Duration(10 * time.Second),
 				PathConfs: map[string]*conf.Path{
 					"mypath": {
 						Name:       "mypath",
@@ -468,8 +469,9 @@ func TestOnGetDifferentInit(t *testing.T) {
 	writeSegment3(t, filepath.Join(dir, "mypath", "2008-11-07_11-23-02-500000.mp4"))
 
 	s := &Server{
-		Address:     "127.0.0.1:9996",
-		ReadTimeout: conf.Duration(10 * time.Second),
+		Address:      "127.0.0.1:9996",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
 		PathConfs: map[string]*conf.Path{
 			"mypath": {
 				Name:       "mypath",
@@ -546,8 +548,9 @@ func TestOnGetNTPCompensation(t *testing.T) {
 	writeSegment2(t, filepath.Join(dir, "mypath", "2008-11-07_11-23-02-000000.mp4")) // remove 0.5 secs
 
 	s := &Server{
-		Address:     "127.0.0.1:9996",
-		ReadTimeout: conf.Duration(10 * time.Second),
+		Address:      "127.0.0.1:9996",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
 		PathConfs: map[string]*conf.Path{
 			"mypath": {
 				Name:       "mypath",
@@ -732,8 +735,9 @@ func TestOnGetInMiddleOfLastSample(t *testing.T) {
 			}()
 
 			s := &Server{
-				Address:     "127.0.0.1:9996",
-				ReadTimeout: conf.Duration(10 * time.Second),
+				Address:      "127.0.0.1:9996",
+				ReadTimeout:  conf.Duration(10 * time.Second),
+				WriteTimeout: conf.Duration(10 * time.Second),
 				PathConfs: map[string]*conf.Path{
 					"mypath": {
 						Name:       "mypath",
@@ -858,8 +862,9 @@ func TestOnGetBetweenSegments(t *testing.T) {
 			}()
 
 			s := &Server{
-				Address:     "127.0.0.1:9996",
-				ReadTimeout: conf.Duration(10 * time.Second),
+				Address:      "127.0.0.1:9996",
+				ReadTimeout:  conf.Duration(10 * time.Second),
+				WriteTimeout: conf.Duration(10 * time.Second),
 				PathConfs: map[string]*conf.Path{
 					"mypath": {
 						Name:       "mypath",

--- a/internal/playback/on_list_test.go
+++ b/internal/playback/on_list_test.go
@@ -60,8 +60,9 @@ func TestOnList(t *testing.T) {
 			checked := false
 
 			s := &Server{
-				Address:     "127.0.0.1:9996",
-				ReadTimeout: conf.Duration(10 * time.Second),
+				Address:      "127.0.0.1:9996",
+				ReadTimeout:  conf.Duration(10 * time.Second),
+				WriteTimeout: conf.Duration(10 * time.Second),
 				PathConfs: map[string]*conf.Path{
 					"mypath": {
 						Name:       "mypath",
@@ -289,8 +290,9 @@ func TestOnListCachedDuration(t *testing.T) {
 	}()
 
 	s := &Server{
-		Address:     "127.0.0.1:9996",
-		ReadTimeout: conf.Duration(10 * time.Second),
+		Address:      "127.0.0.1:9996",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
 		PathConfs: map[string]*conf.Path{
 			"mypath": {
 				Name:       "mypath",

--- a/internal/playback/server.go
+++ b/internal/playback/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	AllowOrigin    string
 	TrustedProxies conf.IPNetworks
 	ReadTimeout    conf.Duration
+	WriteTimeout   conf.Duration
 	PathConfs      map[string]*conf.Path
 	AuthManager    serverAuthManager
 	Parent         logger.Writer
@@ -46,13 +47,14 @@ func (s *Server) Initialize() error {
 	router.GET("/get", s.onGet)
 
 	s.httpServer = &httpp.Server{
-		Address:     s.Address,
-		ReadTimeout: time.Duration(s.ReadTimeout),
-		Encryption:  s.Encryption,
-		ServerCert:  s.ServerCert,
-		ServerKey:   s.ServerKey,
-		Handler:     router,
-		Parent:      s,
+		Address:      s.Address,
+		ReadTimeout:  time.Duration(s.ReadTimeout),
+		WriteTimeout: time.Duration(s.WriteTimeout),
+		Encryption:   s.Encryption,
+		ServerCert:   s.ServerCert,
+		ServerKey:    s.ServerKey,
+		Handler:      router,
+		Parent:       s,
 	}
 	err := s.httpServer.Initialize()
 	if err != nil {

--- a/internal/playback/server_test.go
+++ b/internal/playback/server_test.go
@@ -17,10 +17,11 @@ import (
 
 func TestPreflightRequest(t *testing.T) {
 	s := &Server{
-		Address:     "127.0.0.1:9996",
-		AllowOrigin: "*",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Parent:      test.NilLogger,
+		Address:      "127.0.0.1:9996",
+		AllowOrigin:  "*",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Parent:       test.NilLogger,
 	}
 	err := s.Initialize()
 	require.NoError(t, err)
@@ -55,8 +56,9 @@ func TestAuthError(t *testing.T) {
 	n := 0
 
 	s := &Server{
-		Address:     "127.0.0.1:9996",
-		ReadTimeout: conf.Duration(10 * time.Second),
+		Address:      "127.0.0.1:9996",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager: &test.AuthManager{
 			AuthenticateImpl: func(req *auth.Request) *auth.Error {
 				if req.Credentials.User == "" {

--- a/internal/pprof/pprof.go
+++ b/internal/pprof/pprof.go
@@ -32,6 +32,7 @@ type PPROF struct {
 	AllowOrigin    string
 	TrustedProxies conf.IPNetworks
 	ReadTimeout    conf.Duration
+	WriteTimeout   conf.Duration
 	AuthManager    pprofAuthManager
 	Parent         pprofParent
 
@@ -49,13 +50,14 @@ func (pp *PPROF) Initialize() error {
 	pprof.Register(router)
 
 	pp.httpServer = &httpp.Server{
-		Address:     pp.Address,
-		ReadTimeout: time.Duration(pp.ReadTimeout),
-		Encryption:  pp.Encryption,
-		ServerCert:  pp.ServerCert,
-		ServerKey:   pp.ServerKey,
-		Handler:     router,
-		Parent:      pp,
+		Address:      pp.Address,
+		ReadTimeout:  time.Duration(pp.ReadTimeout),
+		WriteTimeout: time.Duration(pp.WriteTimeout),
+		Encryption:   pp.Encryption,
+		ServerCert:   pp.ServerCert,
+		ServerKey:    pp.ServerKey,
+		Handler:      router,
+		Parent:       pp,
 	}
 	err := pp.httpServer.Initialize()
 	if err != nil {

--- a/internal/pprof/pprof_test.go
+++ b/internal/pprof/pprof_test.go
@@ -16,10 +16,11 @@ import (
 
 func TestPreflightRequest(t *testing.T) {
 	s := &PPROF{
-		Address:     "127.0.0.1:9999",
-		AllowOrigin: "*",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		Parent:      test.NilLogger,
+		Address:      "127.0.0.1:9999",
+		AllowOrigin:  "*",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		Parent:       test.NilLogger,
 	}
 	err := s.Initialize()
 	require.NoError(t, err)
@@ -54,9 +55,10 @@ func TestPprof(t *testing.T) {
 	checked := false
 
 	s := &PPROF{
-		Address:     "127.0.0.1:9999",
-		AllowOrigin: "*",
-		ReadTimeout: conf.Duration(10 * time.Second),
+		Address:      "127.0.0.1:9999",
+		AllowOrigin:  "*",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager: &test.AuthManager{
 			AuthenticateImpl: func(req *auth.Request) *auth.Error {
 				require.Equal(t, conf.AuthActionPprof, req.Action)
@@ -96,9 +98,10 @@ func TestAuthError(t *testing.T) {
 	n := 0
 
 	s := &PPROF{
-		Address:     "127.0.0.1:9999",
-		AllowOrigin: "*",
-		ReadTimeout: conf.Duration(10 * time.Second),
+		Address:      "127.0.0.1:9999",
+		AllowOrigin:  "*",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager: &test.AuthManager{
 			AuthenticateImpl: func(req *auth.Request) *auth.Error {
 				if req.Credentials.User == "" {

--- a/internal/protocols/httpp/handler_exit_on_panic.go
+++ b/internal/protocols/httpp/handler_exit_on_panic.go
@@ -10,7 +10,7 @@ import (
 // exit when there's a panic inside the HTTP handler.
 // https://github.com/golang/go/issues/16542
 type handlerExitOnPanic struct {
-	http.Handler
+	h http.Handler
 }
 
 func (h *handlerExitOnPanic) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -23,5 +23,5 @@ func (h *handlerExitOnPanic) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			os.Exit(1)
 		}
 	}()
-	h.Handler.ServeHTTP(w, r)
+	h.h.ServeHTTP(w, r)
 }

--- a/internal/protocols/httpp/handler_filter_requests.go
+++ b/internal/protocols/httpp/handler_filter_requests.go
@@ -6,7 +6,7 @@ import (
 
 // reject requests with empty paths.
 type handlerFilterRequests struct {
-	http.Handler
+	h http.Handler
 }
 
 func (h *handlerFilterRequests) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -14,5 +14,5 @@ func (h *handlerFilterRequests) ServeHTTP(w http.ResponseWriter, r *http.Request
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	h.Handler.ServeHTTP(w, r)
+	h.h.ServeHTTP(w, r)
 }

--- a/internal/protocols/httpp/handler_logger.go
+++ b/internal/protocols/httpp/handler_logger.go
@@ -45,7 +45,7 @@ func (w *loggerWriter) dump() string {
 
 // log requests and responses.
 type handlerLogger struct {
-	http.Handler
+	h   http.Handler
 	log logger.Writer
 }
 
@@ -55,7 +55,7 @@ func (h *handlerLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	logw := &loggerWriter{w: w}
 
-	h.Handler.ServeHTTP(logw, r)
+	h.h.ServeHTTP(logw, r)
 
 	h.log.Log(logger.Debug, "[conn %v] [s->c] %s", r.RemoteAddr, logw.dump())
 }

--- a/internal/protocols/httpp/handler_server_header.go
+++ b/internal/protocols/httpp/handler_server_header.go
@@ -6,10 +6,10 @@ import (
 
 // set the Server header.
 type handlerServerHeader struct {
-	http.Handler
+	h http.Handler
 }
 
 func (h *handlerServerHeader) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Server", "mediamtx")
-	h.Handler.ServeHTTP(w, r)
+	h.h.ServeHTTP(w, r)
 }

--- a/internal/protocols/httpp/handler_write_timeout.go
+++ b/internal/protocols/httpp/handler_write_timeout.go
@@ -1,0 +1,44 @@
+package httpp
+
+import (
+	"net/http"
+	"time"
+)
+
+type writeTimeoutWriter struct {
+	w       http.ResponseWriter
+	rc      *http.ResponseController
+	timeout time.Duration
+}
+
+func (w *writeTimeoutWriter) Header() http.Header {
+	return w.w.Header()
+}
+
+func (w *writeTimeoutWriter) Write(p []byte) (int, error) {
+	w.rc.SetWriteDeadline(time.Now().Add(w.timeout)) //nolint:errcheck
+	return w.w.Write(p)
+}
+
+func (w *writeTimeoutWriter) WriteHeader(statusCode int) {
+	w.rc.SetWriteDeadline(time.Now().Add(w.timeout)) //nolint:errcheck
+	w.w.WriteHeader(statusCode)
+}
+
+// apply write deadline before every Write() call.
+// this allows to write long responses, splitted in chunks,
+// without causing timeouts.
+type handlerWriteTimeout struct {
+	h       http.Handler
+	timeout time.Duration
+}
+
+func (h *handlerWriteTimeout) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ww := &writeTimeoutWriter{
+		w:       w,
+		rc:      http.NewResponseController(w),
+		timeout: h.timeout,
+	}
+
+	h.h.ServeHTTP(ww, r)
+}

--- a/internal/protocols/httpp/server_test.go
+++ b/internal/protocols/httpp/server_test.go
@@ -15,9 +15,10 @@ import (
 
 func TestFilterEmptyPath(t *testing.T) {
 	s := &Server{
-		Address:     "localhost:4555",
-		ReadTimeout: 10 * time.Second,
-		Parent:      test.NilLogger,
+		Address:      "localhost:4555",
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		Parent:       test.NilLogger,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
@@ -44,9 +45,10 @@ func TestFilterEmptyPath(t *testing.T) {
 
 func TestUnixSocket(t *testing.T) {
 	s := &Server{
-		Address:     "unix://http.sock",
-		ReadTimeout: 10 * time.Second,
-		Parent:      test.NilLogger,
+		Address:      "unix://http.sock",
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		Parent:       test.NilLogger,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),

--- a/internal/servers/hls/http_server.go
+++ b/internal/servers/hls/http_server.go
@@ -42,6 +42,7 @@ type httpServer struct {
 	allowOrigin    string
 	trustedProxies conf.IPNetworks
 	readTimeout    conf.Duration
+	writeTimeout   conf.Duration
 	pathManager    serverPathManager
 	parent         *Server
 
@@ -57,13 +58,14 @@ func (s *httpServer) initialize() error {
 	router.Use(s.onRequest)
 
 	s.inner = &httpp.Server{
-		Address:     s.address,
-		ReadTimeout: time.Duration(s.readTimeout),
-		Encryption:  s.encryption,
-		ServerCert:  s.serverCert,
-		ServerKey:   s.serverKey,
-		Handler:     router,
-		Parent:      s,
+		Address:      s.address,
+		ReadTimeout:  time.Duration(s.readTimeout),
+		WriteTimeout: time.Duration(s.writeTimeout),
+		Encryption:   s.encryption,
+		ServerCert:   s.serverCert,
+		ServerKey:    s.serverKey,
+		Handler:      router,
+		Parent:       s,
 	}
 	err := s.inner.Initialize()
 	if err != nil {

--- a/internal/servers/hls/server.go
+++ b/internal/servers/hls/server.go
@@ -84,6 +84,7 @@ type Server struct {
 	SegmentMaxSize  conf.StringSize
 	Directory       string
 	ReadTimeout     conf.Duration
+	WriteTimeout    conf.Duration
 	MuxerCloseAfter conf.Duration
 	Metrics         serverMetrics
 	PathManager     serverPathManager
@@ -126,6 +127,7 @@ func (s *Server) Initialize() error {
 		allowOrigin:    s.AllowOrigin,
 		trustedProxies: s.TrustedProxies,
 		readTimeout:    s.ReadTimeout,
+		writeTimeout:   s.WriteTimeout,
 		pathManager:    s.PathManager,
 		parent:         s,
 	}

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -67,11 +67,12 @@ func (pa *dummyPath) RemoveReader(_ defs.PathRemoveReaderReq) {
 
 func TestServerPreflightRequest(t *testing.T) {
 	s := &Server{
-		Address:     "127.0.0.1:8888",
-		AllowOrigin: "*",
-		ReadTimeout: conf.Duration(10 * time.Second),
-		PathManager: &dummyPathManager{},
-		Parent:      test.NilLogger,
+		Address:      "127.0.0.1:8888",
+		AllowOrigin:  "*",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		PathManager:  &dummyPathManager{},
+		Parent:       test.NilLogger,
 	}
 	err := s.Initialize()
 	require.NoError(t, err)
@@ -134,6 +135,7 @@ func TestServerNotFound(t *testing.T) {
 				TrustedProxies:  conf.IPNetworks{},
 				Directory:       "",
 				ReadTimeout:     conf.Duration(10 * time.Second),
+				WriteTimeout:    conf.Duration(10 * time.Second),
 				PathManager:     pm,
 				Parent:          test.NilLogger,
 			}
@@ -224,6 +226,7 @@ func TestServerRead(t *testing.T) {
 					SegmentMaxSize:  50 * 1024 * 1024,
 					TrustedProxies:  conf.IPNetworks{},
 					ReadTimeout:     conf.Duration(10 * time.Second),
+					WriteTimeout:    conf.Duration(10 * time.Second),
 					PathManager:     pm,
 					Parent:          test.NilLogger,
 				}
@@ -315,6 +318,7 @@ func TestServerRead(t *testing.T) {
 					SegmentMaxSize:  50 * 1024 * 1024,
 					TrustedProxies:  conf.IPNetworks{},
 					ReadTimeout:     conf.Duration(10 * time.Second),
+					WriteTimeout:    conf.Duration(10 * time.Second),
 					PathManager:     pm,
 					Parent:          test.NilLogger,
 				}
@@ -441,6 +445,7 @@ func TestServerDirectory(t *testing.T) {
 		TrustedProxies:  conf.IPNetworks{},
 		Directory:       filepath.Join(dir, "mydir"),
 		ReadTimeout:     conf.Duration(10 * time.Second),
+		WriteTimeout:    conf.Duration(10 * time.Second),
 		PathManager:     pm,
 		Parent:          test.NilLogger,
 	}
@@ -493,6 +498,7 @@ func TestServerDynamicAlwaysRemux(t *testing.T) {
 		PartDuration:    conf.Duration(200 * time.Millisecond),
 		SegmentMaxSize:  50 * 1024 * 1024,
 		ReadTimeout:     conf.Duration(10 * time.Second),
+		WriteTimeout:    conf.Duration(10 * time.Second),
 		PathManager:     pm,
 		Parent:          test.NilLogger,
 	}
@@ -518,6 +524,7 @@ func TestAuthError(t *testing.T) {
 		PartDuration:    conf.Duration(200 * time.Millisecond),
 		SegmentMaxSize:  50 * 1024 * 1024,
 		ReadTimeout:     conf.Duration(10 * time.Second),
+		WriteTimeout:    conf.Duration(10 * time.Second),
 		PathManager: &dummyPathManager{
 			findPathConfImpl: func(req defs.PathFindPathConfReq) (*conf.Path, error) {
 				if req.AccessRequest.Credentials.User == "" && req.AccessRequest.Credentials.Pass == "" {

--- a/internal/servers/webrtc/http_server.go
+++ b/internal/servers/webrtc/http_server.go
@@ -79,6 +79,7 @@ type httpServer struct {
 	allowOrigin    string
 	trustedProxies conf.IPNetworks
 	readTimeout    conf.Duration
+	writeTimeout   conf.Duration
 	pathManager    serverPathManager
 	parent         *Server
 
@@ -94,13 +95,14 @@ func (s *httpServer) initialize() error {
 	router.Use(s.onRequest)
 
 	s.inner = &httpp.Server{
-		Address:     s.address,
-		ReadTimeout: time.Duration(s.readTimeout),
-		Encryption:  s.encryption,
-		ServerCert:  s.serverCert,
-		ServerKey:   s.serverKey,
-		Handler:     router,
-		Parent:      s,
+		Address:      s.address,
+		ReadTimeout:  time.Duration(s.readTimeout),
+		WriteTimeout: time.Duration(s.writeTimeout),
+		Encryption:   s.encryption,
+		ServerCert:   s.serverCert,
+		ServerKey:    s.serverKey,
+		Handler:      router,
+		Parent:       s,
 	}
 	err := s.inner.Initialize()
 	if err != nil {

--- a/internal/servers/webrtc/server.go
+++ b/internal/servers/webrtc/server.go
@@ -192,6 +192,7 @@ type Server struct {
 	AllowOrigin           string
 	TrustedProxies        conf.IPNetworks
 	ReadTimeout           conf.Duration
+	WriteTimeout          conf.Duration
 	LocalUDPAddress       string
 	LocalTCPAddress       string
 	IPsFromInterfaces     bool
@@ -254,6 +255,7 @@ func (s *Server) Initialize() error {
 		allowOrigin:    s.AllowOrigin,
 		trustedProxies: s.TrustedProxies,
 		readTimeout:    s.ReadTimeout,
+		writeTimeout:   s.WriteTimeout,
 		pathManager:    s.PathManager,
 		parent:         s,
 	}

--- a/internal/servers/webrtc/server_test.go
+++ b/internal/servers/webrtc/server_test.go
@@ -69,6 +69,7 @@ func initializeTestServer(t *testing.T) *Server {
 		AllowOrigin:           "*",
 		TrustedProxies:        conf.IPNetworks{},
 		ReadTimeout:           conf.Duration(10 * time.Second),
+		WriteTimeout:          conf.Duration(10 * time.Second),
 		LocalUDPAddress:       "127.0.0.1:8887",
 		LocalTCPAddress:       "127.0.0.1:8887",
 		IPsFromInterfaces:     true,
@@ -149,6 +150,7 @@ func TestServerOptionsICEServer(t *testing.T) {
 		Address:               "127.0.0.1:8886",
 		TrustedProxies:        conf.IPNetworks{},
 		ReadTimeout:           conf.Duration(10 * time.Second),
+		WriteTimeout:          conf.Duration(10 * time.Second),
 		LocalUDPAddress:       "127.0.0.1:8887",
 		LocalTCPAddress:       "127.0.0.1:8887",
 		IPsFromInterfaces:     true,
@@ -230,6 +232,7 @@ func TestServerPublish(t *testing.T) {
 		Address:               "127.0.0.1:8886",
 		TrustedProxies:        conf.IPNetworks{},
 		ReadTimeout:           conf.Duration(10 * time.Second),
+		WriteTimeout:          conf.Duration(10 * time.Second),
 		LocalUDPAddress:       "127.0.0.1:8887",
 		LocalTCPAddress:       "127.0.0.1:8887",
 		IPsFromInterfaces:     true,
@@ -512,6 +515,7 @@ func TestServerRead(t *testing.T) {
 			s := &Server{
 				Address:               "127.0.0.1:8886",
 				ReadTimeout:           conf.Duration(10 * time.Second),
+				WriteTimeout:          conf.Duration(10 * time.Second),
 				LocalUDPAddress:       "127.0.0.1:8887",
 				LocalTCPAddress:       "127.0.0.1:8887",
 				IPsFromInterfaces:     true,
@@ -596,6 +600,7 @@ func TestServerReadNotFound(t *testing.T) {
 		Address:               "127.0.0.1:8886",
 		TrustedProxies:        conf.IPNetworks{},
 		ReadTimeout:           conf.Duration(10 * time.Second),
+		WriteTimeout:          conf.Duration(10 * time.Second),
 		LocalUDPAddress:       "127.0.0.1:8887",
 		LocalTCPAddress:       "127.0.0.1:8887",
 		IPsFromInterfaces:     true,
@@ -736,8 +741,9 @@ func TestAuthError(t *testing.T) {
 	n := 0
 
 	s := &Server{
-		Address:     "127.0.0.1:8886",
-		ReadTimeout: conf.Duration(10 * time.Second),
+		Address:      "127.0.0.1:8886",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
 		PathManager: &test.PathManager{
 			FindPathConfImpl: func(req defs.PathFindPathConfReq) (*conf.Path, error) {
 				if req.AccessRequest.Credentials.User == "" && req.AccessRequest.Credentials.Pass == "" {


### PR DESCRIPTION
this prevents zombie connections from piling up.