### PR TITLE
Convert booleans in `mediamtx.yml` template to YAML 1.2 format (`true`/`false`) to improve compatibility with YAML tools

### DIFF
--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -11,7 +11,7 @@ logLevel: info
 # Destinations of log messages; available values are "stdout", "file" and "syslog".
 logDestinations: [stdout]
 # When destination is "stdout" or "file", emit logs in structured format (JSON).
-logStructured: no
+logStructured: false
 # When "file" is in logDestinations, this is the file which will receive logs.
 logFile: mediamtx.log
 # When "syslog" is in logDestinations, use prefix for logs.
@@ -40,7 +40,7 @@ udpReadBufferSize: 0
 # * RTSP_PORT: RTSP server port
 runOnConnect:
 # Restart the command if it exits.
-runOnConnectRestart: no
+runOnConnectRestart: false
 # Command to run when a client disconnects from the server.
 # Environment variables are the same of runOnConnect.
 runOnDisconnect:
@@ -148,12 +148,12 @@ authJWTInHTTPQuery: true
 # Global settings -> Control API
 
 # Enable controlling the server through the Control API.
-api: no
+api: false
 # Address of the Control API listener.
 apiAddress: :9997
 # Enable TLS/HTTPS on the Control API server.
-apiEncryption: no
-# Path to the server key. This is needed only when encryption is yes.
+apiEncryption: false
+# Path to the server key. This is needed only when encryption is true.
 # This can be generated with:
 # openssl genrsa -out server.key 2048
 # openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
@@ -172,12 +172,12 @@ apiTrustedProxies: []
 # Global settings -> Metrics
 
 # Enable Prometheus-compatible metrics.
-metrics: no
+metrics: false
 # Address of the metrics HTTP listener.
 metricsAddress: :9998
 # Enable TLS/HTTPS on the Metrics server.
-metricsEncryption: no
-# Path to the server key. This is needed only when encryption is yes.
+metricsEncryption: false
+# Path to the server key. This is needed only when encryption is true.
 # This can be generated with:
 # openssl genrsa -out server.key 2048
 # openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
@@ -196,12 +196,12 @@ metricsTrustedProxies: []
 # Global settings -> PPROF
 
 # Enable pprof-compatible endpoint to monitor performances.
-pprof: no
+pprof: false
 # Address of the pprof listener.
 pprofAddress: :9999
 # Enable TLS/HTTPS on the pprof server.
-pprofEncryption: no
-# Path to the server key. This is needed only when encryption is yes.
+pprofEncryption: false
+# Path to the server key. This is needed only when encryption is true.
 # This can be generated with:
 # openssl genrsa -out server.key 2048
 # openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
@@ -220,12 +220,12 @@ pprofTrustedProxies: []
 # Global settings -> Playback server
 
 # Enable downloading recordings from the playback server.
-playback: no
+playback: false
 # Address of the playback server listener.
 playbackAddress: :9996
 # Enable TLS/HTTPS on the playback server.
-playbackEncryption: no
-# Path to the server key. This is needed only when encryption is yes.
+playbackEncryption: false
+# Path to the server key. This is needed only when encryption is true.
 # This can be generated with:
 # openssl genrsa -out server.key 2048
 # openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
@@ -244,7 +244,7 @@ playbackTrustedProxies: []
 # Global settings -> RTSP server
 
 # Enable publishing and reading streams with the RTSP protocol.
-rtsp: yes
+rtsp: true
 # List of enabled RTSP transport protocols.
 # UDP is the most performant, but doesn't work when there's a NAT/firewall between
 # server and clients.
@@ -292,7 +292,7 @@ rtspAuthMethods: [basic]
 # Global settings -> RTMP server
 
 # Enable publishing and reading streams with the RTMP protocol.
-rtmp: yes
+rtmp: true
 # Address of the RTMP listener. This is needed only when encryption is "no" or "optional".
 rtmpAddress: :1935
 # Encrypt connections with TLS (RTMPS).
@@ -312,13 +312,13 @@ rtmpServerCert: server.crt
 # Global settings -> HLS server
 
 # Enable reading streams with the HLS protocol.
-hls: yes
+hls: true
 # Address of the HLS listener.
 hlsAddress: :8888
 # Enable TLS/HTTPS on the HLS server.
 # This is required for Low-Latency HLS.
-hlsEncryption: no
-# Path to the server key. This is needed only when encryption is yes.
+hlsEncryption: false
+# Path to the server key. This is needed only when encryption is true.
 # This can be generated with:
 # openssl genrsa -out server.key 2048
 # openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
@@ -334,7 +334,7 @@ hlsAllowOrigins: ['*']
 hlsTrustedProxies: []
 # By default, HLS is generated only when requested by a user.
 # This option allows to generate it always, avoiding the delay between request and generation.
-hlsAlwaysRemux: no
+hlsAlwaysRemux: false
 # Variant of the HLS protocol to use. Available options are:
 # * mpegts - uses MPEG-TS segments, for maximum compatibility.
 # * fmp4 - uses fragmented MP4 segments, more efficient.
@@ -371,11 +371,11 @@ hlsMuxerCloseAfter: 60s
 # Global settings -> WebRTC server
 
 # Enable publishing and reading streams with the WebRTC protocol.
-webrtc: yes
+webrtc: true
 # Address of the WebRTC HTTP listener.
 webrtcAddress: :8889
 # Enable TLS/HTTPS on the WebRTC server.
-webrtcEncryption: no
+webrtcEncryption: false
 # Path to the server key.
 # This can be generated with:
 # openssl genrsa -out server.key 2048
@@ -399,7 +399,7 @@ webrtcLocalUDPAddress: :8189
 webrtcLocalTCPAddress: ''
 # WebRTC clients need to know the IP of the server.
 # Gather IPs from interfaces and send them to clients.
-webrtcIPsFromInterfaces: yes
+webrtcIPsFromInterfaces: true
 # List of interfaces whose IPs will be sent to clients.
 # An empty value means to use all available interfaces.
 webrtcIPsFromInterfacesList: []
@@ -426,7 +426,7 @@ webrtcSTUNGatherTimeout: 5s
 # Global settings -> SRT server
 
 # Enable publishing and reading streams with the SRT protocol.
-srt: yes
+srt: true
 # Address of the SRT listener.
 srtAddress: :8890
 
@@ -474,11 +474,11 @@ pathDefaults:
   sourceFingerprint:
   # If the source is a URL, it will be pulled only when at least
   # one reader is connected, saving bandwidth.
-  sourceOnDemand: no
-  # If sourceOnDemand is "yes", readers will be put on hold until the source is
+  sourceOnDemand: false
+  # If sourceOnDemand is true, readers will be put on hold until the source is
   # ready or until this amount of time has passed.
   sourceOnDemandStartTimeout: 10s
-  # If sourceOnDemand is "yes", the source will be closed when there are no
+  # If sourceOnDemand is true, the source will be closed when there are no
   # readers connected and this amount of time has passed.
   sourceOnDemandCloseAfter: 10s
   # Maximum number of readers. Zero means no limit.
@@ -495,7 +495,7 @@ pathDefaults:
   # Default path settings -> Record
 
   # Record streams to disk.
-  record: no
+  record: false
   # Path of recording segments.
   # Extension is added automatically.
   # Available variables are %path (path name), %Y %m %d (year, month, day),
@@ -521,7 +521,7 @@ pathDefaults:
   # Default path settings -> Publisher source (when source is "publisher")
 
   # Allow another client to disconnect the current publisher and publish in its place.
-  overridePublisher: yes
+  overridePublisher: true
   # SRT encryption passphrase required to publish to this path.
   srtPublishPassphrase:
 
@@ -532,7 +532,7 @@ pathDefaults:
   rtspTransport: automatic
   # Support sources that don't provide server ports or use random server ports. This is a security issue
   # and must be used only when interacting with sources that require it.
-  rtspAnyPort: no
+  rtspAnyPort: false
   # Range header to send to the source, in order to start streaming from the specified offset.
   # available values:
   # * clock: Absolute time
@@ -665,7 +665,7 @@ pathDefaults:
   #   a regular expression.
   runOnInit:
   # Restart the command if it exits.
-  runOnInitRestart: no
+  runOnInitRestart: false
 
   # Command to run when this path is requested by a reader
   # and no one is publishing to this path yet.
@@ -679,7 +679,7 @@ pathDefaults:
   #   a regular expression.
   runOnDemand:
   # Restart the command if it exits.
-  runOnDemandRestart: no
+  runOnDemandRestart: false
   # Readers will be put on hold until the runOnDemand command starts publishing
   # or until this amount of time has passed.
   runOnDemandStartTimeout: 10s
@@ -703,7 +703,7 @@ pathDefaults:
   #   a regular expression.
   runOnReady:
   # Restart the command if it exits.
-  runOnReadyRestart: no
+  runOnReadyRestart: false
   # Command to run when the stream is not available anymore.
   # Environment variables are the same of runOnReady.
   runOnNotReady:
@@ -720,7 +720,7 @@ pathDefaults:
   #   a regular expression.
   runOnRead:
   # Restart the command if it exits.
-  runOnReadRestart: no
+  runOnReadRestart: false
   # Command to run when a client stops reading.
   # Environment variables are the same of runOnRead.
   runOnUnread:


### PR DESCRIPTION
Tools like yq may not support YAML 1.1 booleans anymore, turning them into strings by mistake. Converting the config fully to modern YAML probably makes sense?