### PR TITLE
Add support unix socket types SOCK_SEQPACKET and SOCK_DGRAM

### DIFF
--- a/docs/2-usage/02-publish.md
+++ b/docs/2-usage/02-publish.md
@@ -237,6 +237,7 @@ paths:
   mypath:
     source: unix+mpegts:///tmp/socket.sock
 ```
+Alternatively, you can use the `unixgram+mpegts` or `unixpacket+mpegts` scheme to create SOCK_DGRAM or SOCK_SEQPACKET socket type, respectively. These socket types support packet boundaries, preventing packet merging at the transport layer, which can lead to decoding errors. The publisher must have the same socket type.
 
 ### RTP
 
@@ -279,6 +280,7 @@ paths:
       a=rtpmap:96 H264/90000
       a=fmtp:96 profile-level-id=42e01e;packetization-mode=1;sprop-parameter-sets=Z0LAHtkDxWhAAAADAEAAAAwDxYuS,aMuMsg==
 ```
+Alternatively, you can use the `unixgram+rtp` or `unixpacket+rtp` scheme to create SOCK_DGRAM or SOCK_SEQPACKET socket type, respectively. These socket types support packet boundaries, preventing packet merging at the transport layer, which can lead to decoding errors. The publisher must have the same socket type.
 
 ## Devices
 

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -438,6 +438,10 @@ func (pconf *Path) validate(
 
 	case strings.HasPrefix(pconf.Source, "unix+mpegts://"):
 
+	case strings.HasPrefix(pconf.Source, "unixpacket+mpegts://"):
+
+	case strings.HasPrefix(pconf.Source, "unixgram+mpegts://"):
+
 	case strings.HasPrefix(pconf.Source, "udp+rtp://"):
 		_, _, err := net.SplitHostPort(pconf.Source[len("udp+rtp://"):])
 		if err != nil {
@@ -449,6 +453,16 @@ func (pconf *Path) validate(
 		}
 
 	case strings.HasPrefix(pconf.Source, "unix+rtp://"):
+		if pconf.RTPSDP == "" {
+			return fmt.Errorf("`rtpSDP` was not provided")
+		}
+
+	case strings.HasPrefix(pconf.Source, "unixpacket+rtp://"):
+		if pconf.RTPSDP == "" {
+			return fmt.Errorf("`rtpSDP` was not provided")
+		}
+
+	case strings.HasPrefix(pconf.Source, "unixgram+rtp://"):
 		if pconf.RTPSDP == "" {
 			return fmt.Errorf("`rtpSDP` was not provided")
 		}

--- a/internal/protocols/unix/unix.go
+++ b/internal/protocols/unix/unix.go
@@ -115,7 +115,7 @@ func (r *unixConn) SetWriteDeadline(_ time.Time) error {
 }
 
 // CreateConn creates a Unix socket connection.
-func CreateConn(u *url.URL) (net.Conn, error) {
+func CreateConn(u *url.URL, n string) (net.Conn, error) {
 	var pa string
 	if u.Path != "" {
 		pa = u.Path
@@ -124,12 +124,12 @@ func CreateConn(u *url.URL) (net.Conn, error) {
 	}
 
 	if pa == "" {
-		return nil, fmt.Errorf("invalid unix path")
+		return nil, fmt.Errorf("invalid %s path", n)
 	}
 
 	os.Remove(pa)
 
-	socket, err := net.Listen("unix", pa)
+	socket, err := net.Listen(n, pa)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/protocols/unixgram/unixgram.go
+++ b/internal/protocols/unixgram/unixgram.go
@@ -1,0 +1,90 @@
+// Package unix contains utilities to work with Unix sockets.
+package unixgram
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/bluenviron/gortsplib/v5/pkg/readbuffer"
+)
+
+type packetConn interface {
+	net.PacketConn
+	SetReadBuffer(bytes int) error
+	SyscallConn() (syscall.RawConn, error)
+}
+
+type unixgramConn struct {
+	pc net.PacketConn
+}
+
+func (r *unixgramConn) Close() error {
+	return r.pc.Close()
+}
+
+func (r *unixgramConn) Read(p []byte) (int, error) {
+	n, _, err := r.pc.ReadFrom(p)
+	return n, err
+}
+
+func (r *unixgramConn) Write(_ []byte) (int, error) {
+	panic("unimplemented")
+}
+
+func (r *unixgramConn) LocalAddr() net.Addr {
+	panic("unimplemented")
+}
+
+func (r *unixgramConn) RemoteAddr() net.Addr {
+	panic("unimplemented")
+}
+
+func (r *unixgramConn) SetDeadline(_ time.Time) error {
+	panic("unimplemented")
+}
+
+func (r *unixgramConn) SetReadDeadline(t time.Time) error {
+	return r.pc.SetReadDeadline(t)
+}
+
+func (r *unixgramConn) SetWriteDeadline(_ time.Time) error {
+	panic("unimplemented")
+}
+
+// CreateConn creates a Unix socket connection.
+func CreateConn(u *url.URL, udpReadBufferSize int) (net.Conn, error) {
+	var pa string
+	if u.Path != "" {
+		pa = u.Path
+	} else {
+		pa = u.Host
+	}
+
+	if pa == "" {
+		return nil, fmt.Errorf("invalid unixgram path")
+	}
+
+	os.Remove(pa)
+
+	var pc packetConn
+	var tmp net.PacketConn
+	tmp, err := net.ListenPacket("unixgram", pa)
+	if err != nil {
+		return nil, err
+	}
+	pc = tmp.(*net.UnixConn)
+
+	if udpReadBufferSize != 0 {
+		err = readbuffer.SetReadBuffer(pc, udpReadBufferSize)
+		if err != nil {
+			pc.Close()
+			return nil, err
+		}
+	}
+
+	return &unixgramConn{pc: pc}, nil
+}

--- a/internal/protocols/unixgram/unixgram.go
+++ b/internal/protocols/unixgram/unixgram.go
@@ -1,4 +1,4 @@
-// Package unix contains utilities to work with Unix sockets.
+// Package unixgram contains utilities to work with Unix sockets.
 package unixgram
 
 import (

--- a/internal/staticsources/handler.go
+++ b/internal/staticsources/handler.go
@@ -126,7 +126,9 @@ func (s *Handler) Initialize() {
 
 	case strings.HasPrefix(s.Conf.Source, "udp://") ||
 		strings.HasPrefix(s.Conf.Source, "udp+mpegts://") ||
-		strings.HasPrefix(s.Conf.Source, "unix+mpegts://"):
+		strings.HasPrefix(s.Conf.Source, "unix+mpegts://") ||
+		strings.HasPrefix(s.Conf.Source, "unixpacket+mpegts://") ||
+		strings.HasPrefix(s.Conf.Source, "unixgram+mpegts://"):
 		s.instance = &ssmpegts.Source{
 			ReadTimeout:       s.ReadTimeout,
 			UDPReadBufferSize: s.UDPReadBufferSize,
@@ -148,7 +150,9 @@ func (s *Handler) Initialize() {
 		}
 
 	case strings.HasPrefix(s.Conf.Source, "udp+rtp://") ||
-		strings.HasPrefix(s.Conf.Source, "unix+rtp://"):
+		strings.HasPrefix(s.Conf.Source, "unix+rtp://") ||
+		strings.HasPrefix(s.Conf.Source, "unixpacket+rtp://") ||
+		strings.HasPrefix(s.Conf.Source, "unixgram+rtp://"):
 		s.instance = &ssrtp.Source{
 			ReadTimeout:       s.ReadTimeout,
 			UDPReadBufferSize: s.UDPReadBufferSize,

--- a/internal/staticsources/mpegts/source.go
+++ b/internal/staticsources/mpegts/source.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bluenviron/mediamtx/internal/protocols/mpegts"
 	"github.com/bluenviron/mediamtx/internal/protocols/udp"
 	"github.com/bluenviron/mediamtx/internal/protocols/unix"
+	"github.com/bluenviron/mediamtx/internal/protocols/unixgram"
 	"github.com/bluenviron/mediamtx/internal/stream"
 )
 
@@ -50,7 +51,24 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 
 	switch u.Scheme {
 	case "unix+mpegts":
-		nc, err = unix.CreateConn(u)
+		nc, err = unix.CreateConn(u, "unix")
+		if err != nil {
+			return err
+		}
+
+	case "unixpacket+mpegts":
+		nc, err = unix.CreateConn(u, "unixpacket")
+		if err != nil {
+			return err
+		}
+
+	case "unixgram+mpegts":
+		udpReadBufferSize := s.UDPReadBufferSize
+		if params.Conf.RTPUDPReadBufferSize != nil {
+			udpReadBufferSize = *params.Conf.RTPUDPReadBufferSize
+		}
+
+		nc, err = unixgram.CreateConn(u, int(udpReadBufferSize))
 		if err != nil {
 			return err
 		}

--- a/internal/staticsources/rtp/source.go
+++ b/internal/staticsources/rtp/source.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/protocols/udp"
 	"github.com/bluenviron/mediamtx/internal/protocols/unix"
+	"github.com/bluenviron/mediamtx/internal/protocols/unixgram"
 	"github.com/bluenviron/mediamtx/internal/stream"
 	"github.com/pion/rtp"
 )
@@ -63,7 +64,24 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 
 	switch u.Scheme {
 	case "unix+rtp":
-		nc, err = unix.CreateConn(u)
+		nc, err = unix.CreateConn(u, "unix")
+		if err != nil {
+			return err
+		}
+
+	case "unixpacket+rtp":
+		nc, err = unix.CreateConn(u, "unixpacket")
+		if err != nil {
+			return err
+		}
+
+	case "unixgram+rtp":
+		udpReadBufferSize := s.UDPReadBufferSize
+		if params.Conf.RTPUDPReadBufferSize != nil {
+			udpReadBufferSize = *params.Conf.RTPUDPReadBufferSize
+		}
+
+		nc, err = unixgram.CreateConn(u, int(udpReadBufferSize))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As mentioned in issue #4999, the socket with type SOCK_STREAM causes packet merging and decoding errors. Adding the SOCK_DGRAM and SOCK_SEQPACKET types ensures record boundaries, allowing packets to be read correctly one at a time.