### PR TITLE
deprecate unix+rtp (#5318) (#4999) (#5351)

### DIFF
--- a/docs/2-usage/02-publish.md
+++ b/docs/2-usage/02-publish.md
@@ -265,23 +265,6 @@ paths:
 
 Some clients that can publish with UDP and MPEG-TS are [FFmpeg](#ffmpeg) and [GStreamer](#gstreamer).
 
-Unix sockets are more efficient than UDP packets and can be used as transport by specifying the `unix+rtp` scheme:
-
-```yml
-paths:
-  mypath:
-    source: unix+rtp:///tmp/socket.sock
-    rtpSDP: |
-      v=0
-      o=- 123456789 123456789 IN IP4 192.168.1.100
-      s=H264 Video Stream
-      c=IN IP4 192.168.1.100
-      t=0 0
-      m=video 5004 RTP/AVP 96
-      a=rtpmap:96 H264/90000
-      a=fmtp:96 profile-level-id=42e01e;packetization-mode=1;sprop-parameter-sets=Z0LAHtkDxWhAAAADAEAAAAwDxYuS,aMuMsg==
-```
-
 ## Devices
 
 ### Raspberry Pi Cameras

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -465,6 +465,7 @@ func (pconf *Path) validate(
 		}
 
 	case strings.HasPrefix(pconf.Source, "unix+rtp://"):
+		l.Log(logger.Warn, "source 'unix+rtp' is deprecated due to intrinsic instability, use 'udp+rtp' instead")
 		if pconf.RTPSDP == "" {
 			return fmt.Errorf("`rtpSDP` was not provided")
 		}

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -457,7 +457,6 @@ pathDefaults:
   # * udp+mpegts://ip:port -> the stream is pulled from MPEG-TS over UDP, by listening on the specified address
   # * unix+mpegts://socket -> the stream is pulled from MPEG-TS over Unix socket, by using the socket
   # * udp+rtp://ip:port -> the stream is pulled from RTP over UDP, by listening on the specified address
-  # * unix+rtp://socket -> the stream is pulled from RTP over Unix socket, by using the socket
   # * srt://existing-url -> the stream is pulled from another SRT server / camera
   # * whep://existing-url -> the stream is pulled from another WebRTC server / camera
   # * wheps://existing-url -> the stream is pulled from another WebRTC server / camera with HTTPS


### PR DESCRIPTION
Unix socket are stream-based connections, while RTP requires packet-based connections. While packet-based Unix sockets exist (unixgram), no client supports them. Consequently we are forced to deprecate unix+rtp.