### PR TITLE
rtmp: fix freeze when reading source

### DIFF
--- a/internal/servers/rtmp/conn.go
+++ b/internal/servers/rtmp/conn.go
@@ -203,7 +203,6 @@ func (c *conn) runRead() error {
 	})
 	defer onUnreadHook()
 
-	// disable read deadline
 	c.nconn.SetReadDeadline(time.Time{})
 
 	strm.AddReader(r)
@@ -274,7 +273,6 @@ func (c *conn) runPublish() error {
 	c.query = c.rconn.URL.RawQuery
 	c.mutex.Unlock()
 
-	// disable write deadline to allow outgoing acknowledges
 	c.nconn.SetWriteDeadline(time.Time{})
 
 	for {


### PR DESCRIPTION
Tracks were read without deadlines, freezing the server if they are not present. This patch also allows to close the server immediately during track reading.