### PR TITLE
recorder: write additional infos inside segments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/bluenviron/gohlslib/v2 v2.2.3
 	github.com/bluenviron/gortmplib v0.1.0
 	github.com/bluenviron/gortsplib/v5 v5.0.1
-	github.com/bluenviron/mediacommon/v2 v2.4.3
+	github.com/bluenviron/mediacommon/v2 v2.4.4-0.20251012155238-8c0b4c88a199
 	github.com/datarhei/gosrt v0.9.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-contrib/pprof v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/bluenviron/gortmplib v0.1.0 h1:VtcmOrSsNNmjF5/hFVk/bvNFdairX2+ejhRIZ9
 github.com/bluenviron/gortmplib v0.1.0/go.mod h1:FtII41guzpc9wMhdmZFsIKuC2hXN3yCMRsFlHYp1qQA=
 github.com/bluenviron/gortsplib/v5 v5.0.1 h1:mM3zK1T0WojnAwQTQ/IK3mDnOpy8Yvm11QK7UmB8grk=
 github.com/bluenviron/gortsplib/v5 v5.0.1/go.mod h1:jc0WG8LUa6Kb8lkDbLCJzAFdc/Ek7vM2rlO4VCHhbEQ=
-github.com/bluenviron/mediacommon/v2 v2.4.3 h1:GFXKaMFgnQqbKv+uaAEfmgBZXBBRTtwabVepDowVDtM=
-github.com/bluenviron/mediacommon/v2 v2.4.3/go.mod h1:zy1fODPuS/kBd93ftgJS1Jhvjq7LFWfAo32KP7By9AE=
+github.com/bluenviron/mediacommon/v2 v2.4.4-0.20251012155238-8c0b4c88a199 h1:Ib+Azwbjy02RKurl+QHeKn+ZkLBdOzOFrxkUs425KHU=
+github.com/bluenviron/mediacommon/v2 v2.4.4-0.20251012155238-8c0b4c88a199/go.mod h1:zy1fODPuS/kBd93ftgJS1Jhvjq7LFWfAo32KP7By9AE=
 github.com/bytedance/sonic v1.14.0 h1:/OfKt8HFw0kh2rj8N0F6C/qPGRESq0BbaNZgcNXXzQQ=
 github.com/bytedance/sonic v1.14.0/go.mod h1:WoEbx8WTcFJfzCe0hbmyTGrfjt8PzNEBdxlNUO24NhA=
 github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=

--- a/internal/recorder/format_fmp4.go
+++ b/internal/recorder/format_fmp4.go
@@ -101,9 +101,10 @@ func jpegExtractSize(image []byte) (int, int, error) {
 type formatFMP4 struct {
 	ri *recorderInstance
 
-	tracks         []*formatFMP4Track
-	hasVideo       bool
-	currentSegment *formatFMP4Segment
+	tracks            []*formatFMP4Track
+	hasVideo          bool
+	currentSegment    *formatFMP4Segment
+	nextSegmentNumber uint64
 }
 
 func (f *formatFMP4) initialize() bool {

--- a/internal/recorder/format_fmp4_track.go
+++ b/internal/recorder/format_fmp4_track.go
@@ -67,8 +67,10 @@ func (t *formatFMP4Track) write(sample *sample) error {
 			f:        t.f,
 			startDTS: dts,
 			startNTP: sample.ntp,
+			number:   t.f.nextSegmentNumber,
 		}
 		t.f.currentSegment.initialize()
+		t.f.nextSegmentNumber++
 	} else if (dts - t.f.currentSegment.startDTS) < 0 { // BaseTime is negative, this is not supported by fMP4
 		t.f.ri.Log(logger.Warn, "sample of track %d received too late, discarding", t.initTrack.ID)
 		return nil
@@ -95,8 +97,10 @@ func (t *formatFMP4Track) write(sample *sample) error {
 			f:        t.f,
 			startDTS: oldestDTS,
 			startNTP: oldestNTP,
+			number:   t.f.nextSegmentNumber,
 		}
 		t.f.currentSegment.initialize()
+		t.f.nextSegmentNumber++
 	}
 
 	return nil

--- a/internal/recorder/format_mpegts.go
+++ b/internal/recorder/format_mpegts.go
@@ -468,11 +468,16 @@ func (f *formatMPEGTS) write(
 	switch {
 	case f.currentSegment == nil:
 		f.currentSegment = &formatMPEGTSSegment{
-			f:        f,
-			startDTS: dts,
-			startNTP: ntp,
+			pathFormat2:       f.ri.pathFormat2,
+			flush:             f.bw.Flush,
+			onSegmentCreate:   f.ri.onSegmentCreate,
+			onSegmentComplete: f.ri.onSegmentComplete,
+			startDTS:          dts,
+			startNTP:          ntp,
+			log:               f.ri,
 		}
 		f.currentSegment.initialize()
+		f.dw.setTarget(f.currentSegment)
 	case (!f.hasVideo || isVideo) &&
 		randomAccess &&
 		(dts-f.currentSegment.startDTS) >= f.ri.segmentDuration:
@@ -483,11 +488,16 @@ func (f *formatMPEGTS) write(
 		}
 
 		f.currentSegment = &formatMPEGTSSegment{
-			f:        f,
-			startDTS: dts,
-			startNTP: ntp,
+			pathFormat2:       f.ri.pathFormat2,
+			flush:             f.bw.Flush,
+			onSegmentCreate:   f.ri.onSegmentCreate,
+			onSegmentComplete: f.ri.onSegmentComplete,
+			startDTS:          dts,
+			startNTP:          ntp,
+			log:               f.ri,
 		}
 		f.currentSegment.initialize()
+		f.dw.setTarget(f.currentSegment)
 
 	case (dts - f.currentSegment.lastFlush) >= f.ri.partDuration:
 		err := f.bw.Flush()

--- a/internal/recorder/recorder_instance.go
+++ b/internal/recorder/recorder_instance.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/bluenviron/mediacommon/v2/pkg/formats/fmp4"
+	"github.com/google/uuid"
 
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/logger"
@@ -30,6 +31,7 @@ type recorderInstance struct {
 	onSegmentComplete OnSegmentCompleteFunc
 	parent            logger.Writer
 
+	streamID    uuid.UUID
 	pathFormat2 string
 	format2     format
 	skip        bool
@@ -45,6 +47,7 @@ func (ri *recorderInstance) Log(level logger.Level, format string, args ...inter
 }
 
 func (ri *recorderInstance) initialize() {
+	ri.streamID = uuid.New()
 	ri.pathFormat2 = ri.pathFormat
 	ri.pathFormat2 = recordstore.PathAddExtension(
 		strings.ReplaceAll(ri.pathFormat2, "%path", ri.pathName),

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	amp4 "github.com/abema/go-mp4"
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	rtspformat "github.com/bluenviron/gortsplib/v5/pkg/format"
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/mpeg4audio"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/logger"
+	"github.com/bluenviron/mediamtx/internal/recordstore"
 	"github.com/bluenviron/mediamtx/internal/stream"
 	"github.com/bluenviron/mediamtx/internal/test"
 	"github.com/bluenviron/mediamtx/internal/unit"
@@ -269,6 +271,13 @@ func TestRecorder(t *testing.T) {
 								SampleRate:   44100,
 								ChannelCount: 2,
 							},
+						},
+					},
+					UserData: []amp4.IBox{
+						&recordstore.Mtxi{
+							StreamID: init.UserData[0].(*recordstore.Mtxi).StreamID,
+							DTS:      50000000000,
+							NTP:      1211321725000000000,
 						},
 					},
 				}, init)

--- a/internal/recordstore/mp4_boxes.go
+++ b/internal/recordstore/mp4_boxes.go
@@ -1,0 +1,25 @@
+package recordstore
+
+import (
+	amp4 "github.com/abema/go-mp4"
+)
+
+func boxTypeMtxi() amp4.BoxType { return amp4.StrToBoxType("mtxi") }
+
+func init() { //nolint:gochecknoinits
+	amp4.AddBoxDef(&Mtxi{}, 0)
+}
+
+// Mtxi is a MediaMTX segment info.
+type Mtxi struct {
+	amp4.FullBox  `mp4:"0,extend"`
+	StreamID      [16]byte `mp4:"1,size=8"`
+	SegmentNumber uint64   `mp4:"2,size=64"`
+	DTS           int64    `mp4:"3,size=64"`
+	NTP           int64    `mp4:"4,size=64"`
+}
+
+// GetType implements amp4.IBox.
+func (*Mtxi) GetType() amp4.BoxType {
+	return boxTypeMtxi()
+}


### PR DESCRIPTION
write stream ID, segment number, DTS, NTP in a dedicated box. This
allows to improve the merge algorithm in the playback server.