### PR TITLE
Update hlsEncryption documentation on Low-Latency HLS requirements

### DIFF
--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -316,7 +316,7 @@ hls: yes
 # Address of the HLS listener.
 hlsAddress: :8888
 # Enable TLS/HTTPS on the HLS server.
-# This is required for Low-Latency HLS.
+# This is required for Low-Latency HLS to function correctly on Apple devices.
 hlsEncryption: no
 # Path to the server key. This is needed only when encryption is yes.
 # This can be generated with:


### PR DESCRIPTION
Updates the comments on the configuration file for the hlsEncryption property to reflect the changes in #1420 

I initially thought Low-Latency HLS wasn't supported without encryption until I found that pull request