### PR TITLE
recorder: prevent FMP4 durations from overflowing (#4711)

### DIFF
--- a/internal/recorder/format_fmp4_track.go
+++ b/internal/recorder/format_fmp4_track.go
@@ -58,7 +58,14 @@ func (t *formatFMP4Track) write(sample *sample) error {
 	if sample == nil {
 		return nil
 	}
-	sample.Duration = uint32(t.nextSample.dts - sample.dts)
+
+	duration := t.nextSample.dts - sample.dts
+	if duration < 0 {
+		t.nextSample.dts = sample.dts
+		duration = 0
+	}
+
+	sample.Duration = uint32(duration)
 
 	dts := timestampToDuration(sample.dts, int(t.initTrack.TimeScale))
 


### PR DESCRIPTION
Fixes #4711 

The timestamp difference between two samples was put inside an unsigned integer, and, when negative, caused an overflow.