### PR TITLE
estimate absolute timestamp more precisely

### DIFF
--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -377,7 +377,7 @@ func (pa *path) doReloadConf(newConf *conf.Path) {
 }
 
 func (pa *path) doSourceStaticSetReady(req defs.PathSourceStaticSetReadyReq) {
-	err := pa.setReady(req.Desc, req.GenerateRTPPackets)
+	err := pa.setReady(req.Desc, req.GenerateRTPPackets, req.FillNTP)
 	if err != nil {
 		req.Res <- defs.PathSourceStaticSetReadyRes{Err: err}
 		return
@@ -474,7 +474,7 @@ func (pa *path) doAddPublisher(req defs.PathAddPublisherReq) {
 	pa.source = req.Author
 	pa.publisherQuery = req.AccessRequest.Query
 
-	err := pa.setReady(req.Desc, req.GenerateRTPPackets)
+	err := pa.setReady(req.Desc, req.GenerateRTPPackets, req.FillNTP)
 	if err != nil {
 		pa.source = nil
 		req.Res <- defs.PathAddPublisherRes{Err: err}
@@ -684,12 +684,13 @@ func (pa *path) onDemandPublisherStop(reason string) {
 	pa.onDemandPublisherState = pathOnDemandStateInitial
 }
 
-func (pa *path) setReady(desc *description.Session, allocateEncoder bool) error {
+func (pa *path) setReady(desc *description.Session, generateRTPPackets bool, fillNTP bool) error {
 	pa.stream = &stream.Stream{
 		WriteQueueSize:     pa.writeQueueSize,
 		RTPMaxPayloadSize:  pa.rtpMaxPayloadSize,
 		Desc:               desc,
-		GenerateRTPPackets: allocateEncoder,
+		GenerateRTPPackets: generateRTPPackets,
+		FillNTP:            fillNTP,
 		Parent:             pa.source,
 	}
 	err := pa.stream.Initialize()

--- a/internal/defs/path.go
+++ b/internal/defs/path.go
@@ -67,6 +67,7 @@ type PathAddPublisherReq struct {
 	Author             Publisher
 	Desc               *description.Session
 	GenerateRTPPackets bool
+	FillNTP            bool
 	ConfToCompare      *conf.Path
 	AccessRequest      PathAccessRequest
 	Res                chan PathAddPublisherRes
@@ -108,6 +109,7 @@ type PathSourceStaticSetReadyRes struct {
 type PathSourceStaticSetReadyReq struct {
 	Desc               *description.Session
 	GenerateRTPPackets bool
+	FillNTP            bool
 	Res                chan PathSourceStaticSetReadyRes
 }
 

--- a/internal/ntpestimator/estimator.go
+++ b/internal/ntpestimator/estimator.go
@@ -1,0 +1,45 @@
+// Package ntpestimator contains a NTP estimator.
+package ntpestimator
+
+import (
+	"time"
+)
+
+var timeNow = time.Now
+
+func multiplyAndDivide(v, m, d time.Duration) time.Duration {
+	secs := v / d
+	dec := v % d
+	return (secs*m + dec*m/d)
+}
+
+// Estimator is a NTP estimator.
+type Estimator struct {
+	ClockRate int
+
+	refNTP time.Time
+	refPTS int64
+}
+
+var zero = time.Time{}
+
+// Estimate returns estimated NTP.
+func (e *Estimator) Estimate(pts int64) time.Time {
+	now := timeNow()
+
+	if e.refNTP.Equal(zero) {
+		e.refNTP = now
+		e.refPTS = pts
+		return now
+	}
+
+	computed := e.refNTP.Add((multiplyAndDivide(time.Duration(pts-e.refPTS), time.Second, time.Duration(e.ClockRate))))
+
+	if computed.After(now) {
+		e.refNTP = now
+		e.refPTS = pts
+		return now
+	}
+
+	return computed
+}

--- a/internal/ntpestimator/estimator_test.go
+++ b/internal/ntpestimator/estimator_test.go
@@ -1,0 +1,32 @@
+package ntpestimator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimator(t *testing.T) {
+	e := &Estimator{ClockRate: 90000}
+
+	timeNow = func() time.Time { return time.Date(2003, 11, 4, 23, 15, 7, 0, time.UTC) }
+	ntp := e.Estimate(90000)
+	require.Equal(t, time.Date(2003, 11, 4, 23, 15, 7, 0, time.UTC), ntp)
+
+	timeNow = func() time.Time { return time.Date(2003, 11, 4, 23, 15, 8, 0, time.UTC) }
+	ntp = e.Estimate(2 * 90000)
+	require.Equal(t, time.Date(2003, 11, 4, 23, 15, 8, 0, time.UTC), ntp)
+
+	timeNow = func() time.Time { return time.Date(2003, 11, 4, 23, 15, 10, 0, time.UTC) }
+	ntp = e.Estimate(3 * 90000)
+	require.Equal(t, time.Date(2003, 11, 4, 23, 15, 9, 0, time.UTC), ntp)
+
+	timeNow = func() time.Time { return time.Date(2003, 11, 4, 23, 15, 9, 0, time.UTC) }
+	ntp = e.Estimate(4 * 90000)
+	require.Equal(t, time.Date(2003, 11, 4, 23, 15, 9, 0, time.UTC), ntp)
+
+	timeNow = func() time.Time { return time.Date(2003, 11, 4, 23, 15, 15, 0, time.UTC) }
+	ntp = e.Estimate(5 * 90000)
+	require.Equal(t, time.Date(2003, 11, 4, 23, 15, 10, 0, time.UTC), ntp)
+}

--- a/internal/protocols/mpegts/to_stream.go
+++ b/internal/protocols/mpegts/to_stream.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	"github.com/bluenviron/gortsplib/v5/pkg/format"
@@ -24,7 +23,7 @@ var errNoSupportedCodecs = errors.New(
 // ToStream maps a MPEG-TS stream to a MediaMTX stream.
 func ToStream(
 	r *EnhancedReader,
-	stream **stream.Stream,
+	strm **stream.Stream,
 	l logger.Writer,
 ) ([]*description.Media, error) {
 	var medias []*description.Media //nolint:prealloc
@@ -48,8 +47,7 @@ func ToStream(
 			r.OnDataH265(track, func(pts int64, _ int64, au [][]byte) error {
 				pts = td.Decode(pts)
 
-				(*stream).WriteUnit(medi, medi.Formats[0], &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, medi.Formats[0], &unit.Unit{
 					PTS:     pts, // no conversion is needed since clock rate is 90khz in both MPEG-TS and RTSP
 					Payload: unit.PayloadH265(au),
 				})
@@ -68,8 +66,7 @@ func ToStream(
 			r.OnDataH264(track, func(pts int64, _ int64, au [][]byte) error {
 				pts = td.Decode(pts)
 
-				(*stream).WriteUnit(medi, medi.Formats[0], &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, medi.Formats[0], &unit.Unit{
 					PTS:     pts, // no conversion is needed since clock rate is 90khz in both MPEG-TS and RTSP
 					Payload: unit.PayloadH264(au),
 				})
@@ -87,8 +84,7 @@ func ToStream(
 			r.OnDataMPEGxVideo(track, func(pts int64, frame []byte) error {
 				pts = td.Decode(pts)
 
-				(*stream).WriteUnit(medi, medi.Formats[0], &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, medi.Formats[0], &unit.Unit{
 					PTS:     pts, // no conversion is needed since clock rate is 90khz in both MPEG-TS and RTSP
 					Payload: unit.PayloadMPEG4Video(frame),
 				})
@@ -104,8 +100,7 @@ func ToStream(
 			r.OnDataMPEGxVideo(track, func(pts int64, frame []byte) error {
 				pts = td.Decode(pts)
 
-				(*stream).WriteUnit(medi, medi.Formats[0], &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, medi.Formats[0], &unit.Unit{
 					PTS:     pts, // no conversion is needed since clock rate is 90khz in both MPEG-TS and RTSP
 					Payload: unit.PayloadMPEG1Video(frame),
 				})
@@ -124,8 +119,7 @@ func ToStream(
 			r.OnDataOpus(track, func(pts int64, packets [][]byte) error {
 				pts = td.Decode(pts)
 
-				(*stream).WriteUnit(medi, medi.Formats[0], &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, medi.Formats[0], &unit.Unit{
 					PTS:     multiplyAndDivide(pts, int64(medi.Formats[0].ClockRate()), 90000),
 					Payload: unit.PayloadOpus(packets),
 				})
@@ -142,8 +136,7 @@ func ToStream(
 			r.OnDataKLV(track, func(pts int64, uni []byte) error {
 				pts = td.Decode(pts)
 
-				(*stream).WriteUnit(medi, medi.Formats[0], &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, medi.Formats[0], &unit.Unit{
 					PTS:     pts,
 					Payload: unit.PayloadKLV(uni),
 				})
@@ -165,8 +158,7 @@ func ToStream(
 			r.OnDataMPEG4Audio(track, func(pts int64, aus [][]byte) error {
 				pts = td.Decode(pts)
 
-				(*stream).WriteUnit(medi, medi.Formats[0], &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, medi.Formats[0], &unit.Unit{
 					PTS:     multiplyAndDivide(pts, int64(medi.Formats[0].ClockRate()), 90000),
 					Payload: unit.PayloadMPEG4Audio(aus),
 				})
@@ -217,8 +209,7 @@ func ToStream(
 						return err
 					}
 
-					(*stream).WriteUnit(medi, medi.Formats[0], &unit.Unit{
-						NTP:     time.Now(),
+					(*strm).WriteUnit(medi, medi.Formats[0], &unit.Unit{
 						PTS:     pts,
 						Payload: unit.PayloadMPEG4AudioLATM(buf),
 					})
@@ -238,8 +229,7 @@ func ToStream(
 			r.OnDataMPEG1Audio(track, func(pts int64, frames [][]byte) error {
 				pts = td.Decode(pts)
 
-				(*stream).WriteUnit(medi, medi.Formats[0], &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, medi.Formats[0], &unit.Unit{
 					PTS:     pts, // no conversion is needed since clock rate is 90khz in both MPEG-TS and RTSP
 					Payload: unit.PayloadMPEG1Audio(frames),
 				})
@@ -259,8 +249,7 @@ func ToStream(
 			r.OnDataAC3(track, func(pts int64, frame []byte) error {
 				pts = td.Decode(pts)
 
-				(*stream).WriteUnit(medi, medi.Formats[0], &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, medi.Formats[0], &unit.Unit{
 					PTS:     multiplyAndDivide(pts, int64(medi.Formats[0].ClockRate()), 90000),
 					Payload: unit.PayloadAC3{frame},
 				})

--- a/internal/protocols/rtmp/from_stream.go
+++ b/internal/protocols/rtmp/from_stream.go
@@ -267,8 +267,6 @@ func FromStream(
 				}
 
 			case *format.MPEG1Audio:
-				// TODO: check sample rate and layer,
-				// unfortunately they are not available at this stage.
 				r.OnData(
 					media,
 					forma,

--- a/internal/protocols/rtmp/to_stream.go
+++ b/internal/protocols/rtmp/to_stream.go
@@ -31,7 +31,10 @@ func fourCCToString(c message.FourCC) string {
 }
 
 // ToStream maps a RTMP stream to a MediaMTX stream.
-func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media, error) {
+func ToStream(
+	r *gortmplib.Reader,
+	strm **stream.Stream,
+) ([]*description.Media, error) {
 	var medias []*description.Media
 
 	for _, track := range r.Tracks() {
@@ -46,8 +49,7 @@ func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media
 			medias = append(medias, medi)
 
 			r.OnDataAV1(ttrack, func(pts time.Duration, tu [][]byte) {
-				(*stream).WriteUnit(medi, ctrack, &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, ctrack, &unit.Unit{
 					PTS:     durationToTimestamp(pts, ctrack.ClockRate()),
 					Payload: unit.PayloadAV1(tu),
 				})
@@ -61,8 +63,7 @@ func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media
 			medias = append(medias, medi)
 
 			r.OnDataVP9(ttrack, func(pts time.Duration, frame []byte) {
-				(*stream).WriteUnit(medi, ctrack, &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, ctrack, &unit.Unit{
 					PTS:     durationToTimestamp(pts, ctrack.ClockRate()),
 					Payload: unit.PayloadVP9(frame),
 				})
@@ -76,8 +77,7 @@ func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media
 			medias = append(medias, medi)
 
 			r.OnDataH265(ttrack, func(pts time.Duration, _ time.Duration, au [][]byte) {
-				(*stream).WriteUnit(medi, ctrack, &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, ctrack, &unit.Unit{
 					PTS:     durationToTimestamp(pts, ctrack.ClockRate()),
 					Payload: unit.PayloadH265(au),
 				})
@@ -91,8 +91,7 @@ func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media
 			medias = append(medias, medi)
 
 			r.OnDataH264(ttrack, func(pts time.Duration, _ time.Duration, au [][]byte) {
-				(*stream).WriteUnit(medi, ctrack, &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, ctrack, &unit.Unit{
 					PTS:     durationToTimestamp(pts, ctrack.ClockRate()),
 					Payload: unit.PayloadH264(au),
 				})
@@ -106,8 +105,7 @@ func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media
 			medias = append(medias, medi)
 
 			r.OnDataOpus(ttrack, func(pts time.Duration, packet []byte) {
-				(*stream).WriteUnit(medi, ctrack, &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, ctrack, &unit.Unit{
 					PTS:     durationToTimestamp(pts, ctrack.ClockRate()),
 					Payload: unit.PayloadOpus{packet},
 				})
@@ -121,8 +119,7 @@ func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media
 			medias = append(medias, medi)
 
 			r.OnDataMPEG4Audio(ttrack, func(pts time.Duration, au []byte) {
-				(*stream).WriteUnit(medi, ctrack, &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, ctrack, &unit.Unit{
 					PTS:     durationToTimestamp(pts, ctrack.ClockRate()),
 					Payload: unit.PayloadMPEG4Audio{au},
 				})
@@ -136,8 +133,7 @@ func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media
 			medias = append(medias, medi)
 
 			r.OnDataMPEG1Audio(ttrack, func(pts time.Duration, frame []byte) {
-				(*stream).WriteUnit(medi, ctrack, &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, ctrack, &unit.Unit{
 					PTS:     durationToTimestamp(pts, ctrack.ClockRate()),
 					Payload: unit.PayloadMPEG1Audio{frame},
 				})
@@ -151,8 +147,7 @@ func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media
 			medias = append(medias, medi)
 
 			r.OnDataAC3(ttrack, func(pts time.Duration, frame []byte) {
-				(*stream).WriteUnit(medi, ctrack, &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, ctrack, &unit.Unit{
 					PTS:     durationToTimestamp(pts, ctrack.ClockRate()),
 					Payload: unit.PayloadAC3{frame},
 				})
@@ -166,8 +161,7 @@ func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media
 			medias = append(medias, medi)
 
 			r.OnDataG711(ttrack, func(pts time.Duration, samples []byte) {
-				(*stream).WriteUnit(medi, ctrack, &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, ctrack, &unit.Unit{
 					PTS:     durationToTimestamp(pts, ctrack.ClockRate()),
 					Payload: unit.PayloadG711(samples),
 				})
@@ -181,8 +175,7 @@ func ToStream(r *gortmplib.Reader, stream **stream.Stream) ([]*description.Media
 			medias = append(medias, medi)
 
 			r.OnDataLPCM(ttrack, func(pts time.Duration, samples []byte) {
-				(*stream).WriteUnit(medi, ctrack, &unit.Unit{
-					NTP:     time.Now(),
+				(*strm).WriteUnit(medi, ctrack, &unit.Unit{
 					PTS:     durationToTimestamp(pts, ctrack.ClockRate()),
 					Payload: unit.PayloadLPCM(samples),
 				})

--- a/internal/protocols/rtsp/to_stream.go
+++ b/internal/protocols/rtsp/to_stream.go
@@ -49,7 +49,7 @@ func ToStream(
 			handleNTP := func(pkt *rtp.Packet) (time.Time, bool) {
 				switch ntpStat {
 				case ntpStateReplace:
-					return time.Now(), true
+					return time.Time{}, true
 
 				case ntpStateInitial:
 					ntp, avail := source.PacketNTP(cmedi, pkt)

--- a/internal/protocols/webrtc/from_stream_test.go
+++ b/internal/protocols/webrtc/from_stream_test.go
@@ -182,7 +182,7 @@ func TestFromStreamResampleOpus(t *testing.T) {
 	n := 0
 	var ts uint32
 
-	tracks[0].OnPacketRTP = func(pkt *rtp.Packet, _ time.Time) {
+	tracks[0].OnPacketRTP = func(pkt *rtp.Packet) {
 		n++
 
 		switch n {

--- a/internal/protocols/webrtc/peer_connection.go
+++ b/internal/protocols/webrtc/peer_connection.go
@@ -144,7 +144,6 @@ type PeerConnection struct {
 	STUNGatherTimeout     conf.Duration
 	Publish               bool
 	OutgoingTracks        []*OutgoingTrack
-	UseAbsoluteTimestamp  bool
 	Log                   logger.Writer
 
 	wr                 *webrtc.PeerConnection
@@ -698,13 +697,12 @@ func (co *PeerConnection) GatherIncomingTracks() error {
 
 		case pair := <-co.incomingTrack:
 			t := &IncomingTrack{
-				useAbsoluteTimestamp: co.UseAbsoluteTimestamp,
-				track:                pair.track,
-				receiver:             pair.receiver,
-				writeRTCP:            co.wr.WriteRTCP,
-				log:                  co.Log,
-				rtpPacketsReceived:   co.rtpPacketsReceived,
-				rtpPacketsLost:       co.rtpPacketsLost,
+				track:              pair.track,
+				receiver:           pair.receiver,
+				writeRTCP:          co.wr.WriteRTCP,
+				log:                co.Log,
+				rtpPacketsReceived: co.rtpPacketsReceived,
+				rtpPacketsLost:     co.rtpPacketsLost,
 			}
 			t.initialize()
 			co.incomingTracks = append(co.incomingTracks, t)

--- a/internal/protocols/webrtc/to_stream_test.go
+++ b/internal/protocols/webrtc/to_stream_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestToStreamNoSupportedCodecs(t *testing.T) {
 	pc := &PeerConnection{}
-	_, err := ToStream(pc, nil)
+	_, err := ToStream(pc, &conf.Path{}, nil, nil)
 	require.Equal(t, errNoSupportedCodecsTo, err)
 }
 
@@ -406,7 +406,7 @@ func TestToStream(t *testing.T) {
 			require.NoError(t, err)
 
 			var stream *stream.Stream
-			medias, err := ToStream(pc2, &stream)
+			medias, err := ToStream(pc2, &conf.Path{}, &stream, nil)
 			require.NoError(t, err)
 			require.Equal(t, ca.out, medias[0].Formats[0])
 		})

--- a/internal/protocols/whip/client.go
+++ b/internal/protocols/whip/client.go
@@ -26,12 +26,11 @@ const (
 
 // Client is a WHIP client.
 type Client struct {
-	URL                  *url.URL
-	Publish              bool
-	OutgoingTracks       []*webrtc.OutgoingTrack
-	HTTPClient           *http.Client
-	UseAbsoluteTimestamp bool
-	Log                  logger.Writer
+	URL            *url.URL
+	Publish        bool
+	OutgoingTracks []*webrtc.OutgoingTrack
+	HTTPClient     *http.Client
+	Log            logger.Writer
 
 	pc               *webrtc.PeerConnection
 	patchIsSupported bool
@@ -45,15 +44,14 @@ func (c *Client) Initialize(ctx context.Context) error {
 	}
 
 	c.pc = &webrtc.PeerConnection{
-		LocalRandomUDP:       true,
-		ICEServers:           iceServers,
-		IPsFromInterfaces:    true,
-		HandshakeTimeout:     conf.Duration(10 * time.Second),
-		TrackGatherTimeout:   conf.Duration(2 * time.Second),
-		Publish:              c.Publish,
-		OutgoingTracks:       c.OutgoingTracks,
-		UseAbsoluteTimestamp: c.UseAbsoluteTimestamp,
-		Log:                  c.Log,
+		LocalRandomUDP:     true,
+		ICEServers:         iceServers,
+		IPsFromInterfaces:  true,
+		HandshakeTimeout:   conf.Duration(10 * time.Second),
+		TrackGatherTimeout: conf.Duration(2 * time.Second),
+		Publish:            c.Publish,
+		OutgoingTracks:     c.OutgoingTracks,
+		Log:                c.Log,
 	}
 	err = c.pc.Start()
 	if err != nil {

--- a/internal/protocols/whip/client_test.go
+++ b/internal/protocols/whip/client_test.go
@@ -225,7 +225,7 @@ func TestClientRead(t *testing.T) {
 
 			for i, track := range cl.IncomingTracks() {
 				ci := i
-				track.OnPacketRTP = func(_ *rtp.Packet, _ time.Time) {
+				track.OnPacketRTP = func(_ *rtp.Packet) {
 					close(recv[ci])
 				}
 			}
@@ -340,7 +340,7 @@ func TestClientPublish(t *testing.T) {
 
 							for i, track := range pc.IncomingTracks() {
 								ci := i
-								track.OnPacketRTP = func(_ *rtp.Packet, _ time.Time) {
+								track.OnPacketRTP = func(_ *rtp.Packet) {
 									close(recv[ci])
 								}
 							}

--- a/internal/servers/rtmp/conn.go
+++ b/internal/servers/rtmp/conn.go
@@ -242,6 +242,7 @@ func (c *conn) runPublish() error {
 		Author:             c,
 		Desc:               &description.Session{Medias: medias},
 		GenerateRTPPackets: true,
+		FillNTP:            true,
 		AccessRequest: defs.PathAccessRequest{
 			Name:    pathName,
 			Query:   c.rconn.URL.RawQuery,

--- a/internal/servers/rtsp/session.go
+++ b/internal/servers/rtsp/session.go
@@ -311,6 +311,7 @@ func (s *session) onRecord(_ *gortsplib.ServerHandlerOnRecordCtx) (*base.Respons
 		Author:             s,
 		Desc:               s.rsession.AnnouncedDescription(),
 		GenerateRTPPackets: false,
+		FillNTP:            !s.pathConf.UseAbsoluteTimestamp,
 		ConfToCompare:      s.pathConf,
 		AccessRequest: defs.PathAccessRequest{
 			Name:     s.rsession.Path()[1:],

--- a/internal/servers/srt/conn.go
+++ b/internal/servers/srt/conn.go
@@ -225,6 +225,7 @@ func (c *conn) runPublishReader(sconn srt.Conn, streamID *streamID, pathConf *co
 		Author:             c,
 		Desc:               &description.Session{Medias: medias},
 		GenerateRTPPackets: true,
+		FillNTP:            true,
 		ConfToCompare:      pathConf,
 		AccessRequest: defs.PathAccessRequest{
 			Name:     streamID.path,

--- a/internal/servers/webrtc/server_test.go
+++ b/internal/servers/webrtc/server_test.go
@@ -567,7 +567,7 @@ func TestServerRead(t *testing.T) {
 
 			done := make(chan struct{})
 
-			wc.IncomingTracks()[0].OnPacketRTP = func(pkt *rtp.Packet, _ time.Time) {
+			wc.IncomingTracks()[0].OnPacketRTP = func(pkt *rtp.Packet) {
 				select {
 				case <-done:
 				default:

--- a/internal/servers/webrtc/session.go
+++ b/internal/servers/webrtc/session.go
@@ -168,7 +168,6 @@ func (s *session) runPublish() (int, error) {
 		TrackGatherTimeout:    s.trackGatherTimeout,
 		STUNGatherTimeout:     s.stunGatherTimeout,
 		Publish:               false,
-		UseAbsoluteTimestamp:  pathConf.UseAbsoluteTimestamp,
 		Log:                   s,
 	}
 	err = pc.Start()
@@ -234,7 +233,7 @@ func (s *session) runPublish() (int, error) {
 
 	var stream *stream.Stream
 
-	medias, err := webrtc.ToStream(pc, &stream)
+	medias, err := webrtc.ToStream(pc, pathConf, &stream, s)
 	if err != nil {
 		return 0, err
 	}
@@ -244,6 +243,7 @@ func (s *session) runPublish() (int, error) {
 		Author:             s,
 		Desc:               &description.Session{Medias: medias},
 		GenerateRTPPackets: false,
+		FillNTP:            !pathConf.UseAbsoluteTimestamp,
 		ConfToCompare:      pathConf,
 		AccessRequest: defs.PathAccessRequest{
 			Name:     s.req.pathName,
@@ -312,7 +312,6 @@ func (s *session) runRead() (int, error) {
 		TrackGatherTimeout:    s.trackGatherTimeout,
 		STUNGatherTimeout:     s.stunGatherTimeout,
 		Publish:               true,
-		UseAbsoluteTimestamp:  path.SafeConf().UseAbsoluteTimestamp,
 		Log:                   s,
 	}
 

--- a/internal/staticsources/mpegts/source.go
+++ b/internal/staticsources/mpegts/source.go
@@ -120,6 +120,7 @@ func (s *Source) runReader(nc net.Conn) error {
 	res := s.Parent.SetReady(defs.PathSourceStaticSetReadyReq{
 		Desc:               &description.Session{Medias: medias},
 		GenerateRTPPackets: true,
+		FillNTP:            true,
 	})
 	if res.Err != nil {
 		return res.Err

--- a/internal/staticsources/rtmp/source.go
+++ b/internal/staticsources/rtmp/source.go
@@ -117,6 +117,7 @@ func (s *Source) runReader(ctx context.Context, u *url.URL, fingerprint string) 
 	res := s.Parent.SetReady(defs.PathSourceStaticSetReadyReq{
 		Desc:               &description.Session{Medias: medias},
 		GenerateRTPPackets: true,
+		FillNTP:            true,
 	})
 	if res.Err != nil {
 		conn.Close()

--- a/internal/staticsources/rtp/source.go
+++ b/internal/staticsources/rtp/source.go
@@ -149,6 +149,7 @@ func (s *Source) runReader(desc *description.Session, nc net.Conn) error {
 			res := s.Parent.SetReady(defs.PathSourceStaticSetReadyReq{
 				Desc:               desc,
 				GenerateRTPPackets: false,
+				FillNTP:            true,
 			})
 			if res.Err != nil {
 				return res.Err
@@ -171,7 +172,7 @@ func (s *Source) runReader(desc *description.Session, nc net.Conn) error {
 			continue
 		}
 
-		stream.WriteRTPPacket(media, forma, &pkt, time.Now(), pts)
+		stream.WriteRTPPacket(media, forma, &pkt, time.Time{}, pts)
 	}
 }
 

--- a/internal/staticsources/rtsp/source.go
+++ b/internal/staticsources/rtsp/source.go
@@ -195,6 +195,7 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 			res := s.Parent.SetReady(defs.PathSourceStaticSetReadyReq{
 				Desc:               desc,
 				GenerateRTPPackets: false,
+				FillNTP:            !params.Conf.UseAbsoluteTimestamp,
 			})
 			if res.Err != nil {
 				return res.Err

--- a/internal/staticsources/srt/source.go
+++ b/internal/staticsources/srt/source.go
@@ -111,6 +111,7 @@ func (s *Source) runReader(sconn srt.Conn) error {
 	res := s.Parent.SetReady(defs.PathSourceStaticSetReadyReq{
 		Desc:               &description.Session{Medias: medias},
 		GenerateRTPPackets: true,
+		FillNTP:            true,
 	})
 	if res.Err != nil {
 		return res.Err

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -23,6 +23,7 @@ type Stream struct {
 	RTPMaxPayloadSize  int
 	Desc               *description.Session
 	GenerateRTPPackets bool
+	FillNTP            bool
 	Parent             logger.Writer
 
 	bytesReceived    *uint64
@@ -61,6 +62,7 @@ func (s *Stream) Initialize() error {
 			rtpMaxPayloadSize:  s.RTPMaxPayloadSize,
 			media:              media,
 			generateRTPPackets: s.GenerateRTPPackets,
+			fillNTP:            s.FillNTP,
 			processingErrors:   s.processingErrors,
 			parent:             s.Parent,
 		}

--- a/internal/stream/stream_media.go
+++ b/internal/stream/stream_media.go
@@ -11,6 +11,7 @@ type streamMedia struct {
 	rtpMaxPayloadSize  int
 	media              *description.Media
 	generateRTPPackets bool
+	fillNTP            bool
 	processingErrors   *counterdumper.CounterDumper
 	parent             logger.Writer
 
@@ -25,6 +26,7 @@ func (sm *streamMedia) initialize() error {
 			rtpMaxPayloadSize:  sm.rtpMaxPayloadSize,
 			format:             forma,
 			generateRTPPackets: sm.generateRTPPackets,
+			fillNTP:            sm.fillNTP,
 			processingErrors:   sm.processingErrors,
 			parent:             sm.parent,
 		}


### PR DESCRIPTION
When the absolute timestamp of incoming frames was not available, it
was filled with the current timestamp, which is influenced by latency
over time.
    
This mechanism is replaced by an algorithm that detects when latency is
the lowest, stores the current timestamp and uses it as reference
throughout the rest of the stream.