### PR TITLE
SRT PeerIdleTimeout follows MTX readTimeout

### DIFF
--- a/internal/servers/srt/server.go
+++ b/internal/servers/srt/server.go
@@ -107,6 +107,7 @@ type Server struct {
 func (s *Server) Initialize() error {
 	conf := srt.DefaultConfig()
 	conf.ConnectionTimeout = time.Duration(s.ReadTimeout)
+	conf.PeerIdleTimeout = time.Duration(s.ReadTimeout)
 	conf.PayloadSize = uint32(srtMaxPayloadSize(s.UDPMaxPayloadSize))
 
 	var err error


### PR DESCRIPTION
This PR would address issue #5428 by assigning the default SRT PeerIdleTimeout to mimic MediaMTX's configured readTimeout alongside ConnectionTimeout.  The upstream gosrt library uses 2s, which severely limits SRT's effectiveness in the lossy environments it was designed to work in.  Mimicking readTimeout is an elegant way to address the issue since PeerIdleTimeout is virtually a reader timeout with regards to SRT.