### PR TITLE
prevent setting slices to null

### DIFF
--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -770,3 +770,11 @@ func TestSampleConfFile(t *testing.T) {
 		require.Equal(t, conf1.Paths, conf2.Paths)
 	}()
 }
+
+func TestClone(t *testing.T) {
+	conf1, _, err := Load("", nil, nil)
+	require.NoError(t, err)
+
+	conf2 := conf1.Clone()
+	require.Equal(t, conf1, conf2)
+}

--- a/internal/conf/jsonwrapper/unmarshal.go
+++ b/internal/conf/jsonwrapper/unmarshal.go
@@ -4,14 +4,54 @@ package jsonwrapper
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
 )
 
 // differences with respect to the standard package:
-// - unknown fields cause an error
-// - using existing elements of slices is prevented, fixing https://github.com/golang/go/issues/21092
+// - prevents setting unknown fields
+// - prevents using existing elements of slices, fixing https://github.com/golang/go/issues/21092
+// - prevents setting slices to nil
+
+func process(v reflect.Value, raw any) error {
+	switch v.Kind() {
+	case reflect.Slice:
+		if raw == nil {
+			return fmt.Errorf("cannot set slice to nil")
+		}
+
+		// nil existing slice to prevent reuse of elements
+		if !v.IsNil() {
+			v.Set(reflect.Zero(v.Type()))
+		}
+
+	case reflect.Struct:
+		if rawMap, ok := raw.(map[string]any); ok {
+			vType := v.Type()
+			for i := 0; i < v.NumField(); i++ {
+				field := v.Field(i)
+				fieldType := vType.Field(i)
+
+				jsonKey := fieldType.Tag.Get("json")
+				if jsonKey == "" || jsonKey == "-" {
+					continue
+				}
+				jsonKey = strings.Split(jsonKey, ",")[0]
+
+				if rawVal, ok2 := rawMap[jsonKey]; ok2 {
+					err := process(field, rawVal)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
 
 // Unmarshal decodes JSON.
 func Unmarshal(buf []byte, dest any) error {
@@ -31,59 +71,12 @@ func Decode(r io.Reader, dest any) error {
 		return err
 	}
 
-	nilExistingSlices(reflect.ValueOf(dest), raw)
+	err = process(reflect.ValueOf(dest).Elem(), raw)
+	if err != nil {
+		return err
+	}
 
 	d := json.NewDecoder(bytes.NewReader(buf))
 	d.DisallowUnknownFields()
 	return d.Decode(dest)
-}
-
-// nilExistingSlices recursively nils slices that are present in the JSON data.
-func nilExistingSlices(v reflect.Value, jsonData any) {
-	if !v.IsValid() || jsonData == nil {
-		return
-	}
-
-	for v.Kind() == reflect.Pointer {
-		if v.IsNil() {
-			return
-		}
-		v = v.Elem()
-	}
-
-	switch v.Kind() {
-	case reflect.Slice:
-		if _, ok := jsonData.([]any); ok {
-			if !v.IsNil() {
-				v.Set(reflect.Zero(v.Type()))
-			}
-			return
-		}
-
-	case reflect.Struct:
-		jsonMap, ok := jsonData.(map[string]any)
-		if !ok {
-			return
-		}
-
-		vType := v.Type()
-		for i := 0; i < v.NumField(); i++ {
-			field := v.Field(i)
-			fieldType := vType.Field(i)
-
-			jsonKey := fieldType.Tag.Get("json")
-			if jsonKey == "" || jsonKey == "-" {
-				continue
-			}
-			jsonKey = strings.Split(jsonKey, ",")[0]
-
-			if jsonValue, exists := jsonMap[jsonKey]; exists {
-				if field.Kind() == reflect.Slice && !field.IsNil() {
-					field.Set(reflect.Zero(field.Type()))
-				}
-
-				nilExistingSlices(field, jsonValue)
-			}
-		}
-	}
 }

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -1,7 +1,6 @@
 package conf
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -107,8 +106,8 @@ func FindPathConf(pathConfs map[string]*Path, name string) (*Path, []string, err
 
 // Path is a path configuration.
 type Path struct {
-	Regexp *regexp.Regexp `json:"-"`    // filled by Check()
-	Name   string         `json:"name"` // filled by Check()
+	Regexp *regexp.Regexp `json:"-"`    // filled by Validate()
+	Name   string         `json:"name"` // filled by Validate()
 
 	// General
 	Source                     string   `json:"source"`
@@ -206,11 +205,11 @@ type Path struct {
 	RPICameraSoftwareH264Level     string    `json:"rpiCameraSoftwareH264Level"`
 	RPICameraJPEGQuality           *uint     `json:"rpiCameraJPEGQuality,omitempty"` // deprecated
 	RPICameraMJPEGQuality          uint      `json:"rpiCameraMJPEGQuality"`
-	RPICameraPrimaryName           string    `json:"-"` // filled by Check()
-	RPICameraSecondaryWidth        uint      `json:"-"` // filled by Check()
-	RPICameraSecondaryHeight       uint      `json:"-"` // filled by Check()
-	RPICameraSecondaryFPS          float64   `json:"-"` // filled by Check()
-	RPICameraSecondaryMJPEGQuality uint      `json:"-"` // filled by Check()
+	RPICameraPrimaryName           string    `json:"-"` // filled by Validate()
+	RPICameraSecondaryWidth        uint      `json:"-"` // filled by Validate()
+	RPICameraSecondaryHeight       uint      `json:"-"` // filled by Validate()
+	RPICameraSecondaryFPS          float64   `json:"-"` // filled by Validate()
+	RPICameraSecondaryMJPEGQuality uint      `json:"-"` // filled by Validate()
 
 	// Hooks
 	RunOnInit                  string   `json:"runOnInit"`
@@ -286,25 +285,8 @@ func newPath(defaults *Path, partial *OptionalPath) *Path {
 
 // Clone clones the configuration.
 func (pconf Path) Clone() *Path {
-	enc, err := json.Marshal(pconf)
-	if err != nil {
-		panic(err)
-	}
-
-	var dest Path
-	err = json.Unmarshal(enc, &dest)
-	if err != nil {
-		panic(err)
-	}
-
-	dest.Regexp = pconf.Regexp
-	dest.RPICameraPrimaryName = pconf.RPICameraPrimaryName
-	dest.RPICameraSecondaryWidth = pconf.RPICameraSecondaryWidth
-	dest.RPICameraSecondaryHeight = pconf.RPICameraSecondaryHeight
-	dest.RPICameraSecondaryFPS = pconf.RPICameraSecondaryFPS
-	dest.RPICameraSecondaryMJPEGQuality = pconf.RPICameraSecondaryMJPEGQuality
-
-	return &dest
+	cloned := deepClone(reflect.ValueOf(pconf)).Interface().(Path)
+	return &cloned
 }
 
 func (pconf *Path) validate(

--- a/internal/conf/path_test.go
+++ b/internal/conf/path_test.go
@@ -1,0 +1,20 @@
+package conf
+
+import (
+	"testing"
+
+	"github.com/bluenviron/gortsplib/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathClone(t *testing.T) {
+	original := &Path{
+		Name:                "example",
+		RTSPTransport:       RTSPTransport{ptrOf(gortsplib.ProtocolUDP)},
+		SourceAnyPortEnable: ptrOf(true),
+		RecordPath:          "/var/recordings",
+	}
+
+	clone := original.Clone()
+	require.Equal(t, original, clone)
+}

--- a/internal/conf/yamlwrapper/unmarshal.go
+++ b/internal/conf/yamlwrapper/unmarshal.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/bluenviron/mediamtx/internal/conf/jsonwrapper"
 	"gopkg.in/yaml.v2"
 )
 
@@ -47,8 +48,7 @@ func convertKeys(i any) (any, error) {
 
 // Unmarshal loads the configuration from YAML.
 func Unmarshal(buf []byte, dest any) error {
-	// load YAML into a generic map
-	// from documentation:
+	// load YAML into a generic map.
 	// "UnmarshalStrict is like Unmarshal except that any fields that are found in the data
 	// that do not have corresponding struct members, or mapping keys that are duplicates, will result in an error."
 	var temp any
@@ -70,5 +70,5 @@ func Unmarshal(buf []byte, dest any) error {
 	}
 
 	// load JSON into destination
-	return json.Unmarshal(buf, dest)
+	return jsonwrapper.Unmarshal(buf, dest)
 }

--- a/internal/conf/yamlwrapper/unmarshal_test.go
+++ b/internal/conf/yamlwrapper/unmarshal_test.go
@@ -1,0 +1,17 @@
+package yamlwrapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalDuplicateKey(t *testing.T) {
+	buf := []byte(`
+key: value1
+key: value2
+`)
+
+	err := Unmarshal(buf, &map[string]string{})
+	require.EqualError(t, err, "yaml: unmarshal errors:\n  line 3: key \"key\" already set in map")
+}

--- a/internal/testapidocs/apidocs_test.go
+++ b/internal/testapidocs/apidocs_test.go
@@ -10,30 +10,30 @@ import (
 
 	"github.com/bluenviron/gortsplib/v5/pkg/auth"
 	"github.com/bluenviron/mediamtx/internal/conf"
-	"github.com/bluenviron/mediamtx/internal/conf/yamlwrapper"
 	"github.com/bluenviron/mediamtx/internal/defs"
 	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 type openAPIProperty struct {
-	Ref      string           `json:"$ref"`
-	Type     string           `json:"type"`
-	Format   string           `json:"format"`
-	Nullable bool             `json:"nullable"`
-	Items    *openAPIProperty `json:"items"`
+	Ref      string           `yaml:"$ref"`
+	Type     string           `yaml:"type"`
+	Format   string           `yaml:"format"`
+	Nullable bool             `yaml:"nullable"`
+	Items    *openAPIProperty `yaml:"items"`
 }
 
 type openAPISchema struct {
-	Type       string                     `json:"type"`
-	Properties map[string]openAPIProperty `json:"properties"`
+	Type       string                     `yaml:"type"`
+	Properties map[string]openAPIProperty `yaml:"properties"`
 }
 
 type openAPI struct {
 	Components struct {
-		Schemas map[string]openAPISchema `json:"schemas"`
-	} `json:"components"`
+		Schemas map[string]openAPISchema `yaml:"schemas"`
+	} `yaml:"components"`
 }
 
 func fillProperty(t *testing.T, rt reflect.Type, existing openAPIProperty) openAPIProperty {
@@ -133,7 +133,7 @@ func TestAPIDocs(t *testing.T) {
 	require.NoError(t, err)
 
 	var doc openAPI
-	err = yamlwrapper.Unmarshal(byts, &doc)
+	err = yaml.Unmarshal(byts, &doc)
 	require.NoError(t, err)
 
 	for _, ca := range []struct {


### PR DESCRIPTION
In Golang, slices can be set to nil, while in most other languages they cannot. This causes compatibility issues, especially because the OpenAPI definition of the API does not allow slices to be nil. This prevents slices from being set to nil through JSON/YAML decoding, and also sets default slices to an empty list instead of nil.