### PR TITLE
Fix OpenAPI/Swagger double number format

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -432,16 +432,16 @@ components:
           type: boolean
         rpiCameraBrightness:
           type: number
-          format: float64
+          format: double
         rpiCameraContrast:
           type: number
-          format: float64
+          format: double
         rpiCameraSaturation:
           type: number
-          format: float64
+          format: double
         rpiCameraSharpness:
           type: number
-          format: float64
+          format: double
         rpiCameraExposure:
           type: string
         rpiCameraAWB:
@@ -452,7 +452,7 @@ components:
           maxItems: 2
           items:
             type: number
-            format: float64
+            format: double
         rpiCameraDenoise:
           type: string
         rpiCameraShutter:
@@ -462,10 +462,10 @@ components:
           type: string
         rpiCameraGain:
           type: number
-          format: float64
+          format: double
         rpiCameraEV:
           type: number
-          format: float64
+          format: double
         rpiCameraROI:
           type: string
         rpiCameraHDR:
@@ -476,7 +476,7 @@ components:
           type: string
         rpiCameraFPS:
           type: number
-          format: float64
+          format: double
         rpiCameraAfMode:
           type: string
         rpiCameraAfRange:
@@ -485,7 +485,7 @@ components:
           type: string
         rpiCameraLensPosition:
           type: number
-          format: float64
+          format: double
         rpiCameraAfWindow:
           type: string
         rpiCameraFlickerPeriod:
@@ -814,7 +814,7 @@ components:
           format: int64
         rtpPacketsJitter:
           type: number
-          format: float64
+          format: double
         rtcpPacketsReceived:
           type: integer
           format: int64
@@ -975,7 +975,7 @@ components:
           description: Same as packetsReceivedUndecrypt, but expressed in bytes, including payload and all the headers (IP, TCP, SRT)
         usPacketsSendPeriod:
           type: number
-          format: float64
+          format: double
           description: Current minimum time interval between which consecutive packets are sent, in microseconds
         packetsFlowWindow:
           type: integer
@@ -987,19 +987,19 @@ components:
           description: The number of packets in flight
         msRTT:
           type: number
-          format: float64
+          format: double
           description: Smoothed round-trip time (SRTT), an exponentially-weighted moving average (EWMA) of an endpoint's RTT samples, in milliseconds
         mbpsSendRate:
           type: number
-          format: float64
+          format: double
           description: Current transmission bandwidth, in Mbps
         mbpsReceiveRate:
           type: number
-          format: float64
+          format: double
           description: Current receiving bandwidth, in Mbps
         mbpsLinkCapacity:
           type: number
-          format: float64
+          format: double
           description: Estimated capacity of the network link, in Mbps
         bytesAvailSendBuf:
           type: integer
@@ -1011,7 +1011,7 @@ components:
           description: The available space in the receiver's buffer, in bytes
         mbpsMaxBW:
           type: number
-          format: float64
+          format: double
           description: Transmission bandwidth limit, in Mbps
         byteMSS:
           type: integer
@@ -1059,11 +1059,11 @@ components:
           description: Accumulated difference between the current time and the time-to-play of a packet that is received late
         packetsSendLossRate:
           type: number
-          format: float64
+          format: double
           description: Percentage of resent data vs. sent data
         packetsReceivedLossRate:
           type: number
-          format: float64
+          format: double
           description: Percentage of retransmitted data vs. received data
 
     SRTConnList:
@@ -1119,7 +1119,7 @@ components:
           format: int64
         rtpPacketsJitter:
           type: number
-          format: float64
+          format: double
         rtcpPacketsReceived:
           type: integer
           format: int64

--- a/internal/testapidocs/apidocs_test.go
+++ b/internal/testapidocs/apidocs_test.go
@@ -171,7 +171,7 @@ func TestAPIDocs(t *testing.T) {
 						content2.Properties[js] = openAPIProperty{Type: "integer", Format: "int64"}
 
 					case sf.Type == reflect.TypeOf(float64(0)):
-						content2.Properties[js] = openAPIProperty{Type: "number", Format: "float64"}
+						content2.Properties[js] = openAPIProperty{Type: "number", Format: "double"}
 
 					case sf.Type == reflect.TypeOf(false):
 						content2.Properties[js] = openAPIProperty{Type: "boolean"}


### PR DESCRIPTION
Change the format for properties of type `number` from `float64` to `double`.
As stated by the OpenAPI/Swagger v3 [spec](https://swagger.io/docs/specification/v3_0/data-models/data-types/#numbers) there isn't a `float64` format for numbers.
This allows code generation tools like [openapi-go](https://github.com/swaggest/openapi-go) to generate the proper types/stubs.