### PR TITLE
Add per path metadata and the ability to search paths list

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -560,6 +560,18 @@ func (a *API) onPathsList(ctx *gin.Context) {
 		return
 	}
 
+	// Filter by search parameter if provided
+	search := ctx.Query("search")
+	if search != "" {
+		filteredItems := make([]*defs.APIPath, 0, len(data.Items))
+		for _, item := range data.Items {
+			if strings.Contains(strings.ToLower(item.Name), strings.ToLower(search)) {
+				filteredItems = append(filteredItems, item)
+			}
+		}
+		data.Items = filteredItems
+	}
+
 	data.ItemCount = len(data.Items)
 	pageCount, err := paginate(&data.Items, ctx.Query("itemsPerPage"), ctx.Query("page"))
 	if err != nil {

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -229,6 +229,9 @@ type Path struct {
 	RunOnUnread                string   `json:"runOnUnread"`
 	RunOnRecordSegmentCreate   string   `json:"runOnRecordSegmentCreate"`
 	RunOnRecordSegmentComplete string   `json:"runOnRecordSegmentComplete"`
+
+	// Custom metadata
+	Metadata map[string]any `json:"metadata"`
 }
 
 func (pconf *Path) setDefaults() {

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -590,6 +590,7 @@ func (pa *path) doAPIPathsGet(req pathAPIPathsGetReq) {
 				}
 				return ret
 			}(),
+			Metadata: pa.conf.Metadata,
 		},
 	}
 }

--- a/internal/defs/api.go
+++ b/internal/defs/api.go
@@ -85,6 +85,7 @@ type APIPath struct {
 	BytesReceived uint64                  `json:"bytesReceived"`
 	BytesSent     uint64                  `json:"bytesSent"`
 	Readers       []APIPathSourceOrReader `json:"readers"`
+	Metadata      map[string]any          `json:"metadata" yaml:"metadata"`
 }
 
 // APIPathList is a list of paths.


### PR DESCRIPTION
This update adds two improvements to the MediaMTX paths API.

1. Per-path metadata
Each path can now include optional metadata fields in its configuration, such as expected bitrate or camera origin. These values are returned in the /v3/paths/list response so that monitoring tools or clients can understand the expected characteristics of each stream.

2. Path search support
The /v3/paths/list endpoint now supports a "search" query parameter. It filters the results and returns only the paths whose name starts with the given string. This is useful for grouping paths by camera or any naming prefix.

Example:
curl 'http://127.0.0.1:9997/v3/paths/list?search=cam2'
returns only cam2/main and cam2/sub.

Calling /v3/paths/list without the search parameter returns all paths.