### PR TITLE
docs: clarify jwt in query option for rtsp and rtmp

### DIFF
--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -149,8 +149,9 @@ authJWTClaimKey: mediamtx_permissions
 # Actions to exclude from JWT-based authentication.
 # Format is the same as the one of user permissions.
 authJWTExclude: []
-# allow passing the JWT through query parameters of HTTP requests (i.e. ?jwt=JWT).
+# Allow passing the JWT through query parameters of HTTP requests (i.e. ?jwt=JWT).
 # This is a security risk and will be disabled in the future.
+# RTSP and RTMP always allow JWT in query even if disabled, since there is no alternative.
 authJWTInHTTPQuery: true
 # Expected issuer (iss) claim in the JWT. Leave empty to skip validation.
 authJWTIssuer:


### PR DESCRIPTION
I was going through the code while working on #5569 and noticed that RTSP and RTMP always allow jwt in http query, regardless of the setting in the config. It wasn't very obvious to me, so suggest a bit of clarification in the config example.

Reasoning: I was having it enabled, because thought was required for RTSP. But it wasn't, and just introduces additional security implications for other protocols that don't need it.