### PR TITLE
recorder: reset fMP4 sequence number during segment switch

### DIFF
--- a/internal/recorder/format_fmp4.go
+++ b/internal/recorder/format_fmp4.go
@@ -101,10 +101,9 @@ func jpegExtractSize(image []byte) (int, int, error) {
 type formatFMP4 struct {
 	ri *recorderInstance
 
-	tracks             []*formatFMP4Track
-	hasVideo           bool
-	currentSegment     *formatFMP4Segment
-	nextSequenceNumber uint32
+	tracks         []*formatFMP4Track
+	hasVideo       bool
+	currentSegment *formatFMP4Segment
 }
 
 func (f *formatFMP4) initialize() bool {

--- a/internal/recorder/format_fmp4_segment.go
+++ b/internal/recorder/format_fmp4_segment.go
@@ -103,10 +103,11 @@ type formatFMP4Segment struct {
 	startDTS time.Duration
 	startNTP time.Time
 
-	path    string
-	fi      *os.File
-	curPart *formatFMP4Part
-	endDTS  time.Duration
+	path               string
+	fi                 *os.File
+	curPart            *formatFMP4Part
+	endDTS             time.Duration
+	nextSequenceNumber uint32
 }
 
 func (s *formatFMP4Segment) initialize() {
@@ -152,11 +153,11 @@ func (s *formatFMP4Segment) write(track *formatFMP4Track, sample *sample, dts ti
 	if s.curPart == nil {
 		s.curPart = &formatFMP4Part{
 			s:              s,
-			sequenceNumber: s.f.nextSequenceNumber,
+			sequenceNumber: s.nextSequenceNumber,
 			startDTS:       dts,
 		}
 		s.curPart.initialize()
-		s.f.nextSequenceNumber++
+		s.nextSequenceNumber++
 	} else if s.curPart.duration() >= s.f.ri.partDuration {
 		err := s.curPart.close()
 		s.curPart = nil
@@ -167,11 +168,11 @@ func (s *formatFMP4Segment) write(track *formatFMP4Track, sample *sample, dts ti
 
 		s.curPart = &formatFMP4Part{
 			s:              s,
-			sequenceNumber: s.f.nextSequenceNumber,
+			sequenceNumber: s.nextSequenceNumber,
 			startDTS:       dts,
 		}
 		s.curPart.initialize()
-		s.f.nextSequenceNumber++
+		s.nextSequenceNumber++
 	}
 
 	return s.curPart.write(track, sample, dts)


### PR DESCRIPTION
It's useless to make sequence numbers unique across the entire stream.