### PR TITLE
fix error 400 with parallel describe and publish requests (#5095)

### DIFF
--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"sync"
 
@@ -59,10 +60,8 @@ type pathSetHLSServerReq struct {
 	res chan pathSetHLSServerRes
 }
 
-type pathData struct {
-	path     *path
-	ready    bool
-	confName string
+type pathManagerAuthManager interface {
+	Authenticate(req *auth.Request) *auth.Error
 }
 
 type pathManagerParent interface {
@@ -71,7 +70,7 @@ type pathManagerParent interface {
 
 type pathManager struct {
 	logLevel          conf.LogLevel
-	authManager       *auth.Manager
+	authManager       pathManagerAuthManager
 	rtspAddress       string
 	readTimeout       conf.Duration
 	writeTimeout      conf.Duration
@@ -87,20 +86,20 @@ type pathManager struct {
 	ctxCancel func()
 	wg        sync.WaitGroup
 	hlsServer *hls.Server
-	paths     map[string]*pathData
+	paths     map[string]*path
 
 	// in
-	chReloadConf   chan map[string]*conf.Path
-	chSetHLSServer chan pathSetHLSServerReq
-	chClosePath    chan *path
-	chPathReady    chan *path
-	chPathNotReady chan *path
-	chFindPathConf chan defs.PathFindPathConfReq
-	chDescribe     chan defs.PathDescribeReq
-	chAddReader    chan defs.PathAddReaderReq
-	chAddPublisher chan defs.PathAddPublisherReq
-	chAPIPathsList chan pathAPIPathsListReq
-	chAPIPathsGet  chan pathAPIPathsGetReq
+	chReloadConf      chan map[string]*conf.Path
+	chSetHLSServer    chan pathSetHLSServerReq
+	chRemovePath      chan *path
+	chSetPathReady    chan *path
+	chSetPathNotReady chan *path
+	chFindPathConf    chan defs.PathFindPathConfReq
+	chDescribe        chan defs.PathDescribeReq
+	chAddReader       chan defs.PathAddReaderReq
+	chAddPublisher    chan defs.PathAddPublisherReq
+	chAPIPathsList    chan pathAPIPathsListReq
+	chAPIPathsGet     chan pathAPIPathsGetReq
 }
 
 func (pm *pathManager) initialize() {
@@ -108,12 +107,12 @@ func (pm *pathManager) initialize() {
 
 	pm.ctx = ctx
 	pm.ctxCancel = ctxCancel
-	pm.paths = make(map[string]*pathData)
+	pm.paths = make(map[string]*path)
 	pm.chReloadConf = make(chan map[string]*conf.Path)
 	pm.chSetHLSServer = make(chan pathSetHLSServerReq)
-	pm.chClosePath = make(chan *path)
-	pm.chPathReady = make(chan *path)
-	pm.chPathNotReady = make(chan *path)
+	pm.chRemovePath = make(chan *path)
+	pm.chSetPathReady = make(chan *path)
+	pm.chSetPathNotReady = make(chan *path)
 	pm.chFindPathConf = make(chan defs.PathFindPathConfReq)
 	pm.chDescribe = make(chan defs.PathDescribeReq)
 	pm.chAddReader = make(chan defs.PathAddReaderReq)
@@ -166,14 +165,16 @@ outer:
 			readyPaths := pm.doSetHLSServer(req.s)
 			req.res <- pathSetHLSServerRes{readyPaths: readyPaths}
 
-		case pa := <-pm.chClosePath:
-			pm.doClosePath(pa)
+		case pa := <-pm.chRemovePath:
+			if pa2, ok := pm.paths[pa.name]; ok && pa2 == pa {
+				delete(pm.paths, pa.name)
+			}
 
-		case pa := <-pm.chPathReady:
-			pm.doPathReady(pa)
+		case pa := <-pm.chSetPathReady:
+			pm.doSetPathReady(pa)
 
-		case pa := <-pm.chPathNotReady:
-			pm.doPathNotReady(pa)
+		case pa := <-pm.chSetPathNotReady:
+			pm.doSetPathNotReady(pa)
 
 		case req := <-pm.chFindPathConf:
 			pm.doFindPathConf(req)
@@ -218,39 +219,38 @@ func (pm *pathManager) doReloadConf(newPaths map[string]*conf.Path) {
 	}
 
 	// process existing paths
-	for pathName, pathData := range pm.paths {
-		path := pathData.path
+	for pathName, pa := range pm.paths {
 		newPathConf, _, err := conf.FindPathConf(newPaths, pathName)
 		// path does not have a config anymore: delete it
 		if err != nil {
-			pm.removeAndClosePath(path)
+			pm.doClosePath(pa)
 			continue
 		}
 
 		// path now belongs to a different config
-		if newPathConf.Name != pathData.confName {
+		if newPathConf.Name != pa.confName {
 			// path config can be hot reloaded
-			oldPathConf := pm.pathConfs[pathData.confName]
+			oldPathConf := pm.pathConfs[pa.confName]
 			if pathConfCanBeUpdated(oldPathConf, newPathConf) {
-				pm.paths[path.name].confName = newPathConf.Name
-				go path.reloadConf(newPathConf)
+				pa.confName = newPathConf.Name
+				go pa.reloadConf(newPathConf)
 				continue
 			}
 
 			// Configuration cannot be hot reloaded: delete the path
-			pm.removeAndClosePath(path)
+			pm.doClosePath(pa)
 			continue
 		}
 
 		// path configuration has changed and cannot be hot reloaded: delete path
 		if _, ok := confsToRecreate[newPathConf.Name]; ok {
-			pm.removeAndClosePath(path)
+			pm.doClosePath(pa)
 			continue
 		}
 
 		// path configuration has changed but can be hot reloaded: reload it
 		if _, ok := confsToReload[newPathConf.Name]; ok {
-			go path.reloadConf(newPathConf)
+			go pa.reloadConf(newPathConf)
 		}
 	}
 
@@ -266,10 +266,10 @@ func (pm *pathManager) doReloadConf(newPaths map[string]*conf.Path) {
 	}
 }
 
-func (pm *pathManager) removeAndClosePath(path *path) {
-	pm.removePath(path)
-	path.close()
-	path.wait() // avoid conflicts between sources
+func (pm *pathManager) doClosePath(pa *path) {
+	delete(pm.paths, pa.name)
+	pa.close()
+	pa.wait() // avoid conflicts between sources
 }
 
 func (pm *pathManager) doSetHLSServer(m *hls.Server) []defs.Path {
@@ -277,24 +277,17 @@ func (pm *pathManager) doSetHLSServer(m *hls.Server) []defs.Path {
 
 	var ret []defs.Path
 
-	for _, pd := range pm.paths {
-		if pd.ready {
-			ret = append(ret, pd.path)
+	for _, pa := range pm.paths {
+		if pa.ready {
+			ret = append(ret, pa)
 		}
 	}
 
 	return ret
 }
 
-func (pm *pathManager) doClosePath(pa *path) {
-	if pd, ok := pm.paths[pa.name]; !ok || pd.path != pa {
-		return
-	}
-	pm.removePath(pa)
-}
-
-func (pm *pathManager) doPathReady(pa *path) {
-	if pd, ok := pm.paths[pa.name]; !ok || pd.path != pa {
+func (pm *pathManager) doSetPathReady(pa *path) {
+	if pa2, ok := pm.paths[pa.name]; !ok || pa2 != pa {
 		return
 	}
 
@@ -305,8 +298,8 @@ func (pm *pathManager) doPathReady(pa *path) {
 	}
 }
 
-func (pm *pathManager) doPathNotReady(pa *path) {
-	if pd, ok := pm.paths[pa.name]; !ok || pd.path != pa {
+func (pm *pathManager) doSetPathNotReady(pa *path) {
+	if pa2, ok := pm.paths[pa.name]; !ok || pa2 != pa {
 		return
 	}
 
@@ -351,8 +344,9 @@ func (pm *pathManager) doDescribe(req defs.PathDescribeReq) {
 		pm.createPath(pathConf, req.AccessRequest.Name, pathMatches)
 	}
 
-	pd := pm.paths[req.AccessRequest.Name]
-	req.Res <- defs.PathDescribeRes{Path: pd.path}
+	pa := pm.paths[req.AccessRequest.Name]
+
+	req.Res <- defs.PathDescribeRes{Path: pa}
 }
 
 func (pm *pathManager) doAddReader(req defs.PathAddReaderReq) {
@@ -375,8 +369,9 @@ func (pm *pathManager) doAddReader(req defs.PathAddReaderReq) {
 		pm.createPath(pathConf, req.AccessRequest.Name, pathMatches)
 	}
 
-	pd := pm.paths[req.AccessRequest.Name]
-	req.Res <- defs.PathAddReaderRes{Path: pd.path}
+	pa := pm.paths[req.AccessRequest.Name]
+
+	req.Res <- defs.PathAddReaderRes{Path: pa}
 }
 
 func (pm *pathManager) doAddPublisher(req defs.PathAddPublisherReq) {
@@ -404,28 +399,26 @@ func (pm *pathManager) doAddPublisher(req defs.PathAddPublisherReq) {
 		pm.createPath(pathConf, req.AccessRequest.Name, pathMatches)
 	}
 
-	pd := pm.paths[req.AccessRequest.Name]
-	req.Res <- defs.PathAddPublisherRes{Path: pd.path}
+	pa := pm.paths[req.AccessRequest.Name]
+
+	req.Res <- defs.PathAddPublisherRes{Path: pa}
 }
 
 func (pm *pathManager) doAPIPathsList(req pathAPIPathsListReq) {
 	paths := make(map[string]*path)
-
-	for name, pd := range pm.paths {
-		paths[name] = pd.path
-	}
+	maps.Copy(paths, pm.paths)
 
 	req.res <- pathAPIPathsListRes{paths: paths}
 }
 
 func (pm *pathManager) doAPIPathsGet(req pathAPIPathsGetReq) {
-	pd, ok := pm.paths[req.name]
+	pa, ok := pm.paths[req.name]
 	if !ok {
 		req.res <- pathAPIPathsGetRes{err: conf.ErrPathNotFound}
 		return
 	}
 
-	req.res <- pathAPIPathsGetRes{path: pd.path}
+	req.res <- pathAPIPathsGetRes{path: pa}
 }
 
 func (pm *pathManager) createPath(
@@ -450,15 +443,7 @@ func (pm *pathManager) createPath(
 		parent:            pm,
 	}
 	pa.initialize()
-
-	pm.paths[name] = &pathData{
-		path:     pa,
-		confName: pathConf.Name,
-	}
-}
-
-func (pm *pathManager) removePath(pa *path) {
-	delete(pm.paths, pa.name)
+	pm.paths[name] = pa
 }
 
 // ReloadPathConfs is called by core.
@@ -469,28 +454,28 @@ func (pm *pathManager) ReloadPathConfs(pathConfs map[string]*conf.Path) {
 	}
 }
 
-// pathReady is called by path.
-func (pm *pathManager) pathReady(pa *path) {
+// setPathReady is called by path.
+func (pm *pathManager) setPathReady(pa *path) {
 	select {
-	case pm.chPathReady <- pa:
+	case pm.chSetPathReady <- pa:
 	case <-pm.ctx.Done():
 	case <-pa.ctx.Done(): // in case pathManager is blocked by path.wait()
 	}
 }
 
-// pathNotReady is called by path.
-func (pm *pathManager) pathNotReady(pa *path) {
+// setPathNotReady is called by path.
+func (pm *pathManager) setPathNotReady(pa *path) {
 	select {
-	case pm.chPathNotReady <- pa:
+	case pm.chSetPathNotReady <- pa:
 	case <-pm.ctx.Done():
 	case <-pa.ctx.Done(): // in case pathManager is blocked by path.wait()
 	}
 }
 
-// closePath is called by path.
-func (pm *pathManager) closePath(pa *path) {
+// removePath is called by path.
+func (pm *pathManager) removePath(pa *path) {
 	select {
-	case pm.chClosePath <- pa:
+	case pm.chRemovePath <- pa:
 	case <-pm.ctx.Done():
 	case <-pa.ctx.Done(): // in case pathManager is blocked by path.wait()
 	}

--- a/internal/core/path_manager_test.go
+++ b/internal/core/path_manager_test.go
@@ -1,90 +1,83 @@
 package core
 
 import (
-	"bufio"
-	"net"
 	"net/http"
+	"regexp"
 	"testing"
 	"time"
 
 	"github.com/bluenviron/gortsplib/v5"
-	"github.com/bluenviron/gortsplib/v5/pkg/base"
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
-	"github.com/bluenviron/gortsplib/v5/pkg/headers"
 	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bluenviron/mediamtx/internal/conf"
+	"github.com/bluenviron/mediamtx/internal/defs"
+	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/test"
 )
 
-func TestPathAutoDeletion(t *testing.T) {
-	for _, ca := range []string{"describe", "setup"} {
+type dummyPublisher struct{}
+
+func (d *dummyPublisher) Close() {}
+
+func (d *dummyPublisher) Log(_ logger.Level, _ string, _ ...any) {}
+
+func (d *dummyPublisher) APISourceDescribe() *defs.APIPathSource {
+	return nil
+}
+
+type dummyReader struct{}
+
+func (d *dummyReader) Close() {}
+
+func (d *dummyReader) Log(_ logger.Level, _ string, _ ...any) {}
+
+func (d *dummyReader) APIReaderDescribe() *defs.APIPathReader {
+	return nil
+}
+
+func TestPathManagerDynamicPathAutoDeletion(t *testing.T) {
+	for _, ca := range []string{"describe", "add reader"} {
 		t.Run(ca, func(t *testing.T) {
-			p, ok := newInstance("paths:\n" +
-				"  all_others:\n")
-			require.Equal(t, true, ok)
-			defer p.Close()
+			pathConfs := map[string]*conf.Path{
+				"all_others": {
+					Regexp: regexp.MustCompile("^.*$"),
+					Name:   "all_others",
+					Source: "publisher",
+				},
+			}
+
+			pm := &pathManager{
+				authManager: test.NilAuthManager,
+				pathConfs:   pathConfs,
+				parent:      test.NilLogger,
+			}
+			pm.initialize()
+			defer pm.close()
 
 			func() {
-				conn, err := net.Dial("tcp", "localhost:8554")
-				require.NoError(t, err)
-				defer conn.Close()
-				br := bufio.NewReader(conn)
-
 				if ca == "describe" {
-					var u *base.URL
-					u, err = base.ParseURL("rtsp://localhost:8554/mypath")
-					require.NoError(t, err)
-
-					byts, _ := base.Request{
-						Method: base.Describe,
-						URL:    u,
-						Header: base.Header{
-							"CSeq": base.HeaderValue{"1"},
+					res := pm.Describe(defs.PathDescribeReq{
+						AccessRequest: defs.PathAccessRequest{
+							Name: "mypath",
 						},
-					}.Marshal()
-					_, err = conn.Write(byts)
-					require.NoError(t, err)
-
-					var res base.Response
-					err = res.Unmarshal(br)
-					require.NoError(t, err)
-					require.Equal(t, base.StatusNotFound, res.StatusCode)
+					})
+					require.EqualError(t, res.Err, "no stream is available on path 'mypath'")
 				} else {
-					var u *base.URL
-					u, err = base.ParseURL("rtsp://localhost:8554/mypath/trackID=0")
-					require.NoError(t, err)
-
-					byts, _ := base.Request{
-						Method: base.Setup,
-						URL:    u,
-						Header: base.Header{
-							"CSeq": base.HeaderValue{"1"},
-							"Transport": headers.Transport{
-								Mode: func() *headers.TransportMode {
-									v := headers.TransportModePlay
-									return &v
-								}(),
-								Delivery: func() *headers.TransportDelivery {
-									v := headers.TransportDeliveryUnicast
-									return &v
-								}(),
-								Protocol:    headers.TransportProtocolUDP,
-								ClientPorts: &[2]int{35466, 35467},
-							}.Marshal(),
+					_, _, err := pm.AddReader(defs.PathAddReaderReq{
+						Author: &dummyReader{},
+						AccessRequest: defs.PathAccessRequest{
+							Name: "mypath",
 						},
-					}.Marshal()
-					_, err = conn.Write(byts)
-					require.NoError(t, err)
-
-					var res base.Response
-					err = res.Unmarshal(br)
-					require.NoError(t, err)
-					require.Equal(t, base.StatusNotFound, res.StatusCode)
+					})
+					require.EqualError(t, err, "no stream is available on path 'mypath'")
 				}
 			}()
 
-			data, err := p.pathManager.APIPathsList()
+			time.Sleep(100 * time.Millisecond)
+
+			data, err := pm.APIPathsList()
 			require.NoError(t, err)
 
 			require.Empty(t, data.Items)
@@ -92,7 +85,7 @@ func TestPathAutoDeletion(t *testing.T) {
 	}
 }
 
-func TestPathConfigurationHotReload(t *testing.T) {
+func TestPathManagerConfigHotReload(t *testing.T) {
 	// Start MediaMTX with basic configuration
 	p, ok := newInstance("api: yes\n" +
 		"paths:\n" +

--- a/internal/test/auth_manager.go
+++ b/internal/test/auth_manager.go
@@ -9,7 +9,7 @@ type AuthManager struct {
 	RefreshJWTJWKSImpl func()
 }
 
-// Authenticate replicates auth.Manager.Replicate
+// Authenticate replicates auth.Manager.Authenticate.
 func (m *AuthManager) Authenticate(req *auth.Request) *auth.Error {
 	return m.AuthenticateImpl(req)
 }


### PR DESCRIPTION
Fixes #5095 

When a path is dynamic, and the path receives multiple describe and publish requests in parallel, describe requests might cause the path to be deleted, and this might cause pending publish requests to fail, since the path has been deleted.

This patch improves the situation by checking for pending requests before deleting a path.