### PR TITLE
deprecate fallback

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -372,8 +372,6 @@ components:
           format: int64
         srtReadPassphrase:
           type: string
-        fallback:
-          type: string
         useAbsoluteTimestamp:
           type: boolean
 

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -148,7 +148,7 @@ type Path struct {
 	SourceOnDemandCloseAfter   Duration `json:"sourceOnDemandCloseAfter"`
 	MaxReaders                 int      `json:"maxReaders"`
 	SRTReadPassphrase          string   `json:"srtReadPassphrase"`
-	Fallback                   string   `json:"fallback"`
+	Fallback                   *string  `json:"fallback,omitempty"` // deprecated
 	UseAbsoluteTimestamp       bool     `json:"useAbsoluteTimestamp"`
 
 	// Always available
@@ -662,8 +662,9 @@ func (pconf *Path) validate(
 		}
 	}
 
-	if pconf.Fallback != "" {
-		err := checkRedirect(pconf.Fallback)
+	if pconf.Fallback != nil {
+		l.Log(logger.Warn, "the 'fallback' feature is deprecated, use 'alwaysAvailable' instead")
+		err := checkRedirect(*pconf.Fallback)
 		if err != nil {
 			return err
 		}

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -480,8 +480,8 @@ func (pa *path) doDescribe(req defs.PathDescribeReq) {
 		return
 	}
 
-	if pa.conf.Fallback != "" {
-		req.Res <- defs.PathDescribeRes{Redirect: pa.conf.Fallback}
+	if pa.conf.Fallback != nil {
+		req.Res <- defs.PathDescribeRes{Redirect: *pa.conf.Fallback}
 		return
 	}
 

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -480,9 +480,6 @@ pathDefaults:
   maxReaders: 0
   # SRT encryption passphrase required to read from this path.
   srtReadPassphrase:
-  # If the stream is not available, redirect readers to this path.
-  # It can be can be a relative path (i.e. /otherstream) or an absolute RTSP URL.
-  fallback:
   # Use absolute timestamp of frames, instead of replacing them with the current time.
   useAbsoluteTimestamp: false
 


### PR DESCRIPTION
The fallback feature worked with RTSP only and did not allow readers to resume the original stream. It has been replaced by alwaysAvailable.