### PR TITLE
feat(api): add support for multiple allowed origins with wildcards

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -144,8 +144,10 @@ components:
           type: string
         metricsServerCert:
           type: string
-        metricsAllowOrigin:
-          type: string
+        metricsAllowOrigins:
+          type: array
+          items:
+            type: string
         metricsTrustedProxies:
           type: array
           items:
@@ -162,8 +164,10 @@ components:
           type: string
         pprofServerCert:
           type: string
-        pprofAllowOrigin:
-          type: string
+        pprofAllowOrigins:
+          type: array
+          items:
+            type: string
         pprofTrustedProxies:
           type: array
           items:
@@ -180,8 +184,10 @@ components:
           type: string
         playbackServerCert:
           type: string
-        playbackAllowOrigin:
-          type: string
+        playbackAllowOrigins:
+          type: array
+          items:
+            type: string
         playbackTrustedProxies:
           type: array
           items:
@@ -256,8 +262,10 @@ components:
           type: string
         hlsServerCert:
           type: string
-        hlsAllowOrigin:
-          type: string
+        hlsAllowOrigins:
+          type: array
+          items:
+            type: string
         hlsTrustedProxies:
           type: array
           items:
@@ -291,8 +299,10 @@ components:
           type: string
         webrtcServerCert:
           type: string
-        webrtcAllowOrigin:
-          type: string
+        webrtcAllowOrigins:
+          type: array
+          items:
+            type: string
         webrtcTrustedProxies:
           type: array
           items:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -124,8 +124,10 @@ components:
           type: string
         apiServerCert:
           type: string
-        apiAllowOrigin:
-          type: string
+        apiAllowOrigins:
+          type: array
+          items:
+            type: string
         apiTrustedProxies:
           type: array
           items:

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -117,98 +116,6 @@ func TestPreflightRequest(t *testing.T) {
 	require.Equal(t, "OPTIONS, GET, POST, PATCH, DELETE", res.Header.Get("Access-Control-Allow-Methods"))
 	require.Equal(t, "Authorization, Content-Type", res.Header.Get("Access-Control-Allow-Headers"))
 	require.Equal(t, byts, []byte{})
-}
-
-func TestMiddlewareOrigin(t *testing.T) {
-	allowOrigins := []string{}
-	origin := ""
-	allowedOrigin, err := isOriginAllowed(origin, allowOrigins)
-	if err == nil {
-		t.Fatalf("expected error for empty origin, got nil")
-	}
-	if allowedOrigin != "" {
-		t.Fatalf("expected empty allowed origin, got %s", allowedOrigin)
-	}
-
-	allowOrigins = []string{"http://example.com"}
-	allowedOrigin, err = isOriginAllowed(origin, allowOrigins)
-	if err == nil {
-		t.Fatalf("expected error for empty origin with allowed origins, got nil")
-	}
-	if allowedOrigin != "" {
-		t.Fatalf("unexpected allowed origin: %s", allowedOrigin)
-	}
-
-	allowOrigins = []string{"*"}
-	allowedOrigin, err = isOriginAllowed(origin, allowOrigins)
-	if err != nil {
-		t.Fatalf("unexpected error for wildcard origin: %v", err)
-	}
-	if allowedOrigin != "*" {
-		t.Fatalf("unexpected allowed origin: %s", allowedOrigin)
-	}
-
-	origin = "http://example.com"
-	allowedOrigin, err = isOriginAllowed(origin, allowOrigins)
-	if err != nil {
-		t.Fatalf("unexpected error for matching wildcard: %v", err)
-	}
-	if allowedOrigin != "*" {
-		t.Fatalf("unexpected allowed origin: %s", allowedOrigin)
-	}
-
-	allowOrigins = []string{"http://example.com", "https://example.org"}
-	allowedOrigin, err = isOriginAllowed(origin, allowOrigins)
-	if err != nil {
-		t.Fatalf("unexpected error for matching origin: %v", err)
-	}
-	if allowedOrigin != origin {
-		t.Fatalf("expected empty allowed origin, got %s", allowedOrigin)
-	}
-
-	allowedOrigin, err = isOriginAllowed(origin, allowOrigins)
-	if err != nil {
-		t.Fatalf("unexpected error for matching origin: %v", err)
-	}
-	if allowedOrigin != origin {
-		t.Fatalf("unexpected allowed origin: %s", allowedOrigin)
-	}
-
-	origin = "https://example.org"
-	allowedOrigin, err = isOriginAllowed(origin, allowOrigins)
-	if err != nil {
-		t.Fatalf("unexpected error for matching origin: %v", err)
-	}
-	if allowedOrigin != origin {
-		t.Fatalf("unexpected allowed origin: %s", allowedOrigin)
-	}
-
-	allowedOrigin, err = isOriginAllowed("http://notallowed.com", allowOrigins)
-	if !errors.Is(err, errOriginNotAllowed) {
-		t.Fatalf("expected errOriginNotAllowed for disallowed origin, got %v", err)
-	}
-	if allowedOrigin != "" {
-		t.Fatalf("expected empty allowed origin, got %s", allowedOrigin)
-	}
-
-	allowOrigins = []string{"http://*.example.com"}
-	origin = "http://test.example.com"
-	allowedOrigin, err = isOriginAllowed(origin, allowOrigins)
-	if err != nil {
-		t.Fatalf("unexpected error for wildcard subdomain: %v", err)
-	}
-	if allowedOrigin != origin {
-		t.Fatalf("unexpected allowed origin: %s", allowedOrigin)
-	}
-
-	origin = "http://example.com"
-	allowedOrigin, err = isOriginAllowed(origin, allowOrigins)
-	if err != nil {
-		t.Fatalf("unexpected error for exact subdomain match: %v", err)
-	}
-	if allowedOrigin != origin {
-		t.Fatalf("unexpected allowed origin: %s", allowedOrigin)
-	}
 }
 
 func TestInfo(t *testing.T) {

--- a/internal/conf/allowed_origins.go
+++ b/internal/conf/allowed_origins.go
@@ -1,3 +1,4 @@
 package conf
 
+// AllowedOrigins is a list of allowed CORS origins.
 type AllowedOrigins []string

--- a/internal/conf/allowed_origins.go
+++ b/internal/conf/allowed_origins.go
@@ -1,0 +1,3 @@
+package conf
+
+type AllowedOrigins []string

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -182,7 +182,8 @@ type Conf struct {
 	APIEncryption     bool       `json:"apiEncryption"`
 	APIServerKey      string     `json:"apiServerKey"`
 	APIServerCert     string     `json:"apiServerCert"`
-	APIAllowOrigin    string     `json:"apiAllowOrigin"`
+	APIAllowOrigin    *string    `json:"apiAllowOrigin,omitempty"` // deprecated
+	APIAllowOrigins   []string   `json:"apiAllowOrigins"`
 	APITrustedProxies IPNetworks `json:"apiTrustedProxies"`
 
 	// Metrics
@@ -340,7 +341,7 @@ func (conf *Conf) setDefaults() {
 	conf.APIAddress = ":9997"
 	conf.APIServerKey = "server.key"
 	conf.APIServerCert = "server.crt"
-	conf.APIAllowOrigin = "*"
+	conf.APIAllowOrigins = []string{"*"}
 
 	// Metrics
 	conf.MetricsAddress = ":9998"
@@ -605,6 +606,13 @@ func (conf *Conf) Validate(l logger.Writer) error {
 		if conf.AuthJWTClaimKey == "" {
 			return fmt.Errorf("'authJWTClaimKey' is empty")
 		}
+	}
+
+	// Control API
+
+	if conf.APIAllowOrigin != nil {
+		l.Log(logger.Warn, "parameter 'apiAllowOrigin' is deprecated and has been replaced with 'apiAllowOrigins'")
+		conf.APIAllowOrigins = []string{*conf.APIAllowOrigin}
 	}
 
 	// RTSP

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -177,44 +177,44 @@ type Conf struct {
 	AuthJWTInHTTPQuery        bool                        `json:"authJWTInHTTPQuery"`
 
 	// Control API
-	API               bool       `json:"api"`
-	APIAddress        string     `json:"apiAddress"`
-	APIEncryption     bool       `json:"apiEncryption"`
-	APIServerKey      string     `json:"apiServerKey"`
-	APIServerCert     string     `json:"apiServerCert"`
-	APIAllowOrigin    *string    `json:"apiAllowOrigin,omitempty"` // deprecated
-	APIAllowOrigins   []string   `json:"apiAllowOrigins"`          // TODO: move in alias
-	APITrustedProxies IPNetworks `json:"apiTrustedProxies"`
+	API               bool           `json:"api"`
+	APIAddress        string         `json:"apiAddress"`
+	APIEncryption     bool           `json:"apiEncryption"`
+	APIServerKey      string         `json:"apiServerKey"`
+	APIServerCert     string         `json:"apiServerCert"`
+	APIAllowOrigin    *string        `json:"apiAllowOrigin,omitempty"` // deprecated
+	APIAllowOrigins   AllowedOrigins `json:"apiAllowOrigins"`
+	APITrustedProxies IPNetworks     `json:"apiTrustedProxies"`
 
 	// Metrics
-	Metrics               bool       `json:"metrics"`
-	MetricsAddress        string     `json:"metricsAddress"`
-	MetricsEncryption     bool       `json:"metricsEncryption"`
-	MetricsServerKey      string     `json:"metricsServerKey"`
-	MetricsServerCert     string     `json:"metricsServerCert"`
-	MetricsAllowOrigin    *string    `json:"metricsAllowOrigin,omitempty"` // deprecated
-	MetricsAllowOrigins   []string   `json:"metricsAllowOrigins"`
-	MetricsTrustedProxies IPNetworks `json:"metricsTrustedProxies"`
+	Metrics               bool           `json:"metrics"`
+	MetricsAddress        string         `json:"metricsAddress"`
+	MetricsEncryption     bool           `json:"metricsEncryption"`
+	MetricsServerKey      string         `json:"metricsServerKey"`
+	MetricsServerCert     string         `json:"metricsServerCert"`
+	MetricsAllowOrigin    *string        `json:"metricsAllowOrigin,omitempty"` // deprecated
+	MetricsAllowOrigins   AllowedOrigins `json:"metricsAllowOrigins"`
+	MetricsTrustedProxies IPNetworks     `json:"metricsTrustedProxies"`
 
 	// PPROF
-	PPROF               bool       `json:"pprof"`
-	PPROFAddress        string     `json:"pprofAddress"`
-	PPROFEncryption     bool       `json:"pprofEncryption"`
-	PPROFServerKey      string     `json:"pprofServerKey"`
-	PPROFServerCert     string     `json:"pprofServerCert"`
-	PPROFAllowOrigin    *string    `json:"pprofAllowOrigin,omitempty"` // deprecated
-	PPROFAllowOrigins   []string   `json:"pprofAllowOrigins"`
-	PPROFTrustedProxies IPNetworks `json:"pprofTrustedProxies"`
+	PPROF               bool           `json:"pprof"`
+	PPROFAddress        string         `json:"pprofAddress"`
+	PPROFEncryption     bool           `json:"pprofEncryption"`
+	PPROFServerKey      string         `json:"pprofServerKey"`
+	PPROFServerCert     string         `json:"pprofServerCert"`
+	PPROFAllowOrigin    *string        `json:"pprofAllowOrigin,omitempty"` // deprecated
+	PPROFAllowOrigins   AllowedOrigins `json:"pprofAllowOrigins"`
+	PPROFTrustedProxies IPNetworks     `json:"pprofTrustedProxies"`
 
 	// Playback
-	Playback               bool       `json:"playback"`
-	PlaybackAddress        string     `json:"playbackAddress"`
-	PlaybackEncryption     bool       `json:"playbackEncryption"`
-	PlaybackServerKey      string     `json:"playbackServerKey"`
-	PlaybackServerCert     string     `json:"playbackServerCert"`
-	PlaybackAllowOrigin    *string    `json:"playbackAllowOrigin,omitempty"` // deprecated
-	PlaybackAllowOrigins   []string   `json:"playbackAllowOrigins"`
-	PlaybackTrustedProxies IPNetworks `json:"playbackTrustedProxies"`
+	Playback               bool           `json:"playback"`
+	PlaybackAddress        string         `json:"playbackAddress"`
+	PlaybackEncryption     bool           `json:"playbackEncryption"`
+	PlaybackServerKey      string         `json:"playbackServerKey"`
+	PlaybackServerCert     string         `json:"playbackServerCert"`
+	PlaybackAllowOrigin    *string        `json:"playbackAllowOrigin,omitempty"` // deprecated
+	PlaybackAllowOrigins   AllowedOrigins `json:"playbackAllowOrigins"`
+	PlaybackTrustedProxies IPNetworks     `json:"playbackTrustedProxies"`
 
 	// RTSP server
 	RTSP                  bool             `json:"rtsp"`
@@ -252,23 +252,23 @@ type Conf struct {
 	RTMPServerCert string     `json:"rtmpServerCert"`
 
 	// HLS server
-	HLS                bool       `json:"hls"`
-	HLSDisable         *bool      `json:"hlsDisable,omitempty"` // deprecated
-	HLSAddress         string     `json:"hlsAddress"`
-	HLSEncryption      bool       `json:"hlsEncryption"`
-	HLSServerKey       string     `json:"hlsServerKey"`
-	HLSServerCert      string     `json:"hlsServerCert"`
-	HLSAllowOrigin     *string    `json:"hlsAllowOrigin,omitempty"` // deprecated
-	HLSAllowOrigins    []string   `json:"hlsAllowOrigins"`
-	HLSTrustedProxies  IPNetworks `json:"hlsTrustedProxies"`
-	HLSAlwaysRemux     bool       `json:"hlsAlwaysRemux"`
-	HLSVariant         HLSVariant `json:"hlsVariant"`
-	HLSSegmentCount    int        `json:"hlsSegmentCount"`
-	HLSSegmentDuration Duration   `json:"hlsSegmentDuration"`
-	HLSPartDuration    Duration   `json:"hlsPartDuration"`
-	HLSSegmentMaxSize  StringSize `json:"hlsSegmentMaxSize"`
-	HLSDirectory       string     `json:"hlsDirectory"`
-	HLSMuxerCloseAfter Duration   `json:"hlsMuxerCloseAfter"`
+	HLS                bool           `json:"hls"`
+	HLSDisable         *bool          `json:"hlsDisable,omitempty"` // deprecated
+	HLSAddress         string         `json:"hlsAddress"`
+	HLSEncryption      bool           `json:"hlsEncryption"`
+	HLSServerKey       string         `json:"hlsServerKey"`
+	HLSServerCert      string         `json:"hlsServerCert"`
+	HLSAllowOrigin     *string        `json:"hlsAllowOrigin,omitempty"` // deprecated
+	HLSAllowOrigins    AllowedOrigins `json:"hlsAllowOrigins"`
+	HLSTrustedProxies  IPNetworks     `json:"hlsTrustedProxies"`
+	HLSAlwaysRemux     bool           `json:"hlsAlwaysRemux"`
+	HLSVariant         HLSVariant     `json:"hlsVariant"`
+	HLSSegmentCount    int            `json:"hlsSegmentCount"`
+	HLSSegmentDuration Duration       `json:"hlsSegmentDuration"`
+	HLSPartDuration    Duration       `json:"hlsPartDuration"`
+	HLSSegmentMaxSize  StringSize     `json:"hlsSegmentMaxSize"`
+	HLSDirectory       string         `json:"hlsDirectory"`
+	HLSMuxerCloseAfter Duration       `json:"hlsMuxerCloseAfter"`
 
 	// WebRTC server
 	WebRTC                      bool             `json:"webrtc"`
@@ -278,7 +278,7 @@ type Conf struct {
 	WebRTCServerKey             string           `json:"webrtcServerKey"`
 	WebRTCServerCert            string           `json:"webrtcServerCert"`
 	WebRTCAllowOrigin           *string          `json:"webrtcAllowOrigin,omitempty"` // deprecated
-	WebRTCAllowOrigins          []string         `json:"webrtcAllowOrigins"`
+	WebRTCAllowOrigins          AllowedOrigins   `json:"webrtcAllowOrigins"`
 	WebRTCTrustedProxies        IPNetworks       `json:"webrtcTrustedProxies"`
 	WebRTCLocalUDPAddress       string           `json:"webrtcLocalUDPAddress"`
 	WebRTCLocalTCPAddress       string           `json:"webrtcLocalTCPAddress"`

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -324,7 +324,7 @@ func (p *Core) createResources(initial bool) error {
 			Encryption:     p.conf.MetricsEncryption,
 			ServerKey:      p.conf.MetricsServerKey,
 			ServerCert:     p.conf.MetricsServerCert,
-			AllowOrigin:    p.conf.MetricsAllowOrigin,
+			AllowOrigins:   p.conf.MetricsAllowOrigins,
 			TrustedProxies: p.conf.MetricsTrustedProxies,
 			ReadTimeout:    p.conf.ReadTimeout,
 			WriteTimeout:   p.conf.WriteTimeout,
@@ -345,7 +345,7 @@ func (p *Core) createResources(initial bool) error {
 			Encryption:     p.conf.PPROFEncryption,
 			ServerKey:      p.conf.PPROFServerKey,
 			ServerCert:     p.conf.PPROFServerCert,
-			AllowOrigin:    p.conf.PPROFAllowOrigin,
+			AllowOrigins:   p.conf.PPROFAllowOrigins,
 			TrustedProxies: p.conf.PPROFTrustedProxies,
 			ReadTimeout:    p.conf.ReadTimeout,
 			WriteTimeout:   p.conf.WriteTimeout,
@@ -375,7 +375,7 @@ func (p *Core) createResources(initial bool) error {
 			Encryption:     p.conf.PlaybackEncryption,
 			ServerKey:      p.conf.PlaybackServerKey,
 			ServerCert:     p.conf.PlaybackServerCert,
-			AllowOrigin:    p.conf.PlaybackAllowOrigin,
+			AllowOrigins:   p.conf.PlaybackAllowOrigins,
 			TrustedProxies: p.conf.PlaybackTrustedProxies,
 			ReadTimeout:    p.conf.ReadTimeout,
 			WriteTimeout:   p.conf.WriteTimeout,
@@ -563,7 +563,7 @@ func (p *Core) createResources(initial bool) error {
 			Encryption:      p.conf.HLSEncryption,
 			ServerKey:       p.conf.HLSServerKey,
 			ServerCert:      p.conf.HLSServerCert,
-			AllowOrigin:     p.conf.HLSAllowOrigin,
+			AllowOrigins:    p.conf.HLSAllowOrigins,
 			TrustedProxies:  p.conf.HLSTrustedProxies,
 			AlwaysRemux:     p.conf.HLSAlwaysRemux,
 			Variant:         p.conf.HLSVariant,
@@ -593,7 +593,7 @@ func (p *Core) createResources(initial bool) error {
 			Encryption:            p.conf.WebRTCEncryption,
 			ServerKey:             p.conf.WebRTCServerKey,
 			ServerCert:            p.conf.WebRTCServerCert,
-			AllowOrigin:           p.conf.WebRTCAllowOrigin,
+			AllowOrigins:          p.conf.WebRTCAllowOrigins,
 			TrustedProxies:        p.conf.WebRTCTrustedProxies,
 			ReadTimeout:           p.conf.ReadTimeout,
 			WriteTimeout:          p.conf.WriteTimeout,
@@ -713,7 +713,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.MetricsEncryption != p.conf.MetricsEncryption ||
 		newConf.MetricsServerKey != p.conf.MetricsServerKey ||
 		newConf.MetricsServerCert != p.conf.MetricsServerCert ||
-		newConf.MetricsAllowOrigin != p.conf.MetricsAllowOrigin ||
+		!slices.Equal(newConf.MetricsAllowOrigins, p.conf.MetricsAllowOrigins) ||
 		!reflect.DeepEqual(newConf.MetricsTrustedProxies, p.conf.MetricsTrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteTimeout != p.conf.WriteTimeout ||
@@ -726,7 +726,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.PPROFEncryption != p.conf.PPROFEncryption ||
 		newConf.PPROFServerKey != p.conf.PPROFServerKey ||
 		newConf.PPROFServerCert != p.conf.PPROFServerCert ||
-		newConf.PPROFAllowOrigin != p.conf.PPROFAllowOrigin ||
+		!slices.Equal(newConf.PPROFAllowOrigins, p.conf.PPROFAllowOrigins) ||
 		!reflect.DeepEqual(newConf.PPROFTrustedProxies, p.conf.PPROFTrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteTimeout != p.conf.WriteTimeout ||
@@ -746,7 +746,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.PlaybackEncryption != p.conf.PlaybackEncryption ||
 		newConf.PlaybackServerKey != p.conf.PlaybackServerKey ||
 		newConf.PlaybackServerCert != p.conf.PlaybackServerCert ||
-		newConf.PlaybackAllowOrigin != p.conf.PlaybackAllowOrigin ||
+		!slices.Equal(newConf.PlaybackAllowOrigins, p.conf.PlaybackAllowOrigins) ||
 		!reflect.DeepEqual(newConf.PlaybackTrustedProxies, p.conf.PlaybackTrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteTimeout != p.conf.WriteTimeout ||
@@ -853,7 +853,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.HLSEncryption != p.conf.HLSEncryption ||
 		newConf.HLSServerKey != p.conf.HLSServerKey ||
 		newConf.HLSServerCert != p.conf.HLSServerCert ||
-		newConf.HLSAllowOrigin != p.conf.HLSAllowOrigin ||
+		!slices.Equal(newConf.HLSAllowOrigins, p.conf.HLSAllowOrigins) ||
 		!reflect.DeepEqual(newConf.HLSTrustedProxies, p.conf.HLSTrustedProxies) ||
 		newConf.HLSAlwaysRemux != p.conf.HLSAlwaysRemux ||
 		newConf.HLSVariant != p.conf.HLSVariant ||
@@ -875,7 +875,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.WebRTCEncryption != p.conf.WebRTCEncryption ||
 		newConf.WebRTCServerKey != p.conf.WebRTCServerKey ||
 		newConf.WebRTCServerCert != p.conf.WebRTCServerCert ||
-		newConf.WebRTCAllowOrigin != p.conf.WebRTCAllowOrigin ||
+		!slices.Equal(newConf.WebRTCAllowOrigins, p.conf.WebRTCAllowOrigins) ||
 		!reflect.DeepEqual(newConf.WebRTCTrustedProxies, p.conf.WebRTCTrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteTimeout != p.conf.WriteTimeout ||

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -912,7 +912,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.APIEncryption != p.conf.APIEncryption ||
 		newConf.APIServerKey != p.conf.APIServerKey ||
 		newConf.APIServerCert != p.conf.APIServerCert ||
-		slices.Equal(newConf.APIAllowOrigins, p.conf.APIAllowOrigins) ||
+		!slices.Equal(newConf.APIAllowOrigins, p.conf.APIAllowOrigins) ||
 		!reflect.DeepEqual(newConf.APITrustedProxies, p.conf.APITrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteTimeout != p.conf.WriteTimeout ||

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -650,7 +651,7 @@ func (p *Core) createResources(initial bool) error {
 			Encryption:     p.conf.APIEncryption,
 			ServerKey:      p.conf.APIServerKey,
 			ServerCert:     p.conf.APIServerCert,
-			AllowOrigin:    p.conf.APIAllowOrigin,
+			AllowOrigins:   p.conf.APIAllowOrigins,
 			TrustedProxies: p.conf.APITrustedProxies,
 			ReadTimeout:    p.conf.ReadTimeout,
 			WriteTimeout:   p.conf.WriteTimeout,
@@ -911,7 +912,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.APIEncryption != p.conf.APIEncryption ||
 		newConf.APIServerKey != p.conf.APIServerKey ||
 		newConf.APIServerCert != p.conf.APIServerCert ||
-		newConf.APIAllowOrigin != p.conf.APIAllowOrigin ||
+		slices.Equal(newConf.APIAllowOrigins, p.conf.APIAllowOrigins) ||
 		!reflect.DeepEqual(newConf.APITrustedProxies, p.conf.APITrustedProxies) ||
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteTimeout != p.conf.WriteTimeout ||

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -74,7 +74,7 @@ type Metrics struct {
 	Encryption     bool
 	ServerKey      string
 	ServerCert     string
-	AllowOrigin    string
+	AllowOrigins   []string
 	TrustedProxies conf.IPNetworks
 	ReadTimeout    conf.Duration
 	WriteTimeout   conf.Duration
@@ -105,7 +105,7 @@ func (m *Metrics) Initialize() error {
 
 	m.httpServer = &httpp.Server{
 		Address:      m.Address,
-		AllowOrigins: []string{m.AllowOrigin},
+		AllowOrigins: m.AllowOrigins,
 		ReadTimeout:  time.Duration(m.ReadTimeout),
 		WriteTimeout: time.Duration(m.WriteTimeout),
 		Encryption:   m.Encryption,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -98,13 +98,14 @@ func (m *Metrics) Initialize() error {
 	router := gin.New()
 	router.SetTrustedProxies(m.TrustedProxies.ToTrustedProxies()) //nolint:errcheck
 
-	router.Use(m.middlewareOrigin)
+	router.Use(m.middlewarePreflightRequests)
 	router.Use(m.middlewareAuth)
 
 	router.GET("/metrics", m.onMetrics)
 
 	m.httpServer = &httpp.Server{
 		Address:      m.Address,
+		AllowOrigins: []string{m.AllowOrigin},
 		ReadTimeout:  time.Duration(m.ReadTimeout),
 		WriteTimeout: time.Duration(m.WriteTimeout),
 		Encryption:   m.Encryption,
@@ -134,11 +135,7 @@ func (m *Metrics) Log(level logger.Level, format string, args ...any) {
 	m.Parent.Log(level, "[metrics] "+format, args...)
 }
 
-func (m *Metrics) middlewareOrigin(ctx *gin.Context) {
-	ctx.Header("Access-Control-Allow-Origin", m.AllowOrigin)
-	ctx.Header("Access-Control-Allow-Credentials", "true")
-
-	// preflight requests
+func (m *Metrics) middlewarePreflightRequests(ctx *gin.Context) {
 	if ctx.Request.Method == http.MethodOptions &&
 		ctx.Request.Header.Get("Access-Control-Request-Method") != "" {
 		ctx.Header("Access-Control-Allow-Methods", "OPTIONS, GET")

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -192,7 +192,7 @@ func (dummyWebRTCServer) APISessionsKick(uuid.UUID) error {
 func TestPreflightRequest(t *testing.T) {
 	m := Metrics{
 		Address:      "localhost:9998",
-		AllowOrigin:  "*",
+		AllowOrigins: []string{"*"},
 		ReadTimeout:  conf.Duration(10 * time.Second),
 		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager:  test.NilAuthManager,
@@ -232,7 +232,7 @@ func TestMetrics(t *testing.T) {
 
 	m := Metrics{
 		Address:      "localhost:9998",
-		AllowOrigin:  "*",
+		AllowOrigins: []string{"*"},
 		ReadTimeout:  conf.Duration(10 * time.Second),
 		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager: &test.AuthManager{
@@ -368,7 +368,7 @@ func TestAuthError(t *testing.T) {
 
 	m := Metrics{
 		Address:      "localhost:9998",
-		AllowOrigin:  "*",
+		AllowOrigins: []string{"*"},
 		ReadTimeout:  conf.Duration(10 * time.Second),
 		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager: &test.AuthManager{
@@ -428,7 +428,7 @@ func TestFilter(t *testing.T) {
 		t.Run(ca, func(t *testing.T) {
 			m := Metrics{
 				Address:      "localhost:9998",
-				AllowOrigin:  "*",
+				AllowOrigins: []string{"*"},
 				ReadTimeout:  conf.Duration(10 * time.Second),
 				WriteTimeout: conf.Duration(10 * time.Second),
 				AuthManager:  test.NilAuthManager,

--- a/internal/playback/server.go
+++ b/internal/playback/server.go
@@ -24,7 +24,7 @@ type Server struct {
 	Encryption     bool
 	ServerKey      string
 	ServerCert     string
-	AllowOrigin    string
+	AllowOrigins   []string
 	TrustedProxies conf.IPNetworks
 	ReadTimeout    conf.Duration
 	WriteTimeout   conf.Duration
@@ -48,7 +48,7 @@ func (s *Server) Initialize() error {
 
 	s.httpServer = &httpp.Server{
 		Address:      s.Address,
-		AllowOrigins: []string{s.AllowOrigin},
+		AllowOrigins: s.AllowOrigins,
 		ReadTimeout:  time.Duration(s.ReadTimeout),
 		WriteTimeout: time.Duration(s.WriteTimeout),
 		Encryption:   s.Encryption,

--- a/internal/playback/server_test.go
+++ b/internal/playback/server_test.go
@@ -18,7 +18,7 @@ import (
 func TestPreflightRequest(t *testing.T) {
 	s := &Server{
 		Address:      "127.0.0.1:9996",
-		AllowOrigin:  "*",
+		AllowOrigins: []string{"*"},
 		ReadTimeout:  conf.Duration(10 * time.Second),
 		WriteTimeout: conf.Duration(10 * time.Second),
 		Parent:       test.NilLogger,

--- a/internal/pprof/pprof.go
+++ b/internal/pprof/pprof.go
@@ -29,7 +29,7 @@ type PPROF struct {
 	Encryption     bool
 	ServerKey      string
 	ServerCert     string
-	AllowOrigin    string
+	AllowOrigins   []string
 	TrustedProxies conf.IPNetworks
 	ReadTimeout    conf.Duration
 	WriteTimeout   conf.Duration
@@ -51,7 +51,7 @@ func (pp *PPROF) Initialize() error {
 
 	pp.httpServer = &httpp.Server{
 		Address:      pp.Address,
-		AllowOrigins: []string{pp.AllowOrigin},
+		AllowOrigins: pp.AllowOrigins,
 		ReadTimeout:  time.Duration(pp.ReadTimeout),
 		WriteTimeout: time.Duration(pp.WriteTimeout),
 		Encryption:   pp.Encryption,

--- a/internal/pprof/pprof_test.go
+++ b/internal/pprof/pprof_test.go
@@ -17,7 +17,7 @@ import (
 func TestPreflightRequest(t *testing.T) {
 	s := &PPROF{
 		Address:      "127.0.0.1:9999",
-		AllowOrigin:  "*",
+		AllowOrigins: []string{"*"},
 		ReadTimeout:  conf.Duration(10 * time.Second),
 		WriteTimeout: conf.Duration(10 * time.Second),
 		Parent:       test.NilLogger,
@@ -56,7 +56,7 @@ func TestPprof(t *testing.T) {
 
 	s := &PPROF{
 		Address:      "127.0.0.1:9999",
-		AllowOrigin:  "*",
+		AllowOrigins: []string{"*"},
 		ReadTimeout:  conf.Duration(10 * time.Second),
 		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager: &test.AuthManager{
@@ -99,7 +99,7 @@ func TestAuthError(t *testing.T) {
 
 	s := &PPROF{
 		Address:      "127.0.0.1:9999",
-		AllowOrigin:  "*",
+		AllowOrigins: []string{"*"},
 		ReadTimeout:  conf.Duration(10 * time.Second),
 		WriteTimeout: conf.Duration(10 * time.Second),
 		AuthManager: &test.AuthManager{

--- a/internal/protocols/httpp/handler_origin.go
+++ b/internal/protocols/httpp/handler_origin.go
@@ -1,0 +1,91 @@
+package httpp
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var errOriginNotAllowed = errors.New("origin not allowed")
+
+func isOriginAllowed(origin string, allowOrigins []string) (string, error) {
+	if len(allowOrigins) == 0 {
+		return "", errOriginNotAllowed
+	}
+
+	for _, o := range allowOrigins {
+		if o == "*" {
+			return o, nil
+		}
+	}
+
+	if origin == "" {
+		return "", errOriginNotAllowed
+	}
+
+	originURL, err := url.Parse(origin)
+	if err != nil || originURL.Scheme == "" {
+		return "", errOriginNotAllowed
+	}
+
+	if originURL.Port() == "" && originURL.Scheme != "" {
+		switch originURL.Scheme {
+		case "http":
+			originURL.Host = net.JoinHostPort(originURL.Host, "80")
+		case "https":
+			originURL.Host = net.JoinHostPort(originURL.Host, "443")
+		}
+	}
+
+	for _, o := range allowOrigins {
+		allowedURL, errAllowed := url.Parse(o)
+		if errAllowed != nil {
+			continue
+		}
+
+		if allowedURL.Port() == "" {
+			switch allowedURL.Scheme {
+			case "http":
+				allowedURL.Host = net.JoinHostPort(allowedURL.Host, "80")
+			case "https":
+				allowedURL.Host = net.JoinHostPort(allowedURL.Host, "443")
+			}
+		}
+
+		if allowedURL.Scheme == originURL.Scheme &&
+			allowedURL.Host == originURL.Host &&
+			allowedURL.Port() == originURL.Port() {
+			return origin, nil
+		}
+
+		if strings.Contains(allowedURL.Host, "*") {
+			pattern := strings.ReplaceAll(allowedURL.Host, "*.", "(.*\\.)?")
+			pattern = strings.ReplaceAll(pattern, "*", ".*")
+			matched, errMatched := regexp.MatchString("^"+pattern+"$", originURL.Host)
+			if errMatched == nil && matched {
+				return origin, nil
+			}
+		}
+	}
+
+	return "", errOriginNotAllowed
+}
+
+// add Access-Control-Allow-Origin and Access-Control-Allow-Credentials
+type handlerOrigin struct {
+	h            http.Handler
+	allowOrigins []string
+}
+
+func (h *handlerOrigin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	origin, err := isOriginAllowed(r.Header.Get("Origin"), h.allowOrigins)
+	if err == nil {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+	}
+
+	h.h.ServeHTTP(w, r)
+}

--- a/internal/protocols/httpp/handler_origin.go
+++ b/internal/protocols/httpp/handler_origin.go
@@ -79,7 +79,7 @@ type handlerOrigin struct {
 
 func (h *handlerOrigin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	origin, ok := isOriginAllowed(r.Header.Get("Origin"), h.allowOrigins)
-	if !ok {
+	if ok {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 	}

--- a/internal/protocols/httpp/handler_origin_test.go
+++ b/internal/protocols/httpp/handler_origin_test.go
@@ -1,0 +1,87 @@
+package httpp
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/bluenviron/mediamtx/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerOrigin(t *testing.T) {
+	for _, ca := range []struct {
+		name           string
+		origin         string
+		allowedOrigins []string
+		expected       string
+	}{
+		{
+			"empty",
+			"",
+			[]string{},
+			"",
+		},
+		{
+			"not allowed",
+			"http://another.com",
+			[]string{"http://example.com"},
+			"",
+		},
+		{
+			"everything allowed, no origin",
+			"",
+			[]string{"*"},
+			"*",
+		},
+		{
+			"everything allowed, with origin",
+			"https://example.com",
+			[]string{"*"},
+			"*",
+		},
+		{
+			"allowed",
+			"https://example.org",
+			[]string{"http://example.com", "https://example.org"},
+			"https://example.org",
+		},
+		{
+			"wildcard",
+			"https://test.example.org",
+			[]string{"https://*.example.org"},
+			"https://test.example.org",
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			s := &Server{
+				Address:      "localhost:4555",
+				AllowOrigins: ca.allowedOrigins,
+				ReadTimeout:  10 * time.Second,
+				WriteTimeout: 10 * time.Second,
+				Parent:       test.NilLogger,
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}),
+			}
+			err := s.Initialize()
+			require.NoError(t, err)
+			defer s.Close()
+
+			tr := &http.Transport{}
+			defer tr.CloseIdleConnections()
+			hc := &http.Client{Transport: tr}
+
+			req, err := http.NewRequest(http.MethodGet, "http://localhost:4555", nil)
+			require.NoError(t, err)
+
+			req.Header.Set("Origin", ca.origin)
+
+			res, err := hc.Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, ca.expected, res.Header.Get("Access-Control-Allow-Origin"))
+		})
+	}
+}

--- a/internal/protocols/httpp/server.go
+++ b/internal/protocols/httpp/server.go
@@ -32,6 +32,7 @@ func (nilWriter) Write(p []byte) (int, error) {
 // - filtering of invalid requests
 type Server struct {
 	Address      string
+	AllowOrigins []string
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 	Encryption   bool
@@ -100,8 +101,9 @@ func (s *Server) Initialize() error {
 	}
 
 	h := s.Handler
-	h = &handlerFilterRequests{h}
+	h = &handlerOrigin{h, s.AllowOrigins}
 	h = &handlerServerHeader{h}
+	h = &handlerFilterRequests{h}
 	h = &handlerLogger{h, s.Parent}
 	h = &handlerExitOnPanic{h}
 	h = &handlerWriteTimeout{h, s.WriteTimeout}

--- a/internal/servers/hls/http_server.go
+++ b/internal/servers/hls/http_server.go
@@ -39,7 +39,7 @@ type httpServer struct {
 	encryption     bool
 	serverKey      string
 	serverCert     string
-	allowOrigin    string
+	allowOrigins   []string
 	trustedProxies conf.IPNetworks
 	readTimeout    conf.Duration
 	writeTimeout   conf.Duration
@@ -59,7 +59,7 @@ func (s *httpServer) initialize() error {
 
 	s.inner = &httpp.Server{
 		Address:      s.address,
-		AllowOrigins: []string{s.allowOrigin},
+		AllowOrigins: s.allowOrigins,
 		ReadTimeout:  time.Duration(s.readTimeout),
 		WriteTimeout: time.Duration(s.writeTimeout),
 		Encryption:   s.encryption,

--- a/internal/servers/hls/http_server.go
+++ b/internal/servers/hls/http_server.go
@@ -53,12 +53,13 @@ func (s *httpServer) initialize() error {
 	router := gin.New()
 	router.SetTrustedProxies(s.trustedProxies.ToTrustedProxies()) //nolint:errcheck
 
-	router.Use(s.middlewareOrigin)
+	router.Use(s.middlewarePreflightRequests)
 
 	router.Use(s.onRequest)
 
 	s.inner = &httpp.Server{
 		Address:      s.address,
+		AllowOrigins: []string{s.allowOrigin},
 		ReadTimeout:  time.Duration(s.readTimeout),
 		WriteTimeout: time.Duration(s.writeTimeout),
 		Encryption:   s.encryption,
@@ -84,11 +85,7 @@ func (s *httpServer) close() {
 	s.inner.Close()
 }
 
-func (s *httpServer) middlewareOrigin(ctx *gin.Context) {
-	ctx.Header("Access-Control-Allow-Origin", s.allowOrigin)
-	ctx.Header("Access-Control-Allow-Credentials", "true")
-
-	// preflight requests
+func (s *httpServer) middlewarePreflightRequests(ctx *gin.Context) {
 	if ctx.Request.Method == http.MethodOptions &&
 		ctx.Request.Header.Get("Access-Control-Request-Method") != "" {
 		ctx.Header("Access-Control-Allow-Methods", "OPTIONS, GET")

--- a/internal/servers/hls/server.go
+++ b/internal/servers/hls/server.go
@@ -74,7 +74,7 @@ type Server struct {
 	Encryption      bool
 	ServerKey       string
 	ServerCert      string
-	AllowOrigin     string
+	AllowOrigins    []string
 	TrustedProxies  conf.IPNetworks
 	AlwaysRemux     bool
 	Variant         conf.HLSVariant
@@ -124,7 +124,7 @@ func (s *Server) Initialize() error {
 		encryption:     s.Encryption,
 		serverKey:      s.ServerKey,
 		serverCert:     s.ServerCert,
-		allowOrigin:    s.AllowOrigin,
+		allowOrigins:   s.AllowOrigins,
 		trustedProxies: s.TrustedProxies,
 		readTimeout:    s.ReadTimeout,
 		writeTimeout:   s.WriteTimeout,

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -68,7 +68,7 @@ func (pa *dummyPath) RemoveReader(_ defs.PathRemoveReaderReq) {
 func TestServerPreflightRequest(t *testing.T) {
 	s := &Server{
 		Address:      "127.0.0.1:8888",
-		AllowOrigin:  "*",
+		AllowOrigins: []string{"*"},
 		ReadTimeout:  conf.Duration(10 * time.Second),
 		WriteTimeout: conf.Duration(10 * time.Second),
 		PathManager:  &dummyPathManager{},
@@ -131,7 +131,6 @@ func TestServerNotFound(t *testing.T) {
 				SegmentDuration: conf.Duration(1 * time.Second),
 				PartDuration:    conf.Duration(200 * time.Millisecond),
 				SegmentMaxSize:  50 * 1024 * 1024,
-				AllowOrigin:     "",
 				TrustedProxies:  conf.IPNetworks{},
 				Directory:       "",
 				ReadTimeout:     conf.Duration(10 * time.Second),
@@ -433,7 +432,6 @@ func TestServerDirectory(t *testing.T) {
 		SegmentDuration: conf.Duration(1 * time.Second),
 		PartDuration:    conf.Duration(200 * time.Millisecond),
 		SegmentMaxSize:  50 * 1024 * 1024,
-		AllowOrigin:     "",
 		TrustedProxies:  conf.IPNetworks{},
 		Directory:       filepath.Join(dir, "mydir"),
 		ReadTimeout:     conf.Duration(10 * time.Second),

--- a/internal/servers/webrtc/http_server.go
+++ b/internal/servers/webrtc/http_server.go
@@ -90,12 +90,13 @@ func (s *httpServer) initialize() error {
 	router := gin.New()
 	router.SetTrustedProxies(s.trustedProxies.ToTrustedProxies()) //nolint:errcheck
 
-	router.Use(s.middlewareOrigin)
+	router.Use(s.middlewarePreflightRequests)
 
 	router.Use(s.onRequest)
 
 	s.inner = &httpp.Server{
 		Address:      s.address,
+		AllowOrigins: []string{s.allowOrigin},
 		ReadTimeout:  time.Duration(s.readTimeout),
 		WriteTimeout: time.Duration(s.writeTimeout),
 		Encryption:   s.encryption,
@@ -319,11 +320,7 @@ func (s *httpServer) onPage(ctx *gin.Context, pathName string, publish bool) {
 	}
 }
 
-func (s *httpServer) middlewareOrigin(ctx *gin.Context) {
-	ctx.Header("Access-Control-Allow-Origin", s.allowOrigin)
-	ctx.Header("Access-Control-Allow-Credentials", "true")
-
-	// preflight requests
+func (s *httpServer) middlewarePreflightRequests(ctx *gin.Context) {
 	if ctx.Request.Method == http.MethodOptions &&
 		ctx.Request.Header.Get("Access-Control-Request-Method") != "" {
 		ctx.Header("Access-Control-Allow-Methods", "OPTIONS, GET, POST, PATCH, DELETE")

--- a/internal/servers/webrtc/http_server.go
+++ b/internal/servers/webrtc/http_server.go
@@ -76,7 +76,7 @@ type httpServer struct {
 	encryption     bool
 	serverKey      string
 	serverCert     string
-	allowOrigin    string
+	allowOrigins   []string
 	trustedProxies conf.IPNetworks
 	readTimeout    conf.Duration
 	writeTimeout   conf.Duration
@@ -96,7 +96,7 @@ func (s *httpServer) initialize() error {
 
 	s.inner = &httpp.Server{
 		Address:      s.address,
-		AllowOrigins: []string{s.allowOrigin},
+		AllowOrigins: s.allowOrigins,
 		ReadTimeout:  time.Duration(s.readTimeout),
 		WriteTimeout: time.Duration(s.writeTimeout),
 		Encryption:   s.encryption,

--- a/internal/servers/webrtc/server.go
+++ b/internal/servers/webrtc/server.go
@@ -190,7 +190,7 @@ type Server struct {
 	Encryption            bool
 	ServerKey             string
 	ServerCert            string
-	AllowOrigin           string
+	AllowOrigins          []string
 	TrustedProxies        conf.IPNetworks
 	ReadTimeout           conf.Duration
 	WriteTimeout          conf.Duration
@@ -254,7 +254,7 @@ func (s *Server) Initialize() error {
 		encryption:     s.Encryption,
 		serverKey:      s.ServerKey,
 		serverCert:     s.ServerCert,
-		allowOrigin:    s.AllowOrigin,
+		allowOrigins:   s.AllowOrigins,
 		trustedProxies: s.TrustedProxies,
 		readTimeout:    s.ReadTimeout,
 		writeTimeout:   s.WriteTimeout,

--- a/internal/servers/webrtc/server_test.go
+++ b/internal/servers/webrtc/server_test.go
@@ -66,7 +66,7 @@ func initializeTestServer(t *testing.T) *Server {
 
 	s := &Server{
 		Address:               "127.0.0.1:8886",
-		AllowOrigin:           "*",
+		AllowOrigins:          []string{"*"},
 		TrustedProxies:        conf.IPNetworks{},
 		ReadTimeout:           conf.Duration(10 * time.Second),
 		WriteTimeout:          conf.Duration(10 * time.Second),

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -158,7 +158,7 @@ apiEncryption: no
 apiServerKey: server.key
 # Path to the server certificate.
 apiServerCert: server.crt
-# Lis.
+# List of allowed HTTP Origins.
 # Supports wildcards: ['http://*.example.com']
 apiAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HTTP server.

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -158,8 +158,11 @@ apiEncryption: no
 apiServerKey: server.key
 # Path to the server certificate.
 apiServerCert: server.crt
-# Value of the Access-Control-Allow-Origin header provided in every HTTP response.
-apiAllowOrigin: '*'
+# List of allowed origins.
+# Supports wildcards: ['http://*.example.com']
+# If apiAllowOrigins is set to '*', the Access-Control-Allow-Origin response will be '*',
+# even if no Origin was sent from the client.
+apiAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HTTP server.
 # If the server receives a request from one of these entries, IP in logs
 # will be taken from the X-Forwarded-For header.

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -158,10 +158,8 @@ apiEncryption: no
 apiServerKey: server.key
 # Path to the server certificate.
 apiServerCert: server.crt
-# List of allowed origins.
+# Lis.
 # Supports wildcards: ['http://*.example.com']
-# If apiAllowOrigins is set to '*', the Access-Control-Allow-Origin response will be '*',
-# even if no Origin was sent from the client.
 apiAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HTTP server.
 # If the server receives a request from one of these entries, IP in logs
@@ -184,8 +182,9 @@ metricsEncryption: no
 metricsServerKey: server.key
 # Path to the server certificate.
 metricsServerCert: server.crt
-# Value of the Access-Control-Allow-Origin header provided in every HTTP response.
-metricsAllowOrigin: '*'
+# List of allowed HTTP Origins.
+# Supports wildcards: ['http://*.example.com']
+metricsAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HTTP server.
 # If the server receives a request from one of these entries, IP in logs
 # will be taken from the X-Forwarded-For header.
@@ -207,8 +206,9 @@ pprofEncryption: no
 pprofServerKey: server.key
 # Path to the server certificate.
 pprofServerCert: server.crt
-# Value of the Access-Control-Allow-Origin header provided in every HTTP response.
-pprofAllowOrigin: '*'
+# List of allowed HTTP Origins.
+# Supports wildcards: ['http://*.example.com']
+pprofAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HTTP server.
 # If the server receives a request from one of these entries, IP in logs
 # will be taken from the X-Forwarded-For header.
@@ -230,8 +230,9 @@ playbackEncryption: no
 playbackServerKey: server.key
 # Path to the server certificate.
 playbackServerCert: server.crt
-# Value of the Access-Control-Allow-Origin header provided in every HTTP response.
-playbackAllowOrigin: '*'
+# List of allowed HTTP Origins.
+# Supports wildcards: ['http://*.example.com']
+playbackAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HTTP server.
 # If the server receives a request from one of these entries, IP in logs
 # will be taken from the X-Forwarded-For header.
@@ -322,9 +323,9 @@ hlsEncryption: no
 hlsServerKey: server.key
 # Path to the server certificate.
 hlsServerCert: server.crt
-# Value of the Access-Control-Allow-Origin header provided in every HTTP response.
-# This allows to play the HLS stream from an external website.
-hlsAllowOrigin: '*'
+# List of allowed HTTP Origins.
+# Supports wildcards: ['http://*.example.com']
+hlsAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HLS server.
 # If the server receives a request from one of these entries, IP in logs
 # will be taken from the X-Forwarded-For header.
@@ -380,9 +381,9 @@ webrtcEncryption: no
 webrtcServerKey: server.key
 # Path to the server certificate.
 webrtcServerCert: server.crt
-# Value of the Access-Control-Allow-Origin header provided in every HTTP response.
-# This allows to play the WebRTC stream from an external website.
-webrtcAllowOrigin: '*'
+# List of allowed HTTP Origins.
+# Supports wildcards: ['http://*.example.com']
+webrtcAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the WebRTC server.
 # If the server receives a request from one of these entries, IP in logs
 # will be taken from the X-Forwarded-For header.

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -158,7 +158,7 @@ apiEncryption: no
 apiServerKey: server.key
 # Path to the server certificate.
 apiServerCert: server.crt
-# List of allowed HTTP Origins.
+# List of allowed CORS origins.
 # Supports wildcards: ['http://*.example.com']
 apiAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HTTP server.
@@ -182,7 +182,7 @@ metricsEncryption: no
 metricsServerKey: server.key
 # Path to the server certificate.
 metricsServerCert: server.crt
-# List of allowed HTTP Origins.
+# List of allowed CORS origins.
 # Supports wildcards: ['http://*.example.com']
 metricsAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HTTP server.
@@ -206,7 +206,7 @@ pprofEncryption: no
 pprofServerKey: server.key
 # Path to the server certificate.
 pprofServerCert: server.crt
-# List of allowed HTTP Origins.
+# List of allowed CORS origins.
 # Supports wildcards: ['http://*.example.com']
 pprofAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HTTP server.
@@ -230,7 +230,7 @@ playbackEncryption: no
 playbackServerKey: server.key
 # Path to the server certificate.
 playbackServerCert: server.crt
-# List of allowed HTTP Origins.
+# List of allowed CORS origins.
 # Supports wildcards: ['http://*.example.com']
 playbackAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HTTP server.
@@ -323,7 +323,7 @@ hlsEncryption: no
 hlsServerKey: server.key
 # Path to the server certificate.
 hlsServerCert: server.crt
-# List of allowed HTTP Origins.
+# List of allowed CORS origins.
 # Supports wildcards: ['http://*.example.com']
 hlsAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the HLS server.
@@ -381,7 +381,7 @@ webrtcEncryption: no
 webrtcServerKey: server.key
 # Path to the server certificate.
 webrtcServerCert: server.crt
-# List of allowed HTTP Origins.
+# List of allowed CORS origins.
 # Supports wildcards: ['http://*.example.com']
 webrtcAllowOrigins: ['*']
 # List of IPs or CIDRs of proxies placed before the WebRTC server.


### PR DESCRIPTION
Introduce a new `allowOrigins` configuration field (slice of strings) to replace the single-string `allowOrigin`.
Add logic to validate origins against allowed patterns, supporting:
- Exact matches
- Wildcard domain matching (e.g., http://*.example.com)

Update configuration handling in core and test components to support the new format.
Maintain backwards compatibility with the old `allowOrigin` field.
Update `openapi.yaml` to reflect the new configuration field.

Fixes #5091 