### PR TITLE
fix: avoid buffering HTTP response body in loggerWriter

### DIFF
--- a/internal/protocols/httpp/handler_logger.go
+++ b/internal/protocols/httpp/handler_logger.go
@@ -12,7 +12,7 @@ import (
 type loggerWriter struct {
 	w      http.ResponseWriter
 	status int
-	buf    bytes.Buffer
+	size   int
 }
 
 func (w *loggerWriter) Header() http.Header {
@@ -23,7 +23,7 @@ func (w *loggerWriter) Write(b []byte) (int, error) {
 	if w.status == 0 {
 		w.status = http.StatusOK
 	}
-	w.buf.Write(b)
+	w.size += len(b)
 	return w.w.Write(b)
 }
 
@@ -37,8 +37,8 @@ func (w *loggerWriter) dump() string {
 	fmt.Fprintf(&buf, "%s %d %s\n", "HTTP/1.1", w.status, http.StatusText(w.status))
 	w.w.Header().Write(&buf) //nolint:errcheck
 	buf.Write([]byte("\n"))
-	if w.buf.Len() > 0 {
-		fmt.Fprintf(&buf, "(body of %d bytes)", w.buf.Len())
+	if w.size > 0 {
+		fmt.Fprintf(&buf, "(body of %d bytes)", w.size)
 	}
 	return buf.String()
 }


### PR DESCRIPTION
loggerWriter was shadow-copying every response byte into a bytes.Buffer to report the body size, causing the entire response to be accumulated in memory for the lifetime of each request. Replace the buffer with a plain int counter since dump() only ever reported the byte count anyway.