### PR TITLE
Copilot/add codec details to paths api

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -573,6 +573,63 @@ components:
           items:
             $ref: '#/components/schemas/PathConf'
 
+    PathTrack:
+      type: object
+      properties:
+        codec:
+          type: string
+        width:
+          type: integer
+          format: int64
+          description: Video width in pixels (video tracks only)
+        height:
+          type: integer
+          format: int64
+          description: Video height in pixels (video tracks only)
+        fps:
+          type: string
+          description: Frames per second (video tracks only)
+        h264Profile:
+          type: string
+          description: H264 profile (H264 tracks only)
+        h264Level:
+          type: string
+          description: H264 level (H264 tracks only)
+        h265Profile:
+          type: string
+          description: H265 profile (H265 tracks only)
+        h265Level:
+          type: string
+          description: H265 level (H265 tracks only)
+        vp9Profile:
+          type: integer
+          format: int64
+          description: VP9 profile (VP9 tracks only)
+        av1Profile:
+          type: integer
+          format: int64
+          description: AV1 profile (AV1 tracks only)
+        av1Level:
+          type: integer
+          format: int64
+          description: AV1 level (AV1 tracks only)
+        av1Tier:
+          type: integer
+          format: int64
+          description: AV1 tier (AV1 tracks only)
+        channels:
+          type: integer
+          format: int64
+          description: Number of audio channels (audio tracks only)
+        sampleRate:
+          type: integer
+          format: int64
+          description: Audio sample rate in Hz (audio tracks only)
+        bitDepth:
+          type: integer
+          format: int64
+          description: Audio bit depth (audio tracks only)
+
     Path:
       type: object
       properties:
@@ -591,7 +648,7 @@ components:
         tracks:
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/PathTrack'
         bytesReceived:
           type: integer
           format: int64

--- a/internal/api/api_paths_test.go
+++ b/internal/api/api_paths_test.go
@@ -41,7 +41,7 @@ func TestPathsList(t *testing.T) {
 				Source:        &defs.APIPathSourceOrReader{Type: "publisher", ID: "pub1"},
 				Ready:         true,
 				ReadyTime:     &now,
-				Tracks:        []string{"H264", "Opus"},
+				Tracks:        []defs.APIPathTrack{{Codec: "H264"}, {Codec: "Opus"}},
 				BytesReceived: 1000,
 				BytesSent:     2000,
 				Readers: []defs.APIPathSourceOrReader{
@@ -52,7 +52,7 @@ func TestPathsList(t *testing.T) {
 				Name:          "test2",
 				ConfName:      "test2",
 				Ready:         false,
-				Tracks:        []string{},
+				Tracks:        []defs.APIPathTrack{},
 				BytesReceived: 500,
 				BytesSent:     100,
 				Readers:       []defs.APIPathSourceOrReader{},
@@ -94,7 +94,7 @@ func TestPathsGet(t *testing.T) {
 				Source:        &defs.APIPathSourceOrReader{Type: "rtspSession", ID: "session123"},
 				Ready:         true,
 				ReadyTime:     &now,
-				Tracks:        []string{"H264", "Opus"},
+				Tracks:        []defs.APIPathTrack{{Codec: "H264"}, {Codec: "Opus"}},
 				BytesReceived: 123456,
 				BytesSent:     789012,
 				Readers: []defs.APIPathSourceOrReader{

--- a/internal/core/api_test.go
+++ b/internal/core/api_test.go
@@ -78,13 +78,17 @@ func TestAPIPathsList(t *testing.T) {
 		Type string `json:"type"`
 	}
 
+	type pathTrack struct {
+		Codec string `json:"codec"`
+	}
+
 	type path struct {
-		Name          string     `json:"name"`
-		Source        pathSource `json:"source"`
-		Ready         bool       `json:"ready"`
-		Tracks        []string   `json:"tracks"`
-		BytesReceived uint64     `json:"bytesReceived"`
-		BytesSent     uint64     `json:"bytesSent"`
+		Name          string      `json:"name"`
+		Source        pathSource  `json:"source"`
+		Ready         bool        `json:"ready"`
+		Tracks        []pathTrack `json:"tracks"`
+		BytesReceived uint64      `json:"bytesReceived"`
+		BytesSent     uint64      `json:"bytesSent"`
 	}
 
 	type pathList struct {
@@ -136,7 +140,7 @@ func TestAPIPathsList(t *testing.T) {
 					Type: "rtspSession",
 				},
 				Ready:         true,
-				Tracks:        []string{"H264", "MPEG-4 Audio"},
+				Tracks:        []pathTrack{{Codec: "H264"}, {Codec: "MPEG-4 Audio"}},
 				BytesReceived: 17,
 			}},
 		}, out)
@@ -184,7 +188,7 @@ func TestAPIPathsList(t *testing.T) {
 					Type: "rtspsSession",
 				},
 				Ready:  true,
-				Tracks: []string{"H264", "MPEG-4 Audio"},
+				Tracks: []pathTrack{{Codec: "H264"}, {Codec: "MPEG-4 Audio"}},
 			}},
 		}, out)
 	})
@@ -213,7 +217,7 @@ func TestAPIPathsList(t *testing.T) {
 					Type: "rtspSource",
 				},
 				Ready:  false,
-				Tracks: []string{},
+				Tracks: []pathTrack{},
 			}},
 		}, out)
 	})
@@ -242,7 +246,7 @@ func TestAPIPathsList(t *testing.T) {
 					Type: "rtmpSource",
 				},
 				Ready:  false,
-				Tracks: []string{},
+				Tracks: []pathTrack{},
 			}},
 		}, out)
 	})
@@ -271,7 +275,7 @@ func TestAPIPathsList(t *testing.T) {
 					Type: "hlsSource",
 				},
 				Ready:  false,
-				Tracks: []string{},
+				Tracks: []pathTrack{},
 			}},
 		}, out)
 	})
@@ -294,13 +298,17 @@ func TestAPIPathsGet(t *testing.T) {
 				Type string `json:"type"`
 			}
 
+			type pathTrack struct {
+				Codec string `json:"codec"`
+			}
+
 			type path struct {
-				Name          string     `json:"name"`
-				Source        pathSource `json:"source"`
-				Ready         bool       `json:"Ready"`
-				Tracks        []string   `json:"tracks"`
-				BytesReceived uint64     `json:"bytesReceived"`
-				BytesSent     uint64     `json:"bytesSent"`
+				Name          string      `json:"name"`
+				Source        pathSource  `json:"source"`
+				Ready         bool        `json:"Ready"`
+				Tracks        []pathTrack `json:"tracks"`
+				BytesReceived uint64      `json:"bytesReceived"`
+				BytesSent     uint64      `json:"bytesSent"`
 			}
 
 			var pathName string
@@ -329,7 +337,7 @@ func TestAPIPathsGet(t *testing.T) {
 						Type: "rtspSession",
 					},
 					Ready:  true,
-					Tracks: []string{"H264"},
+					Tracks: []pathTrack{{Codec: "H264"}},
 				}, out)
 			} else {
 				res, err := hc.Get("http://localhost:9997/v3/paths/get/" + pathName)

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -565,11 +565,11 @@ func (pa *path) doAPIPathsGet(req pathAPIPathsGetReq) {
 				v := pa.readyTime
 				return &v
 			}(),
-			Tracks: func() []string {
+			Tracks: func() []defs.APIPathTrack {
 				if !pa.isReady() {
-					return []string{}
+					return []defs.APIPathTrack{}
 				}
-				return defs.MediasToCodecs(pa.stream.Desc.Medias)
+				return defs.MediasToTracks(pa.stream.Desc.Medias)
 			}(),
 			BytesReceived: func() uint64 {
 				if !pa.isReady() {

--- a/internal/defs/api.go
+++ b/internal/defs/api.go
@@ -80,6 +80,29 @@ type APIPathSourceOrReader struct {
 	ID   string `json:"id"`
 }
 
+// APIPathTrack is a track in a path with detailed codec information.
+type APIPathTrack struct {
+	Codec string `json:"codec"`
+
+	// Video-specific fields (only set for video tracks)
+	Width        *int    `json:"width,omitempty"`
+	Height       *int    `json:"height,omitempty"`
+	FPS          *string `json:"fps,omitempty"`
+	H264Profile  *string `json:"h264Profile,omitempty"`
+	H264Level    *string `json:"h264Level,omitempty"`
+	H265Profile  *string `json:"h265Profile,omitempty"`
+	H265Level    *string `json:"h265Level,omitempty"`
+	VP9Profile   *int    `json:"vp9Profile,omitempty"`
+	AV1Profile   *int    `json:"av1Profile,omitempty"`
+	AV1Level     *int    `json:"av1Level,omitempty"`
+	AV1Tier      *int    `json:"av1Tier,omitempty"`
+
+	// Audio-specific fields (only set for audio tracks)
+	Channels   *int `json:"channels,omitempty"`
+	SampleRate *int `json:"sampleRate,omitempty"`
+	BitDepth   *int `json:"bitDepth,omitempty"`
+}
+
 // APIPath is a path.
 type APIPath struct {
 	Name          string                  `json:"name"`
@@ -87,7 +110,7 @@ type APIPath struct {
 	Source        *APIPathSourceOrReader  `json:"source"`
 	Ready         bool                    `json:"ready"`
 	ReadyTime     *time.Time              `json:"readyTime"`
-	Tracks        []string                `json:"tracks"`
+	Tracks        []APIPathTrack          `json:"tracks"`
 	BytesReceived uint64                  `json:"bytesReceived"`
 	BytesSent     uint64                  `json:"bytesSent"`
 	Readers       []APIPathSourceOrReader `json:"readers"`

--- a/internal/defs/source.go
+++ b/internal/defs/source.go
@@ -13,6 +13,12 @@ import (
 	"github.com/bluenviron/mediamtx/internal/logger"
 )
 
+// G711 default values
+const (
+	g711DefaultChannels   = 1
+	g711DefaultSampleRate = 8000
+)
+
 // Source is an entity that can provide a stream.
 // it can be:
 // - Publisher
@@ -226,12 +232,12 @@ func FormatToTrack(forma format.Format) APIPathTrack {
 	case *format.G711:
 		channels := f.ChannelCount
 		if channels == 0 {
-			channels = 1 // G.711 is typically mono
+			channels = g711DefaultChannels
 		}
 		track.Channels = &channels
 		sampleRate := f.SampleRate
 		if sampleRate == 0 {
-			sampleRate = 8000 // G.711 default sample rate
+			sampleRate = g711DefaultSampleRate
 		}
 		track.SampleRate = &sampleRate
 

--- a/internal/defs/source.go
+++ b/internal/defs/source.go
@@ -2,10 +2,13 @@ package defs
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h265"
 
 	"github.com/bluenviron/mediamtx/internal/logger"
 )
@@ -60,4 +63,205 @@ func MediasInfo(medias []*description.Media) string {
 	}
 
 	return FormatsInfo(formats)
+}
+
+func h264ProfileString(profileIdc uint8) string {
+	switch profileIdc {
+	case 66:
+		return "Baseline"
+	case 77:
+		return "Main"
+	case 88:
+		return "Extended"
+	case 100:
+		return "High"
+	case 110:
+		return "High 10"
+	case 122:
+		return "High 4:2:2"
+	case 244:
+		return "High 4:4:4 Predictive"
+	default:
+		return strconv.Itoa(int(profileIdc))
+	}
+}
+
+func h264LevelString(levelIdc uint8) string {
+	major := levelIdc / 10
+	minor := levelIdc % 10
+	if minor == 0 {
+		return fmt.Sprintf("%d", major)
+	}
+	return fmt.Sprintf("%d.%d", major, minor)
+}
+
+func h265ProfileString(profileIdc uint8) string {
+	switch profileIdc {
+	case 1:
+		return "Main"
+	case 2:
+		return "Main 10"
+	case 3:
+		return "Main Still Picture"
+	case 4:
+		return "Range Extensions"
+	case 5:
+		return "High Throughput"
+	case 6:
+		return "Multiview Main"
+	case 7:
+		return "Scalable Main"
+	case 8:
+		return "3D Main"
+	case 9:
+		return "Screen Content Coding Extensions"
+	case 10:
+		return "Scalable Range Extensions"
+	default:
+		return strconv.Itoa(int(profileIdc))
+	}
+}
+
+func h265LevelString(levelIdc uint8) string {
+	// H.265 level_idc = 30 * level, so 3.0 = 90, 4.0 = 120, 4.1 = 123
+	level := float64(levelIdc) / 30.0
+	// Check if it's a clean level like 3.0, 4.0
+	if levelIdc%30 == 0 {
+		return fmt.Sprintf("%.0f", level)
+	}
+	return fmt.Sprintf("%.1f", level)
+}
+
+func fpsString(fps float64) string {
+	// Round to 2 decimal places for display
+	if fps == float64(int(fps)) {
+		return fmt.Sprintf("%.0f", fps)
+	}
+	return fmt.Sprintf("%.2f", fps)
+}
+
+// FormatToTrack converts a single format to an APIPathTrack with detailed codec information.
+func FormatToTrack(forma format.Format) APIPathTrack {
+	track := APIPathTrack{
+		Codec: forma.Codec(),
+	}
+
+	switch f := forma.(type) {
+	case *format.H264:
+		sps, _ := f.SafeParams()
+		if len(sps) > 0 {
+			var parsedSPS h264.SPS
+			if err := parsedSPS.Unmarshal(sps); err == nil {
+				width := parsedSPS.Width()
+				height := parsedSPS.Height()
+				track.Width = &width
+				track.Height = &height
+
+				fps := parsedSPS.FPS()
+				if fps > 0 {
+					fpsStr := fpsString(fps)
+					track.FPS = &fpsStr
+				}
+
+				profile := h264ProfileString(parsedSPS.ProfileIdc)
+				level := h264LevelString(parsedSPS.LevelIdc)
+				track.H264Profile = &profile
+				track.H264Level = &level
+			}
+		}
+
+	case *format.H265:
+		_, sps, _ := f.SafeParams()
+		if len(sps) > 0 {
+			var parsedSPS h265.SPS
+			if err := parsedSPS.Unmarshal(sps); err == nil {
+				width := parsedSPS.Width()
+				height := parsedSPS.Height()
+				track.Width = &width
+				track.Height = &height
+
+				fps := parsedSPS.FPS()
+				if fps > 0 {
+					fpsStr := fpsString(fps)
+					track.FPS = &fpsStr
+				}
+
+				profile := h265ProfileString(parsedSPS.ProfileTierLevel.GeneralProfileIdc)
+				level := h265LevelString(parsedSPS.ProfileTierLevel.GeneralLevelIdc)
+				track.H265Profile = &profile
+				track.H265Level = &level
+			}
+		}
+
+	case *format.VP9:
+		if f.ProfileID != nil {
+			track.VP9Profile = f.ProfileID
+		}
+
+	case *format.AV1:
+		if f.Profile != nil {
+			track.AV1Profile = f.Profile
+		}
+		if f.LevelIdx != nil {
+			track.AV1Level = f.LevelIdx
+		}
+		if f.Tier != nil {
+			track.AV1Tier = f.Tier
+		}
+
+	case *format.Opus:
+		channels := f.ChannelCount
+		track.Channels = &channels
+		sampleRate := f.ClockRate()
+		track.SampleRate = &sampleRate
+
+	case *format.MPEG4Audio:
+		if f.Config != nil {
+			channels := f.Config.ChannelCount
+			track.Channels = &channels
+			sampleRate := f.Config.SampleRate
+			track.SampleRate = &sampleRate
+		}
+
+	case *format.G711:
+		channels := f.ChannelCount
+		if channels == 0 {
+			channels = 1 // G.711 is typically mono
+		}
+		track.Channels = &channels
+		sampleRate := f.SampleRate
+		if sampleRate == 0 {
+			sampleRate = 8000 // G.711 default sample rate
+		}
+		track.SampleRate = &sampleRate
+
+	case *format.LPCM:
+		bitDepth := f.BitDepth
+		track.BitDepth = &bitDepth
+		channels := f.ChannelCount
+		track.Channels = &channels
+		sampleRate := f.SampleRate
+		track.SampleRate = &sampleRate
+	}
+
+	return track
+}
+
+// FormatsToTracks converts formats to detailed track information.
+func FormatsToTracks(formats []format.Format) []APIPathTrack {
+	ret := make([]APIPathTrack, len(formats))
+	for i, forma := range formats {
+		ret[i] = FormatToTrack(forma)
+	}
+	return ret
+}
+
+// MediasToTracks converts medias to detailed track information.
+func MediasToTracks(medias []*description.Media) []APIPathTrack {
+	var formats []format.Format
+	for _, media := range medias {
+		formats = append(formats, media.Formats...)
+	}
+
+	return FormatsToTracks(formats)
 }

--- a/internal/defs/source_test.go
+++ b/internal/defs/source_test.go
@@ -1,0 +1,202 @@
+package defs
+
+import (
+	"testing"
+
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/mpeg4audio"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatToTrack_H264(t *testing.T) {
+	// H264 SPS with profile=High (100), level=4.1 (41), 1920x1080@30fps
+	sps := []byte{
+		0x67, 0x64, 0x00, 0x29, 0xac, 0xd9, 0x40, 0x78,
+		0x02, 0x27, 0xe5, 0xc0, 0x44, 0x00, 0x00, 0x03,
+		0x00, 0x04, 0x00, 0x00, 0x03, 0x00, 0xf0, 0x3c,
+		0x60, 0xc6, 0x58,
+	}
+	pps := []byte{0x68, 0xeb, 0xe3, 0xcb, 0x22, 0xc0}
+
+	forma := &format.H264{
+		SPS: sps,
+		PPS: pps,
+	}
+
+	track := FormatToTrack(forma)
+
+	require.Equal(t, "H264", track.Codec)
+	require.NotNil(t, track.Width)
+	require.NotNil(t, track.Height)
+	require.NotNil(t, track.H264Profile)
+	require.NotNil(t, track.H264Level)
+	// Profile/level assertions depend on actual SPS parsing
+}
+
+func TestFormatToTrack_H264_NoSPS(t *testing.T) {
+	forma := &format.H264{}
+
+	track := FormatToTrack(forma)
+
+	require.Equal(t, "H264", track.Codec)
+	require.Nil(t, track.Width)
+	require.Nil(t, track.Height)
+	require.Nil(t, track.H264Profile)
+	require.Nil(t, track.H264Level)
+}
+
+func TestFormatToTrack_VP9(t *testing.T) {
+	profile := 0
+	forma := &format.VP9{
+		ProfileID: &profile,
+	}
+
+	track := FormatToTrack(forma)
+
+	require.Equal(t, "VP9", track.Codec)
+	require.NotNil(t, track.VP9Profile)
+	require.Equal(t, 0, *track.VP9Profile)
+}
+
+func TestFormatToTrack_AV1(t *testing.T) {
+	profile := 0
+	level := 5
+	tier := 0
+	forma := &format.AV1{
+		Profile:  &profile,
+		LevelIdx: &level,
+		Tier:     &tier,
+	}
+
+	track := FormatToTrack(forma)
+
+	require.Equal(t, "AV1", track.Codec)
+	require.NotNil(t, track.AV1Profile)
+	require.NotNil(t, track.AV1Level)
+	require.NotNil(t, track.AV1Tier)
+	require.Equal(t, 0, *track.AV1Profile)
+	require.Equal(t, 5, *track.AV1Level)
+	require.Equal(t, 0, *track.AV1Tier)
+}
+
+func TestFormatToTrack_Opus(t *testing.T) {
+	forma := &format.Opus{
+		ChannelCount: 2,
+	}
+
+	track := FormatToTrack(forma)
+
+	require.Equal(t, "Opus", track.Codec)
+	require.NotNil(t, track.Channels)
+	require.NotNil(t, track.SampleRate)
+	require.Equal(t, 2, *track.Channels)
+	require.Equal(t, 48000, *track.SampleRate) // Opus is always 48kHz
+}
+
+func TestFormatToTrack_MPEG4Audio(t *testing.T) {
+	forma := &format.MPEG4Audio{
+		Config: &mpeg4audio.AudioSpecificConfig{
+			SampleRate:   44100,
+			ChannelCount: 2,
+		},
+	}
+
+	track := FormatToTrack(forma)
+
+	require.Equal(t, "MPEG-4 Audio", track.Codec)
+	require.NotNil(t, track.Channels)
+	require.NotNil(t, track.SampleRate)
+	require.Equal(t, 2, *track.Channels)
+	require.Equal(t, 44100, *track.SampleRate)
+}
+
+func TestFormatToTrack_G711(t *testing.T) {
+	forma := &format.G711{
+		MULaw: true,
+	}
+
+	track := FormatToTrack(forma)
+
+	require.Equal(t, "G711", track.Codec)
+	require.NotNil(t, track.Channels)
+	require.NotNil(t, track.SampleRate)
+	require.Equal(t, 1, *track.Channels)
+	require.Equal(t, 8000, *track.SampleRate)
+}
+
+func TestFormatToTrack_LPCM(t *testing.T) {
+	forma := &format.LPCM{
+		BitDepth:     16,
+		SampleRate:   48000,
+		ChannelCount: 2,
+	}
+
+	track := FormatToTrack(forma)
+
+	require.Equal(t, "LPCM", track.Codec)
+	require.NotNil(t, track.BitDepth)
+	require.NotNil(t, track.Channels)
+	require.NotNil(t, track.SampleRate)
+	require.Equal(t, 16, *track.BitDepth)
+	require.Equal(t, 2, *track.Channels)
+	require.Equal(t, 48000, *track.SampleRate)
+}
+
+func TestFormatsToTracks(t *testing.T) {
+	formats := []format.Format{
+		&format.H264{},
+		&format.Opus{ChannelCount: 2},
+	}
+
+	tracks := FormatsToTracks(formats)
+
+	require.Len(t, tracks, 2)
+	require.Equal(t, "H264", tracks[0].Codec)
+	require.Equal(t, "Opus", tracks[1].Codec)
+}
+
+func TestH264ProfileString(t *testing.T) {
+	tests := []struct {
+		profileIdc uint8
+		expected   string
+	}{
+		{66, "Baseline"},
+		{77, "Main"},
+		{88, "Extended"},
+		{100, "High"},
+		{110, "High 10"},
+		{122, "High 4:2:2"},
+		{244, "High 4:4:4 Predictive"},
+		{99, "99"}, // Unknown profile
+	}
+
+	for _, tc := range tests {
+		result := h264ProfileString(tc.profileIdc)
+		require.Equal(t, tc.expected, result)
+	}
+}
+
+func TestH264LevelString(t *testing.T) {
+	tests := []struct {
+		levelIdc uint8
+		expected string
+	}{
+		{10, "1"},
+		{11, "1.1"},
+		{12, "1.2"},
+		{20, "2"},
+		{21, "2.1"},
+		{30, "3"},
+		{31, "3.1"},
+		{40, "4"},
+		{41, "4.1"},
+		{50, "5"},
+		{51, "5.1"},
+		{52, "5.2"},
+	}
+
+	for _, tc := range tests {
+		result := h264LevelString(tc.levelIdc)
+		require.Equal(t, tc.expected, result)
+	}
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -35,7 +35,7 @@ func (dummyPathManager) APIPathsList() (*defs.APIPathList, error) {
 			},
 			Ready:         true,
 			ReadyTime:     ptrOf(time.Date(2003, 11, 4, 23, 15, 7, 0, time.UTC)),
-			Tracks:        []string{"H264", "H265"},
+			Tracks:        []defs.APIPathTrack{{Codec: "H264"}, {Codec: "H265"}},
 			BytesReceived: 123,
 			BytesSent:     456,
 			Readers: []defs.APIPathSourceOrReader{


### PR DESCRIPTION
This pull request updates the API and internal data structures to provide detailed codec information for each track in a path, replacing the previous approach of representing tracks as simple strings. The changes affect the OpenAPI schema, Go structs, serialization, and related tests, enabling clients to access richer metadata for video and audio tracks.

### API and Schema Changes

* Added a new `PathTrack` schema to `api/openapi.yaml` that includes detailed fields for codec type, video dimensions, frame rate, profiles, levels, and audio properties. The `tracks` property in the `Path` schema is now an array of `PathTrack` objects instead of strings. [[1]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3R576-R632) [[2]](diffhunk://#diff-6c08e65eef0374988297d041bd50f87b385613a7e478c3812cb5312cc3e1f1e3L594-R651)

### Go Struct and Serialization Updates

* Introduced the `APIPathTrack` struct in `internal/defs/api.go` with fields for codec, video, and audio details. Updated the `APIPath` struct and all relevant usages to use `[]APIPathTrack` instead of `[]string` for tracks.
* Refactored serialization logic in `internal/core/path.go` and related test mocks to populate detailed track info using the new `MediasToTracks` and `FormatsToTracks` functions. [[1]](diffhunk://#diff-bdb9a5337a779e8bed805dfbe2f23814b956499b8c748f71cd3a2aa28f9b341bL568-R572) [[2]](diffhunk://#diff-8ea0d64df378dd743e9e7106592591a8568f325916af29bf4980054b6373b370L38-R38)

### Track Information Extraction

* Added functions to extract and format profile, level, and other codec-specific metadata from media formats in `internal/defs/source.go`. These functions parse codec parameters and build `APIPathTrack` objects with appropriate fields. [[1]](diffhunk://#diff-8e97d6ffdbb81a9e7aba50a4a6051037ddca8062c950539d1623dc91d2df18d3R5-R21) [[2]](diffhunk://#diff-8e97d6ffdbb81a9e7aba50a4a6051037ddca8062c950539d1623dc91d2df18d3R73-R273)

### Test Updates

* Updated all affected tests to use the new `APIPathTrack` struct for tracks, ensuring correct serialization and deserialization of detailed track info. [[1]](diffhunk://#diff-d13729f5080d7bd4248df3728fc2129e236d93bf85c43061f3537ebe008e7b4bL44-R44) [[2]](diffhunk://#diff-d13729f5080d7bd4248df3728fc2129e236d93bf85c43061f3537ebe008e7b4bL55-R55) [[3]](diffhunk://#diff-d13729f5080d7bd4248df3728fc2129e236d93bf85c43061f3537ebe008e7b4bL97-R97) [[4]](diffhunk://#diff-1502d9dcb9300ff5c516c271f24b2b3bfe18d6966a7594366892f75da2b9dc2eR81-R89) [[5]](diffhunk://#diff-1502d9dcb9300ff5c516c271f24b2b3bfe18d6966a7594366892f75da2b9dc2eL139-R143) [[6]](diffhunk://#diff-1502d9dcb9300ff5c516c271f24b2b3bfe18d6966a7594366892f75da2b9dc2eL187-R191) [[7]](diffhunk://#diff-1502d9dcb9300ff5c516c271f24b2b3bfe18d6966a7594366892f75da2b9dc2eL216-R220) [[8]](diffhunk://#diff-1502d9dcb9300ff5c516c271f24b2b3bfe18d6966a7594366892f75da2b9dc2eL245-R249) [[9]](diffhunk://#diff-1502d9dcb9300ff5c516c271f24b2b3bfe18d6966a7594366892f75da2b9dc2eL274-R278) [[10]](diffhunk://#diff-1502d9dcb9300ff5c516c271f24b2b3bfe18d6966a7594366892f75da2b9dc2eR301-R309) [[11]](diffhunk://#diff-1502d9dcb9300ff5c516c271f24b2b3bfe18d6966a7594366892f75da2b9dc2eL332-R340)

### Unit Tests for Track Extraction

* Added a comprehensive unit test suite for the new track extraction logic in `internal/defs/source_test.go`, covering all supported codecs and validating correct population of metadata fields.