### PR TITLE
revert to Go 1.25 (#5521)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: "1.26"
+        go-version: "1.25"
 
     - run: go generate ./...
 
@@ -33,7 +33,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: "1.26"
+        go-version: "1.25"
 
     - run: make lint-go-mod
 
@@ -45,7 +45,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: "1.26"
+        go-version: "1.25"
 
     - run: make lint-conf
 
@@ -57,7 +57,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: "1.26"
+        go-version: "1.25"
 
     - run: make lint-go2api
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: "1.26"
+        go-version: "1.25"
 
     - run: make test-e2e-nodocker

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASE_IMAGE = golang:1.26-alpine3.22
+BASE_IMAGE = golang:1.25-alpine3.22
 GOLANGCI_LINT_IMAGE = golangci/golangci-lint:v2.10.1
 NODE_IMAGE = node:20-alpine3.22
 

--- a/docs/6-misc/1-compile.md
+++ b/docs/6-misc/1-compile.md
@@ -2,7 +2,7 @@
 
 ## Standard procedure
 
-1. Install git and Go &ge; 1.26.
+1. Install git and Go &ge; 1.25.
 
 2. Clone the repository, enter into the folder and start the building process:
 
@@ -21,7 +21,7 @@ If you need to use a custom or external libcamera to interact with some Raspberr
 
 1. Download [mediamtx-rpicamera source code](https://github.com/bluenviron/mediamtx-rpicamera) and compile it against the external libcamera. Instructions are in the repository.
 
-2. Install git and Go &ge; 1.26.
+2. Install git and Go &ge; 1.25.
 
 3. Clone the _MediaMTX_ repository:
 
@@ -49,7 +49,7 @@ If you need to use a custom or external libcamera to interact with some Raspberr
 
 Cross compilation allows to build an executable for a target machine from another machine with different operating system or architecture. This is useful in case the target machine doesn't have enough resources for compilation or if you don't want to install the compilation dependencies on it.
 
-1. On the machine you want to use to compile, install git and Go &ge; 1.26.
+1. On the machine you want to use to compile, install git and Go &ge; 1.25.
 
 2. Clone the repository, enter into the folder and start the building process:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluenviron/mediamtx
 
-go 1.26.0
+go 1.25.0
 
 require (
 	code.cloudfoundry.org/bytefmt v0.64.0

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -52,7 +52,8 @@ func setAllNilSlicesToEmptyRecursive(rv reflect.Value) {
 	}
 
 	if rv.Kind() == reflect.Struct {
-		for _, field := range rv.Fields() {
+		for i := range rv.NumField() {
+			field := rv.Field(i)
 			switch field.Kind() {
 			case reflect.Slice:
 				if field.IsNil() {


### PR DESCRIPTION
It seems like Go 1.26 is causing segmentation faults, related to channels, on Windows.