### PR TITLE
Update 17-start-on-boot.md

### DIFF
--- a/docs/2-usage/17-start-on-boot.md
+++ b/docs/2-usage/17-start-on-boot.md
@@ -11,12 +11,6 @@ sudo mv mediamtx /usr/local/bin/
 sudo mv mediamtx.yml /usr/local/etc/
 ```
 
-Enable a _wait-online_ service:
-
-```sh
-sudo systemctl enable systemd-networkd-wait-online.service
-```
-
 Create a _systemd_ service:
 
 ```sh
@@ -29,6 +23,12 @@ ExecStart=/usr/local/bin/mediamtx /usr/local/etc/mediamtx.yml
 [Install]
 WantedBy=multi-user.target
 EOF
+```
+
+Enable a _wait-online_ service to make sure that _MediaMTX_ is started after network has been properly initialized:
+
+```sh
+sudo systemctl enable systemd-networkd-wait-online.service
 ```
 
 If SELinux is enabled (for instance in case of RedHat, Rocky, CentOS++), add correct security context:

--- a/docs/2-usage/17-start-on-boot.md
+++ b/docs/2-usage/17-start-on-boot.md
@@ -11,12 +11,19 @@ sudo mv mediamtx /usr/local/bin/
 sudo mv mediamtx.yml /usr/local/etc/
 ```
 
+Enable the _network-online_ service:
+
+```sh
+sudo systemctl enable systemd-networkd-wait-online.service
+```
+
 Create a _systemd_ service:
 
 ```sh
 sudo tee /etc/systemd/system/mediamtx.service >/dev/null << EOF
 [Unit]
-Wants=network.target
+After=network-online.target
+Wants=network-online.target
 [Service]
 ExecStart=/usr/local/bin/mediamtx /usr/local/etc/mediamtx.yml
 [Install]

--- a/docs/2-usage/17-start-on-boot.md
+++ b/docs/2-usage/17-start-on-boot.md
@@ -11,7 +11,7 @@ sudo mv mediamtx /usr/local/bin/
 sudo mv mediamtx.yml /usr/local/etc/
 ```
 
-Enable the _network-online_ service:
+Enable a _wait-online_ service:
 
 ```sh
 sudo systemctl enable systemd-networkd-wait-online.service


### PR DESCRIPTION
Updated the startup requirements for the mediamtx daemon to allow WebRTC clients to connect without continual timeouts.