### PR TITLE
Add curl to ffmpeg images

### DIFF
--- a/docker/ffmpeg-rpi.Dockerfile
+++ b/docker/ffmpeg-rpi.Dockerfile
@@ -12,12 +12,12 @@ FROM --platform=linux/arm/v7 debian:bullseye-slim AS base-arm-v7
 # Raspbian libraries and compilers provide arm v6 compatibility.
 
 RUN apt update \
-	&& apt install -y wget gpg \
-	&& echo "deb http://archive.raspbian.org/raspbian bullseye main rpi firmware" > /etc/apt/sources.list \
-	&& echo "deb http://archive.raspberrypi.org/debian bullseye main" > /etc/apt/sources.list.d/raspi.list \
-	&& wget -O- https://archive.raspbian.org/raspbian.public.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspbian.gpg \
-	&& wget -O- https://archive.raspberrypi.org/debian/raspberrypi.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspberrypi.gpg \
-	&& rm -rf /var/lib/apt/lists/*
+    && apt install -y wget gpg \
+    && echo "deb http://archive.raspbian.org/raspbian bullseye main rpi firmware" > /etc/apt/sources.list \
+    && echo "deb http://archive.raspberrypi.org/debian bullseye main" > /etc/apt/sources.list.d/raspi.list \
+    && wget -O- https://archive.raspbian.org/raspbian.public.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspbian.gpg \
+    && wget -O- https://archive.raspberrypi.org/debian/raspberrypi.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspberrypi.gpg \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN apt update && apt install --reinstall -y \
     libc6 \
@@ -28,10 +28,10 @@ RUN apt update && apt install --reinstall -y \
 FROM --platform=linux/arm64 debian:bullseye-slim AS base-arm64
 
 RUN apt update \
-	&& apt install -y wget gpg \
-	&& echo "deb http://archive.raspberrypi.org/debian bullseye main" > /etc/apt/sources.list.d/raspi.list \
-	&& wget -O- https://archive.raspberrypi.org/debian/raspberrypi.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspberrypi.gpg \
-	&& rm -rf /var/lib/apt/lists/*
+    && apt install -y wget gpg \
+    && echo "deb http://archive.raspberrypi.org/debian bullseye main" > /etc/apt/sources.list.d/raspi.list \
+    && wget -O- https://archive.raspberrypi.org/debian/raspberrypi.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspberrypi.gpg \
+    && rm -rf /var/lib/apt/lists/*
 
 #################################################################
 FROM --platform=linux/amd64 scratch AS base
@@ -47,7 +47,7 @@ ARG TARGETPLATFORM
 COPY --from=base /$TARGETPLATFORM /
 
 RUN apt update \
-    && apt install -y --no-install-recommends ffmpeg \
+    && apt install -y --no-install-recommends ffmpeg curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=binaries /$TARGETPLATFORM /

--- a/docker/ffmpeg.Dockerfile
+++ b/docker/ffmpeg.Dockerfile
@@ -9,7 +9,7 @@ ADD binaries/mediamtx_*_linux_arm64.tar.gz /linux/arm64
 #################################################################
 FROM alpine:3.22
 
-RUN apk add --no-cache ffmpeg
+RUN apk add --no-cache ffmpeg curl
 
 ARG TARGETPLATFORM
 COPY --from=binaries /$TARGETPLATFORM /

--- a/docs/1-kickoff/2-install.md
+++ b/docs/1-kickoff/2-install.md
@@ -39,12 +39,12 @@ docker run --rm -it --network=host bluenviron/mediamtx:1
 
 There are four image variants:
 
-| name                             | FFmpeg included    | RPI Camera support |
-| -------------------------------- | ------------------ | ------------------ |
-| bluenviron/mediamtx:1            | :x:                | :x:                |
-| bluenviron/mediamtx:1-ffmpeg     | :heavy_check_mark: | :x:                |
-| bluenviron/mediamtx:1-rpi        | :x:                | :heavy_check_mark: |
-| bluenviron/mediamtx:1-ffmpeg-rpi | :heavy_check_mark: | :heavy_check_mark: |
+| name                             | FFmpeg included    | curl included      | RPI Camera support |
+| -------------------------------- | ------------------ | ------------------ | ------------------ |
+| bluenviron/mediamtx:1            | :x:                | :x:                | :x:                |
+| bluenviron/mediamtx:1-ffmpeg     | :heavy_check_mark: | :heavy_check_mark: | :x:                |
+| bluenviron/mediamtx:1-rpi        | :x:                | :x:                | :heavy_check_mark: |
+| bluenviron/mediamtx:1-ffmpeg-rpi | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 
 The `1` tag corresponds to the latest `1.x.x` release, that should guarantee backward compatibility when upgrading. It is also possible to bind the image to a specific release, by using the release name as tag (`bluenviron/mediamtx:{docker_version_tag}`).
 


### PR DESCRIPTION
## Add curl to ffmpeg images

Documentation examples for hooks use `curl`, but it's not available in any Docker image. This PR adds `curl` to `docker/ffmpeg.Dockerfile` and `docker/ffmpeg-rpi.Dockerfile`.

| name                             | FFmpeg included    | curl included      | RPI Camera support |
| -------------------------------- | ------------------ | ------------------ | ------------------ |
| bluenviron/mediamtx:1            | :x:                | :x:                | :x:                |
| bluenviron/mediamtx:1-ffmpeg     | :heavy_check_mark: | :heavy_check_mark: | :x:                |
| bluenviron/mediamtx:1-rpi        | :x:                | :x:                | :heavy_check_mark: |
| bluenviron/mediamtx:1-ffmpeg-rpi | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |


Other people had the same problem, for reference #5001 