### PR TITLE
fix: adjust audio synchronization and PTS in offline mode

### DIFF
--- a/internal/stream/offline_sub_stream_track.go
+++ b/internal/stream/offline_sub_stream_track.go
@@ -81,6 +81,12 @@ func (t *offlineSubStreamTrack) run() {
 				payload[i] = []byte{0xF8, 0xFF, 0xFE} // DTX frame
 			}
 
+			select {
+			case <-t.ctx.Done():
+				return
+			default:
+			}
+
 			t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
 				PTS:     pts,
 				NTP:     time.Time{},
@@ -115,6 +121,12 @@ func (t *offlineSubStreamTrack) run() {
 				payload[i] = frame
 			}
 
+			select {
+			case <-t.ctx.Done():
+				return
+			default:
+			}
+
 			t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
 				PTS:     pts,
 				NTP:     time.Time{},
@@ -147,6 +159,12 @@ func (t *offlineSubStreamTrack) run() {
 				payload[i] = sample
 			}
 
+			select {
+			case <-t.ctx.Done():
+				return
+			default:
+			}
+
 			t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
 				PTS:     pts,
 				NTP:     time.Time{},
@@ -168,6 +186,12 @@ func (t *offlineSubStreamTrack) run() {
 
 		for {
 			payload := make(unit.PayloadLPCM, samplesPerWrite*forma.ChannelCount*(forma.BitDepth/8))
+
+			select {
+			case <-t.ctx.Done():
+				return
+			default:
+			}
 
 			t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
 				PTS:     pts,
@@ -261,6 +285,12 @@ func (t *offlineSubStreamTrack) runFile(pts int64, systemTime time.Time, r io.Re
 					return err
 				}
 
+				select {
+				case <-t.ctx.Done():
+					return nil
+				default:
+				}
+
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
 					PTS:     pts,
 					NTP:     time.Time{},
@@ -268,6 +298,13 @@ func (t *offlineSubStreamTrack) runFile(pts int64, systemTime time.Time, r io.Re
 				})
 
 			case *mcodecs.VP9:
+
+				select {
+				case <-t.ctx.Done():
+					return nil
+				default:
+				}
+
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
 					PTS:     pts,
 					NTP:     time.Time{},
@@ -281,6 +318,12 @@ func (t *offlineSubStreamTrack) runFile(pts int64, systemTime time.Time, r io.Re
 					return err
 				}
 
+				select {
+				case <-t.ctx.Done():
+					return nil
+				default:
+				}
+
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
 					PTS:     pts,
 					NTP:     time.Time{},
@@ -292,6 +335,12 @@ func (t *offlineSubStreamTrack) runFile(pts int64, systemTime time.Time, r io.Re
 				err = avcc.Unmarshal(payload)
 				if err != nil {
 					return err
+				}
+
+				select {
+				case <-t.ctx.Done():
+					return nil
+				default:
 				}
 
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{


### PR DESCRIPTION
## Description
This PR improves the shutdown behavior of the offline sub-stream by adding explicit context cancellation checks within the main loops of all supported audio and video formats.

## Changes
- Added `select { case <-t.ctx.Done(): return }` to the following loops:
    - **Audio:** Opus, MPEG4Audio, G711, and LPCM.
    - **Video:** AV1, VP9, H265, and H264 inside `runFile`.
- This ensures that goroutines associated with offline tracks exit immediately when the stream is stopped or transitioned, rather than waiting for the next `WriteUnit` or sleep cycle to complete.

## Why this is important
Without these checks, especially in tracks with long write durations, the goroutines could persist longer than necessary, potentially leading to race conditions or resource leaks during rapid stream restarts or transitions to live sources.

Fixes #5443