### PR TITLE
set default udpMaxPayloadSize to an IPv6 compatible value (#4882)

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -417,7 +417,7 @@ func (conf *Conf) setDefaults() {
 	conf.ReadTimeout = 10 * Duration(time.Second)
 	conf.WriteTimeout = 10 * Duration(time.Second)
 	conf.WriteQueueSize = 512
-	conf.UDPMaxPayloadSize = 1472
+	conf.UDPMaxPayloadSize = 1452
 
 	// Authentication
 	conf.AuthMethod = AuthMethodInternal

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -24,9 +24,10 @@ writeTimeout: 10s
 # Size of the queue of outgoing packets.
 # A higher value allows to increase throughput, a lower value allows to save RAM.
 writeQueueSize: 512
-# Maximum size of outgoing UDP packets.
-# This can be decreased to avoid fragmentation on networks with a low UDP MTU.
-udpMaxPayloadSize: 1472
+# Maximum size of outgoing UDP payloads.
+# It defaults to the maximum packet size on ethernet (1500) minus IPv6 and UDP headers (48).
+# This can be decreased to avoid fragmentation on networks with a low MTU.
+udpMaxPayloadSize: 1452
 # Size of the read buffer of every UDP socket.
 # This can be increased to decrease packet losses.
 # It defaults to the default value of the operating system.


### PR DESCRIPTION
Fixes #4882 

When using IPv6, there are 20 bytes less available for UDP payload, which has been adjusted accordingly.