### PR TITLE
fix race condition when closing HTTP servers

### DIFF
--- a/internal/protocols/httpp/handler_tracker.go
+++ b/internal/protocols/httpp/handler_tracker.go
@@ -1,0 +1,36 @@
+package httpp
+
+import (
+	"net/http"
+	"sync"
+)
+
+type handlerTracker struct {
+	h http.Handler
+
+	mutex  sync.Mutex
+	wg     sync.WaitGroup
+	closed bool
+}
+
+func (h *handlerTracker) close() {
+	h.mutex.Lock()
+	h.closed = true
+	h.mutex.Unlock()
+	h.wg.Wait()
+}
+
+func (h *handlerTracker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mutex.Lock()
+	if h.closed {
+		h.mutex.Unlock()
+		return
+	}
+
+	h.wg.Add(1)
+	h.mutex.Unlock()
+
+	defer h.wg.Done()
+
+	h.h.ServeHTTP(w, r)
+}

--- a/internal/protocols/httpp/handler_tracker_test.go
+++ b/internal/protocols/httpp/handler_tracker_test.go
@@ -1,0 +1,44 @@
+package httpp
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/bluenviron/mediamtx/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerTracker(t *testing.T) {
+	requestReceived := make(chan struct{})
+
+	s := &Server{
+		Address:      "localhost:4667",
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		Parent:       test.NilLogger,
+		Handler: http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			close(requestReceived)
+			time.Sleep(1 * time.Second)
+		}),
+	}
+	err := s.Initialize()
+	require.NoError(t, err)
+
+	go func() {
+		tr := &http.Transport{}
+		defer tr.CloseIdleConnections()
+		hc := &http.Client{Transport: tr}
+
+		_, err2 := hc.Get("http://localhost:4667/test") //nolint:bodyclose
+		require.Error(t, err2)
+	}()
+
+	<-requestReceived
+
+	beforeClose := time.Now()
+
+	s.Close()
+
+	require.Greater(t, time.Since(beforeClose), 1*time.Second)
+}


### PR DESCRIPTION
when a HTTP server is closed, open connections are now immediately closed and open routines are waited before the server is considered closed.