### PR TITLE
rtsp: fix log labels of RTSPS listeners

### DIFF
--- a/internal/servers/rtsp/server.go
+++ b/internal/servers/rtsp/server.go
@@ -39,14 +39,32 @@ func interfaceIsEmpty(i any) bool {
 func printAddresses(srv *gortsplib.Server) string {
 	var ret []string
 
-	ret = append(ret, fmt.Sprintf("%s (TCP)", srv.RTSPAddress))
+	tmp := srv.RTSPAddress
+	if srv.TLSConfig == nil {
+		tmp += " (TCP/RTSP)"
+	} else {
+		tmp += " (TCP/RTSPS)"
+	}
+	ret = append(ret, tmp)
 
 	if srv.UDPRTPAddress != "" {
-		ret = append(ret, fmt.Sprintf("%s (UDP/RTP)", srv.UDPRTPAddress))
+		tmp = srv.UDPRTPAddress
+		if srv.TLSConfig == nil {
+			tmp += " (UDP/RTP)"
+		} else {
+			tmp += " (UDP/SRTP)"
+		}
+		ret = append(ret, tmp)
 	}
 
 	if srv.UDPRTCPAddress != "" {
-		ret = append(ret, fmt.Sprintf("%s (UDP/RTCP)", srv.UDPRTCPAddress))
+		tmp = srv.UDPRTCPAddress
+		if srv.TLSConfig == nil {
+			tmp += " (UDP/RTCP)"
+		} else {
+			tmp += " (UDP/SRTCP)"
+		}
+		ret = append(ret, tmp)
 	}
 
 	return strings.Join(ret, ", ")


### PR DESCRIPTION
use "TCP/RTSPS", "UDP/SRTP", "UDP/SRTCP" to refer to secure listeners