### PR TITLE
core: add reloadOnError option to survive configuration errors

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -247,6 +247,7 @@ type Conf struct {
 	LogFile             string          `json:"logFile"`
 	SysLogPrefix        string          `json:"sysLogPrefix"`
 	DumpPackets         bool            `json:"dumpPackets"`
+	ReloadOnError       ReloadOnError   `json:"reloadOnError"`
 	ReadTimeout         Duration        `json:"readTimeout"`
 	WriteTimeout        Duration        `json:"writeTimeout"`
 	ReadBufferCount     *int            `json:"readBufferCount,omitempty" deprecated:"true"`
@@ -417,6 +418,7 @@ func (conf *Conf) setDefaults() {
 	conf.LogStructured = false
 	conf.LogFile = "mediamtx.log"
 	conf.SysLogPrefix = "mediamtx"
+	conf.ReloadOnError = ReloadOnErrorExit
 	conf.ReadTimeout = 10 * Duration(time.Second)
 	conf.WriteTimeout = 10 * Duration(time.Second)
 	conf.WriteQueueSize = 512

--- a/internal/conf/reload_on_error.go
+++ b/internal/conf/reload_on_error.go
@@ -1,0 +1,56 @@
+package conf
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/bluenviron/mediamtx/internal/conf/jsonwrapper"
+)
+
+// ReloadOnError is the reloadOnError parameter.
+type ReloadOnError int
+
+const (
+	// ReloadOnErrorExit exits the process on config reload error (default, original behavior).
+	ReloadOnErrorExit ReloadOnError = iota
+	// ReloadOnErrorContinue keeps running with the current configuration on config reload error.
+	ReloadOnErrorContinue
+)
+
+// MarshalJSON implements json.Marshaler.
+func (d ReloadOnError) MarshalJSON() ([]byte, error) {
+	var out string
+
+	switch d {
+	case ReloadOnErrorContinue:
+		out = "continue"
+	default:
+		out = "exit"
+	}
+
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (d *ReloadOnError) UnmarshalJSON(b []byte) error {
+	var in string
+	if err := jsonwrapper.Unmarshal(b, &in); err != nil {
+		return err
+	}
+
+	switch in {
+	case "exit":
+		*d = ReloadOnErrorExit
+	case "continue":
+		*d = ReloadOnErrorContinue
+	default:
+		return fmt.Errorf("invalid reloadOnError value: '%s' (valid: exit, continue)", in)
+	}
+
+	return nil
+}
+
+// UnmarshalEnv implements env.Unmarshaler.
+func (d *ReloadOnError) UnmarshalEnv(_ string, v string) error {
+	return d.UnmarshalJSON([]byte(`"` + v + `"`))
+}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -253,12 +253,20 @@ outer:
 
 			newConf, _, err := conf.Load(p.confPath, nil, p.logger)
 			if err != nil {
+				if p.conf.ReloadOnError == conf.ReloadOnErrorContinue {
+					p.Log(logger.Error, "configuration error: %s (keeping current configuration)", err)
+					continue
+				}
 				p.Log(logger.Error, "%s", err)
 				break outer
 			}
 
 			err = p.reloadConf(newConf, false)
 			if err != nil {
+				if p.conf.ReloadOnError == conf.ReloadOnErrorContinue {
+					p.Log(logger.Error, "configuration apply error: %s (keeping current configuration)", err)
+					continue
+				}
 				p.Log(logger.Error, "%s", err)
 				break outer
 			}

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -18,6 +18,10 @@ logFile: mediamtx.log
 sysLogPrefix: mediamtx
 # Dump packets to disk. This is useful for debugging.
 dumpPackets: false
+# Behavior when a configuration reload fails due to a parse or apply error.
+# "exit" (default): exit the process.
+# "continue": log the error and keep running with the current configuration.
+reloadOnError: exit
 
 # Timeout of read operations.
 readTimeout: 10s


### PR DESCRIPTION
When a configuration file change triggers a reload and the new configuration contains a parse or apply error, the current behavior is to exit the process. This kills all active streams, potentially causing an avoidable outage.

This adds a new "reloadOnError" configuration option:
- "exit" (default): exit the process (current behavior, unchanged)
- "continue": log the error and keep running with the current configuration

The option only affects hot reloads. A broken configuration at initial startup always exits, since there is no previous configuration to fall back to.