### PR TITLE
🐛 fix: Add field name to slice nil errors

### DIFF
--- a/internal/conf/jsonwrapper/unmarshal.go
+++ b/internal/conf/jsonwrapper/unmarshal.go
@@ -15,10 +15,13 @@ import (
 // - prevents using existing elements of slices, fixing https://github.com/golang/go/issues/21092
 // - prevents setting slices to nil
 
-func process(v reflect.Value, raw any) error {
+func process(v reflect.Value, raw any, path string) error {
 	switch v.Kind() {
 	case reflect.Slice:
 		if raw == nil {
+			if path != "" {
+				return fmt.Errorf("cannot set slice to nil: field '%s'", path)
+			}
 			return fmt.Errorf("cannot set slice to nil")
 		}
 
@@ -41,7 +44,11 @@ func process(v reflect.Value, raw any) error {
 				jsonKey = strings.Split(jsonKey, ",")[0]
 
 				if rawVal, ok2 := rawMap[jsonKey]; ok2 {
-					err := process(field, rawVal)
+					fieldPath := jsonKey
+					if path != "" {
+						fieldPath = path + "." + jsonKey
+					}
+					err := process(field, rawVal, fieldPath)
 					if err != nil {
 						return err
 					}
@@ -71,7 +78,7 @@ func Decode(r io.Reader, dest any) error {
 		return err
 	}
 
-	err = process(reflect.ValueOf(dest).Elem(), raw)
+	err = process(reflect.ValueOf(dest).Elem(), raw, "")
 	if err != nil {
 		return err
 	}

--- a/internal/conf/jsonwrapper/unmarshal_test.go
+++ b/internal/conf/jsonwrapper/unmarshal_test.go
@@ -74,35 +74,37 @@ func TestUnmarshalPreventSliceReuse(t *testing.T) {
 }
 
 func TestUnmarshalSetSliceToNil(t *testing.T) {
-	type Data struct {
-		Items []string `json:"items"`
-	}
+	t.Run("top level", func(t *testing.T) {
+		type Data struct {
+			Items []string `json:"items"`
+		}
 
-	var data Data
+		var data Data
 
-	json := []byte(`{"items": null}`)
-	err := Unmarshal(json, &data)
-	require.EqualError(t, err, "cannot set slice to nil: field 'items'")
+		json := []byte(`{"items": null}`)
+		err := Unmarshal(json, &data)
+		require.EqualError(t, err, "cannot set slice to nil: field 'items'")
 
-	data = Data{Items: []string{"a", "b"}}
+		data = Data{Items: []string{"a", "b"}}
 
-	json = []byte(`{"items": null}`)
-	err = Unmarshal(json, &data)
-	require.EqualError(t, err, "cannot set slice to nil: field 'items'")
-}
+		json = []byte(`{"items": null}`)
+		err = Unmarshal(json, &data)
+		require.EqualError(t, err, "cannot set slice to nil: field 'items'")
+	})
 
-func TestUnmarshalSetNestedSliceToNil(t *testing.T) {
-	type Inner struct {
-		Values []int `json:"values"`
-	}
-	type Outer struct {
-		Inner Inner `json:"inner"`
-	}
+	t.Run("nested", func(t *testing.T) {
+		type Inner struct {
+			Values []int `json:"values"`
+		}
+		type Outer struct {
+			Inner Inner `json:"inner"`
+		}
 
-	var data Outer
-	json := []byte(`{"inner": {"values": null}}`)
-	err := Unmarshal(json, &data)
-	require.EqualError(t, err, "cannot set slice to nil: field 'inner.values'")
+		var data Outer
+		json := []byte(`{"inner": {"values": null}}`)
+		err := Unmarshal(json, &data)
+		require.EqualError(t, err, "cannot set slice to nil: field 'inner.values'")
+	})
 }
 
 func TestUnmarshalSetNullableSliceToNil(t *testing.T) {

--- a/internal/conf/jsonwrapper/unmarshal_test.go
+++ b/internal/conf/jsonwrapper/unmarshal_test.go
@@ -82,13 +82,27 @@ func TestUnmarshalSetSliceToNil(t *testing.T) {
 
 	json := []byte(`{"items": null}`)
 	err := Unmarshal(json, &data)
-	require.EqualError(t, err, "cannot set slice to nil")
+	require.EqualError(t, err, "cannot set slice to nil: field 'items'")
 
 	data = Data{Items: []string{"a", "b"}}
 
 	json = []byte(`{"items": null}`)
 	err = Unmarshal(json, &data)
-	require.EqualError(t, err, "cannot set slice to nil")
+	require.EqualError(t, err, "cannot set slice to nil: field 'items'")
+}
+
+func TestUnmarshalSetNestedSliceToNil(t *testing.T) {
+	type Inner struct {
+		Values []int `json:"values"`
+	}
+	type Outer struct {
+		Inner Inner `json:"inner"`
+	}
+
+	var data Outer
+	json := []byte(`{"inner": {"values": null}}`)
+	err := Unmarshal(json, &data)
+	require.EqualError(t, err, "cannot set slice to nil: field 'inner.values'")
 }
 
 func TestUnmarshalSetNullableSliceToNil(t *testing.T) {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -99,7 +99,6 @@ func getRTPMaxPayloadSize(udpMaxPayloadSize int, rtspEncryption conf.Encryption)
 var cli struct {
 	Confpath string `arg:"" default:""`
 	Version  bool   `help:"print version"`
-	Check    bool   `help:"validate configuration and exit"`
 	Upgrade  bool   `help:"upgrade executable to the latest version"`
 }
 
@@ -165,36 +164,6 @@ func New(args []string) (*Core, bool) {
 		if err != nil {
 			fmt.Printf("ERR: %v\n", err)
 			os.Exit(1)
-		}
-		os.Exit(0)
-	}
-
-	if cli.Check {
-		tempLogger := &logger.Logger{
-			Level:        logger.Info,
-			Destinations: []logger.Destination{logger.DestinationStdout},
-			Structured:   false,
-			File:         "",
-			SysLogPrefix: "",
-		}
-		tempLogger.Initialize() //nolint:errcheck
-
-		confPaths := append([]string(nil), defaultConfPaths...)
-		if runtime.GOOS != "windows" {
-			confPaths = append(confPaths, defaultConfPathsNotWin...)
-		}
-
-		_, confPath, err := conf.Load(cli.Confpath, confPaths, tempLogger)
-		if err != nil {
-			fmt.Printf("ERR: %s\n", err)
-			os.Exit(1)
-		}
-
-		if confPath != "" {
-			absPath, _ := filepath.Abs(confPath)
-			fmt.Printf("configuration file '%s' is valid\n", absPath)
-		} else {
-			fmt.Println("no configuration file found, using defaults - configuration is valid")
 		}
 		os.Exit(0)
 	}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -99,6 +99,7 @@ func getRTPMaxPayloadSize(udpMaxPayloadSize int, rtspEncryption conf.Encryption)
 var cli struct {
 	Confpath string `arg:"" default:""`
 	Version  bool   `help:"print version"`
+	Check    bool   `help:"validate configuration and exit"`
 	Upgrade  bool   `help:"upgrade executable to the latest version"`
 }
 
@@ -164,6 +165,36 @@ func New(args []string) (*Core, bool) {
 		if err != nil {
 			fmt.Printf("ERR: %v\n", err)
 			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	if cli.Check {
+		tempLogger := &logger.Logger{
+			Level:        logger.Info,
+			Destinations: []logger.Destination{logger.DestinationStdout},
+			Structured:   false,
+			File:         "",
+			SysLogPrefix: "",
+		}
+		tempLogger.Initialize() //nolint:errcheck
+
+		confPaths := append([]string(nil), defaultConfPaths...)
+		if runtime.GOOS != "windows" {
+			confPaths = append(confPaths, defaultConfPathsNotWin...)
+		}
+
+		_, confPath, err := conf.Load(cli.Confpath, confPaths, tempLogger)
+		if err != nil {
+			fmt.Printf("ERR: %s\n", err)
+			os.Exit(1)
+		}
+
+		if confPath != "" {
+			absPath, _ := filepath.Abs(confPath)
+			fmt.Printf("configuration file '%s' is valid\n", absPath)
+		} else {
+			fmt.Println("no configuration file found, using defaults - configuration is valid")
 		}
 		os.Exit(0)
 	}


### PR DESCRIPTION
## What changed
- Error message for null slices now includes the field name

## Why
- `cannot set slice to nil` was unclear - users couldn't identify which field caused the error

## How it works
- Field path is tracked during JSON unmarshaling and included in error messages

## Example

Before:
```
ERR: cannot set slice to nil
```

After:
```
ERR: cannot set slice to nil: field 'webrtcICEServers2'
```

## Testing
- Unit tests updated and passing
