### PR TITLE
support X-Forwarded-Proto in playback server (#4970)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2623,7 +2623,7 @@ paths:
     get:
       operationId: recordingsList
       tags: [Recordings]
-      summary: returns all recordings.
+      summary: returns all recordings, splitted by path.
       description: ''
       parameters:
       - name: page
@@ -2662,7 +2662,7 @@ paths:
     get:
       operationId: recordingsGet
       tags: [Recordings]
-      summary: returns recordings for a path.
+      summary: returns recordings of a path.
       description: ''
       parameters:
       - name: name

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -171,8 +171,8 @@ apiServerCert: server.crt
 # Supports wildcards: ['http://*.example.com']
 apiAllowOrigins: ['*']
 # IPs or CIDRs of proxies placed before the HTTP server.
-# If the server receives a request from one of these entries, IP in logs
-# will be taken from the X-Forwarded-For header.
+# These proxies can use the X-Forwarded-For header to set the real IP of clients,
+# and the X-Forwarded-Proto header to set the original protocol.
 apiTrustedProxies: []
 
 ###############################################
@@ -195,8 +195,8 @@ metricsServerCert: server.crt
 # Supports wildcards: ['http://*.example.com']
 metricsAllowOrigins: ['*']
 # IPs or CIDRs of proxies placed before the HTTP server.
-# If the server receives a request from one of these entries, IP in logs
-# will be taken from the X-Forwarded-For header.
+# These proxies can use the X-Forwarded-For header to set the real IP of clients,
+# and the X-Forwarded-Proto header to set the original protocol.
 metricsTrustedProxies: []
 
 ###############################################
@@ -219,8 +219,8 @@ pprofServerCert: server.crt
 # Supports wildcards: ['http://*.example.com']
 pprofAllowOrigins: ['*']
 # IPs or CIDRs of proxies placed before the HTTP server.
-# If the server receives a request from one of these entries, IP in logs
-# will be taken from the X-Forwarded-For header.
+# These proxies can use the X-Forwarded-For header to set the real IP of clients,
+# and the X-Forwarded-Proto header to set the original protocol.
 pprofTrustedProxies: []
 
 ###############################################
@@ -243,8 +243,8 @@ playbackServerCert: server.crt
 # Supports wildcards: ['http://*.example.com']
 playbackAllowOrigins: ['*']
 # IPs or CIDRs of proxies placed before the HTTP server.
-# If the server receives a request from one of these entries, IP in logs
-# will be taken from the X-Forwarded-For header.
+# These proxies can use the X-Forwarded-For header to set the real IP of clients,
+# and the X-Forwarded-Proto header to set the original protocol.
 playbackTrustedProxies: []
 
 ###############################################


### PR DESCRIPTION
Fixes #4970 

allow reverse proxies to change the schema of URLs returned by the server through the X-Forwarded-Proto header.