### PR TITLE
webrtc: add whepBearerTokenParameter (#3796)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -431,6 +431,8 @@ components:
           type: string
 
         # WHEP source
+        whepBearerToken:
+          type: string
         whepSTUNGatherTimeout:
           type: string
         whepHandshakeTimeout:

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -229,6 +229,7 @@ type Path struct {
 	RTPUDPReadBufferSize *uint  `json:"rtpUDPReadBufferSize,omitempty"` // deprecated
 
 	// WHEP source
+	WHEPBearerToken        string   `json:"whepBearerToken"`
 	WHEPSTUNGatherTimeout  Duration `json:"whepSTUNGatherTimeout"`
 	WHEPHandshakeTimeout   Duration `json:"whepHandshakeTimeout"`
 	WHEPTrackGatherTimeout Duration `json:"whepTrackGatherTimeout"`

--- a/internal/protocols/whip/client.go
+++ b/internal/protocols/whip/client.go
@@ -24,6 +24,7 @@ type Client struct {
 	Publish            bool
 	OutgoingTracks     []*webrtc.OutgoingTrack
 	HTTPClient         *http.Client
+	BearerToken        string
 	UDPReadBufferSize  uint
 	STUNGatherTimeout  time.Duration
 	HandshakeTimeout   time.Duration
@@ -197,6 +198,10 @@ func (c *Client) optionsICEServers(
 		return nil, err
 	}
 
+	if c.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
+	}
+
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -223,6 +228,10 @@ func (c *Client) postOffer(
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URL.String(), bytes.NewReader([]byte(offer.SDP)))
 	if err != nil {
 		return nil, err
+	}
+
+	if c.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
 	}
 
 	req.Header.Set("Content-Type", "application/sdp")
@@ -288,6 +297,10 @@ func (c *Client) patchCandidate(
 		return err
 	}
 
+	if c.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
+	}
+
 	req.Header.Set("Content-Type", "application/trickle-ice-sdpfrag")
 	req.Header.Set("If-Match", etag)
 
@@ -310,6 +323,10 @@ func (c *Client) deleteSession(
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.URL.String(), nil)
 	if err != nil {
 		return err
+	}
+
+	if c.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.BearerToken)
 	}
 
 	res, err := c.HTTPClient.Do(req)

--- a/internal/staticsources/webrtc/source.go
+++ b/internal/staticsources/webrtc/source.go
@@ -59,6 +59,7 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 			Timeout:   time.Duration(s.ReadTimeout),
 			Transport: tr,
 		},
+		BearerToken:        params.Conf.WHEPBearerToken,
 		UDPReadBufferSize:  s.UDPReadBufferSize,
 		STUNGatherTimeout:  time.Duration(params.Conf.WHEPSTUNGatherTimeout),
 		HandshakeTimeout:   time.Duration(params.Conf.WHEPHandshakeTimeout),

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -571,6 +571,8 @@ pathDefaults:
   ###############################################
   # Default path settings -> WebRTC / WHEP source (when source is WHEP)
 
+  # Token to insert in the Authorization: Bearer header.
+  whepBearerToken: ''
   # Maximum time to gather STUN candidates.
   whepSTUNGatherTimeout: 5s
   # Time to wait for the WebRTC handshake to complete.


### PR DESCRIPTION
Fixes #3796

this allows to pass Authorization: Bearer to servers that require it.