### PR TITLE
feat: add resolution and bitrate information to API responses

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -592,6 +592,14 @@ components:
           type: array
           items:
             type: string
+        resolutions:
+          type: array
+          items:
+            type: string
+        bitrates:
+          type: array
+          items:
+            type: string
         bytesReceived:
           type: integer
           format: int64

--- a/internal/api/api_paths_test.go
+++ b/internal/api/api_paths_test.go
@@ -42,6 +42,8 @@ func TestPathsList(t *testing.T) {
 				Ready:         true,
 				ReadyTime:     &now,
 				Tracks:        []string{"H264", "Opus"},
+				Resolutions:   []string{"1920x1080", ""},
+				Bitrates:      []string{"4500kbps", ""},
 				BytesReceived: 1000,
 				BytesSent:     2000,
 				Readers: []defs.APIPathSourceOrReader{

--- a/internal/codecprocessor/h264.go
+++ b/internal/codecprocessor/h264.go
@@ -309,3 +309,12 @@ func (t *h264) ProcessRTPPacket( //nolint:dupl
 
 	return nil
 }
+
+// ExtractH264Resolution extracts width and height from H264 SPS
+func ExtractH264Resolution(sps []byte) (int, int) {
+	var s mch264.SPS
+	if err := s.Unmarshal(sps); err != nil {
+		return 0, 0
+	}
+	return s.Width(), s.Height()
+}

--- a/internal/codecprocessor/h265.go
+++ b/internal/codecprocessor/h265.go
@@ -341,3 +341,12 @@ func (t *h265) ProcessRTPPacket( //nolint:dupl
 
 	return nil
 }
+
+// ExtractH265Resolution extracts width and height from H265 SPS
+func ExtractH265Resolution(sps []byte) (int, int) {
+	var s mch265.SPS
+	if err := s.Unmarshal(sps); err != nil {
+		return 0, 0
+	}
+	return s.Width(), s.Height()
+}

--- a/internal/defs/api.go
+++ b/internal/defs/api.go
@@ -88,6 +88,8 @@ type APIPath struct {
 	Ready         bool                    `json:"ready"`
 	ReadyTime     *time.Time              `json:"readyTime"`
 	Tracks        []string                `json:"tracks"`
+	Resolutions   []string                `json:"resolutions"`
+	Bitrates      []string                `json:"bitrates"`
 	BytesReceived uint64                  `json:"bytesReceived"`
 	BytesSent     uint64                  `json:"bytesSent"`
 	Readers       []APIPathSourceOrReader `json:"readers"`

--- a/internal/defs/source.go
+++ b/internal/defs/source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bluenviron/gortsplib/v5/pkg/format"
 
 	"github.com/bluenviron/mediamtx/internal/logger"
+	"github.com/bluenviron/mediamtx/internal/codecprocessor"
 )
 
 // Source is an entity that can provide a stream.
@@ -50,6 +51,42 @@ func MediasToCodecs(medias []*description.Media) []string {
 	}
 
 	return FormatsToCodecs(formats)
+}
+
+// MediasToResolutions returns the resolutions of given medias.
+func MediasToResolutions(medias []*description.Media) []string {
+	var ret []string
+	for _, media := range medias {
+		for _, forma := range media.Formats {
+			ret = append(ret, getResolution(forma))
+		}
+	}
+	return ret
+}
+
+func getResolution(forma format.Format) string {
+	if h264f, ok := forma.(*format.H264); ok {
+		width, height := codecprocessor.ExtractH264Resolution(h264f.SPS)
+		if width > 0 && width <= 10000 && height > 0 && height <= 10000 {
+			return fmt.Sprintf("%dx%d", width, height)
+		}
+	} else if h265f, ok := forma.(*format.H265); ok {
+		width, height := codecprocessor.ExtractH265Resolution(h265f.SPS)
+		if width > 0 && width <= 10000 && height > 0 && height <= 10000 {
+			return fmt.Sprintf("%dx%d", width, height)
+		}
+	} else if mpeg4f, ok := forma.(*format.MPEG4Video); ok {
+		width, height := codecprocessor.ExtractMPEG4Resolution(mpeg4f.Config)
+		if width > 0 && width <= 10000 && height > 0 && height <= 10000 {
+			return fmt.Sprintf("%dx%d", width, height)
+		}
+	} else if _, ok := forma.(*format.MPEG1Video); ok {
+		width, height := codecprocessor.ExtractMPEG1Resolution(codecprocessor.MPEG1VideoDefaultConfig)
+		if width > 0 && width <= 10000 && height > 0 && height <= 10000 {
+			return fmt.Sprintf("%dx%d", width, height)
+		}
+	}
+	return ""
 }
 
 // MediasInfo returns a description of medias.


### PR DESCRIPTION
Hi everyone! This is my first contribution to a project I really enjoy, and I hope this change can help others.
This PR adds resolutions and bitrates fields to the API...

## What changed
- Added `resolutions` and `bitrates` fields to the API (`/v3/paths/list` and `/v3/paths/get/{name}`).
- Centralized resolution extraction in the `codecprocessor` package for H.264, H.265, MPEG-4, and MPEG-1.
- Updated OpenAPI documentation and tests.

## Why
- Previously, there were times when I needed to get the resolution and bitrate from the camera, and there was nothing in the API to guide me the first time.
- I believe this complements the existing API fields, enriching the API and making it more useful for developers.
- These details have helped me a lot in stream monitoring, so I wanted to share them here hopefully, they’re useful for everyone.

## How it works
- Resolutions come from codec parameters (SPS for H.264/H.265, config for MPEG-4/MPEG-1).
- Bitrate is calculated as an average based on time and received bytes.
- All values are validated to prevent invalid data.

## Testing and notes
- Tested with common streams and worked well.
- There may be edge cases, like corrupted SPS or rare formats, that I haven’t covered fully. Feedback is welcome!
- Local tests pass and nothing existing is broken.

Feedback is very welcome!
<img width="1152" height="648" alt="MediaMtx" src="https://github.com/user-attachments/assets/87482595-7192-467f-adc1-8449a8d371e9" />

