### PR TITLE
auth: add CA certificate support for HTTP authentication

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -263,6 +263,7 @@ type Conf struct {
 	AuthHTTPAddress           string                       `json:"authHTTPAddress"`
 	ExternalAuthenticationURL *string                      `json:"externalAuthenticationURL,omitempty"` // deprecated
 	AuthHTTPExclude           []AuthInternalUserPermission `json:"authHTTPExclude"`
+	AuthHTTPCAFile            string                       `json:"authHTTPCAFile"`
 	AuthJWTJWKS               string                       `json:"authJWTJWKS"`
 	AuthJWTJWKSFingerprint    string                       `json:"authJWTJWKSFingerprint"`
 	AuthJWTClaimKey           string                       `json:"authJWTClaimKey"`

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -338,6 +338,7 @@ func (p *Core) createResources(initial bool) error {
 			InternalUsers:      p.conf.AuthInternalUsers,
 			HTTPAddress:        p.conf.AuthHTTPAddress,
 			HTTPExclude:        p.conf.AuthHTTPExclude,
+			HTTPCAFile:         p.conf.AuthHTTPCAFile,
 			JWTJWKS:            p.conf.AuthJWTJWKS,
 			JWTJWKSFingerprint: p.conf.AuthJWTJWKSFingerprint,
 			JWTClaimKey:        p.conf.AuthJWTClaimKey,

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -106,6 +106,9 @@ authInternalUsers:
 # If the response code is 20x, authentication is accepted, otherwise
 # it is discarded.
 authHTTPAddress:
+# Path to a CA certificate file to verify the HTTP authentication server's certificate.
+# This is useful when using self-signed certificates.
+authHTTPCAFile:
 # Actions to exclude from HTTP-based authentication.
 # Format is the same as the one of user permissions.
 authHTTPExclude:


### PR DESCRIPTION
Allows verification of self-signed certificates when using HTTP-based authentication by specifying a custom CA certificate file via the authHTTPCAFile configuration parameter.

Fixes #5415 