### PR TITLE
fix MPEG-4 audio configuration not matching error (#5468)

### DIFF
--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -96,6 +96,7 @@ func mediasFromAlwaysAvailableFile(alwaysAvailableFile string) ([]*description.M
 						Type:          mpeg4audio.ObjectTypeAACLC,
 						SampleRate:    codec.Config.SampleRate,
 						ChannelConfig: codec.Config.ChannelConfig,
+						ChannelCount:  codec.Config.ChannelCount, //nolint:staticcheck
 					},
 				}},
 			})


### PR DESCRIPTION
This happened when using alwaysAvailableFile and a MPEG-4 audio track.