### PR TITLE
conf: warn on unknown fields in config file instead of failing

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -532,7 +532,7 @@ func Load(fpath string, defaultConfPaths []string, l logger.Writer) (*Conf, stri
 
 	conf.setDefaults()
 
-	fpath, err := conf.loadFromFile(fpath, defaultConfPaths)
+	fpath, err := conf.loadFromFile(fpath, defaultConfPaths, l)
 	if err != nil {
 		return nil, "", err
 	}
@@ -558,7 +558,7 @@ func Load(fpath string, defaultConfPaths []string, l logger.Writer) (*Conf, stri
 	return conf, fpath, nil
 }
 
-func (conf *Conf) loadFromFile(fpath string, defaultConfPaths []string) (string, error) {
+func (conf *Conf) loadFromFile(fpath string, defaultConfPaths []string, l logger.Writer) (string, error) {
 	if fpath == "" {
 		fpath = firstThatExists(defaultConfPaths)
 
@@ -588,9 +588,15 @@ func (conf *Conf) loadFromFile(fpath string, defaultConfPaths []string) (string,
 		}
 	}
 
-	err = yamlwrapper.Unmarshal(byts, conf)
+	warnings, err := yamlwrapper.UnmarshalAllowUnknownFields(byts, conf)
 	if err != nil {
 		return "", err
+	}
+
+	for _, w := range warnings {
+		if l != nil {
+			l.Log(logger.Warn, w)
+		}
 	}
 
 	return fpath, nil

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -275,7 +275,6 @@ func TestConfErrors(t *testing.T) {
 				"paths:\n",
 			"[2:1] mapping key \"paths\" already defined at [1:1]\n   1 |  null\n>  2 | paths:\n       ^\n",
 		},
-		// "non existent parameter" is handled as a warning, tested in TestConfUnknownFieldWarning
 		{
 			"invalid readTimeout",
 			"readTimeout: 0s\n",
@@ -306,7 +305,6 @@ func TestConfErrors(t *testing.T) {
 			"webrtcICEServers: [testing]\n",
 			"invalid ICE server: 'testing'",
 		},
-		// "non existent parameter in path" is handled as a warning, tested in TestConfUnknownFieldWarning
 		{
 			"non existent parameter in auth",
 			"authInternalUsers:\n" +

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -3,6 +3,7 @@ package conf
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -274,11 +275,7 @@ func TestConfErrors(t *testing.T) {
 				"paths:\n",
 			"[2:1] mapping key \"paths\" already defined at [1:1]\n   1 |  null\n>  2 | paths:\n       ^\n",
 		},
-		{
-			"non existent parameter",
-			`invalid: param`,
-			"json: unknown field \"invalid\"",
-		},
+		// "non existent parameter" is handled as a warning, tested in TestConfUnknownFieldWarning
 		{
 			"invalid readTimeout",
 			"readTimeout: 0s\n",
@@ -309,18 +306,12 @@ func TestConfErrors(t *testing.T) {
 			"webrtcICEServers: [testing]\n",
 			"invalid ICE server: 'testing'",
 		},
-		{
-			"non existent parameter in path",
-			"paths:\n" +
-				"  mypath:\n" +
-				"    invalid: parameter\n",
-			"json: unknown field \"invalid\"",
-		},
+		// "non existent parameter in path" is handled as a warning, tested in TestConfUnknownFieldWarning
 		{
 			"non existent parameter in auth",
 			"authInternalUsers:\n" +
 				"- users: test\n",
-			"json: unknown field \"authInternalUsers[0].users\"",
+			"empty usernames are not supported",
 		},
 		{
 			"invalid path name",
@@ -773,6 +764,55 @@ func TestAlwaysAvailableFileErrorMagicBytes(t *testing.T) {
 
 	_, _, err = Load(tmpConf, nil, nil)
 	require.EqualError(t, err, "invalid 'alwaysAvailableFile': file is not MP4, magic bytes are [69 70 71 72]")
+}
+
+type testLogger struct {
+	warnings []string
+}
+
+func (l *testLogger) Log(level logger.Level, format string, args ...any) {
+	if level == logger.Warn {
+		l.warnings = append(l.warnings, fmt.Sprintf(format, args...))
+	}
+}
+
+func TestConfUnknownFieldWarning(t *testing.T) {
+	for _, ca := range []struct {
+		name    string
+		conf    string
+		warning string
+	}{
+		{
+			"unknown top-level parameter",
+			`invalid: param`,
+			`json: unknown field "invalid"`,
+		},
+		{
+			"unknown path parameter",
+			"paths:\n" +
+				"  mypath:\n" +
+				"    invalid: parameter\n",
+			`json: unknown field "invalid"`,
+		},
+		{
+			"unknown pathDefaults parameter",
+			"pathDefaults:\n" +
+				"  futureOption: true\n",
+			`json: unknown field "pathDefaults.futureOption"`,
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			tmpf, err := createTempFile([]byte(ca.conf))
+			require.NoError(t, err)
+			defer os.Remove(tmpf)
+
+			l := &testLogger{}
+			_, _, err = Load(tmpf, nil, l)
+			require.NoError(t, err)
+			require.NotEmpty(t, l.warnings)
+			require.Equal(t, ca.warning, l.warnings[0])
+		})
+	}
 }
 
 func TestSampleConfFile(t *testing.T) {

--- a/internal/conf/jsonwrapper/unmarshal.go
+++ b/internal/conf/jsonwrapper/unmarshal.go
@@ -60,9 +60,7 @@ func collectUnknownFields(rawMap map[string]json.RawMessage, known map[string]in
 	return warnings
 }
 
-// TolerantUnmarshaler can be implemented by types that support unmarshaling
-// with unknown field tolerance. When decoding in tolerant mode, this method
-// is called instead of json.Unmarshaler.UnmarshalJSON.
+// TolerantUnmarshaler is implemented by types that handle unknown fields during decoding.
 type TolerantUnmarshaler interface {
 	UnmarshalJSONAllowUnknownFields(b []byte) ([]string, error)
 }
@@ -242,11 +240,7 @@ func Decode(r io.Reader, dest any) error {
 	return decode(reflect.ValueOf(dest).Elem(), buf, "", nil)
 }
 
-// UnmarshalAllowUnknownFields decodes JSON, collecting unknown fields as warnings
-// instead of returning an error. Unknown fields are skipped and their values
-// are discarded. This is used for config file loading to provide forward
-// compatibility when a config file contains fields not recognized by the
-// current binary version.
+// UnmarshalAllowUnknownFields decodes JSON, collecting unknown fields as warnings instead of errors.
 func UnmarshalAllowUnknownFields(buf []byte, dest any) ([]string, error) {
 	var warnings []string
 	opts := &decodeOptions{

--- a/internal/conf/jsonwrapper/unmarshal.go
+++ b/internal/conf/jsonwrapper/unmarshal.go
@@ -11,7 +11,7 @@ import (
 )
 
 // differences with respect to the standard package:
-// - JSON cannot contain unknown fields
+// - JSON cannot contain unknown fields (unless AllowUnknownFields is set)
 // - existing elements of slices are never used, fixing https://github.com/golang/go/issues/21092
 // - slices cannot be set to nil
 
@@ -46,7 +46,33 @@ func checkForUnknownFields(rawMap map[string]json.RawMessage, known map[string]i
 	return nil
 }
 
-func decode(v reflect.Value, raw json.RawMessage, path string) error {
+func collectUnknownFields(rawMap map[string]json.RawMessage, known map[string]int, path string) []string {
+	var warnings []string
+	for k := range rawMap {
+		if _, ok := known[k]; !ok {
+			if path != "" {
+				warnings = append(warnings, fmt.Sprintf("json: unknown field %q", path+"."+k))
+			} else {
+				warnings = append(warnings, fmt.Sprintf("json: unknown field %q", k))
+			}
+		}
+	}
+	return warnings
+}
+
+// TolerantUnmarshaler can be implemented by types that support unmarshaling
+// with unknown field tolerance. When decoding in tolerant mode, this method
+// is called instead of json.Unmarshaler.UnmarshalJSON.
+type TolerantUnmarshaler interface {
+	UnmarshalJSONAllowUnknownFields(b []byte) ([]string, error)
+}
+
+type decodeOptions struct {
+	allowUnknownFields bool
+	warnings           *[]string
+}
+
+func decode(v reflect.Value, raw json.RawMessage, path string, opts *decodeOptions) error {
 	for v.Kind() == reflect.Ptr {
 		if isJSONNull(raw) {
 			v.Set(reflect.Zero(v.Type()))
@@ -58,6 +84,16 @@ func decode(v reflect.Value, raw json.RawMessage, path string) error {
 		}
 
 		v = v.Elem()
+	}
+
+	if opts != nil && opts.allowUnknownFields {
+		if tunm, ok := v.Addr().Interface().(TolerantUnmarshaler); ok {
+			w, err := tunm.UnmarshalJSONAllowUnknownFields(raw)
+			if opts.warnings != nil {
+				*opts.warnings = append(*opts.warnings, w...)
+			}
+			return err
+		}
 	}
 
 	if unm, ok := v.Addr().Interface().(json.Unmarshaler); ok {
@@ -81,9 +117,16 @@ func decode(v reflect.Value, raw json.RawMessage, path string) error {
 			}
 		}
 
-		err = checkForUnknownFields(rawMap, known, path)
-		if err != nil {
-			return err
+		if opts != nil && opts.allowUnknownFields {
+			w := collectUnknownFields(rawMap, known, path)
+			if opts.warnings != nil {
+				*opts.warnings = append(*opts.warnings, w...)
+			}
+		} else {
+			err = checkForUnknownFields(rawMap, known, path)
+			if err != nil {
+				return err
+			}
 		}
 
 		for key, fieldIdx := range known {
@@ -97,7 +140,7 @@ func decode(v reflect.Value, raw json.RawMessage, path string) error {
 				fieldPath = path + "." + key
 			}
 
-			err = decode(v.Field(fieldIdx), rawVal, fieldPath)
+			err = decode(v.Field(fieldIdx), rawVal, fieldPath, opts)
 			if err != nil {
 				return err
 			}
@@ -126,13 +169,55 @@ func decode(v reflect.Value, raw json.RawMessage, path string) error {
 
 			slice := reflect.MakeSlice(v.Type(), len(rawElems), len(rawElems))
 			for i, re := range rawElems {
-				err := decode(slice.Index(i), re, fmt.Sprintf("%s[%d]", path, i))
+				err := decode(slice.Index(i), re, fmt.Sprintf("%s[%d]", path, i), opts)
 				if err != nil {
 					return err
 				}
 			}
 			v.Set(slice)
 
+			return nil
+		}
+
+		return json.Unmarshal(raw, v.Addr().Interface())
+
+	case reflect.Map:
+		if opts != nil && opts.allowUnknownFields {
+			var rawMap map[string]json.RawMessage
+			err := json.Unmarshal(raw, &rawMap)
+			if err != nil {
+				return json.Unmarshal(raw, v.Addr().Interface())
+			}
+
+			if v.IsNil() {
+				v.Set(reflect.MakeMap(v.Type()))
+			}
+
+			elemType := v.Type().Elem()
+
+			for k, rawVal := range rawMap {
+				elem := reflect.New(elemType).Elem()
+				if elem.Kind() == reflect.Ptr {
+					elem.Set(reflect.New(elemType.Elem()))
+				}
+
+				target := elem
+				if target.Kind() == reflect.Ptr {
+					target = target.Elem()
+				}
+
+				keyPath := k
+				if path != "" {
+					keyPath = path + "." + k
+				}
+
+				err = decode(target, rawVal, keyPath, opts)
+				if err != nil {
+					return err
+				}
+
+				v.SetMapIndex(reflect.ValueOf(k), elem)
+			}
 			return nil
 		}
 
@@ -154,5 +239,20 @@ func Decode(r io.Reader, dest any) error {
 	if err != nil {
 		return err
 	}
-	return decode(reflect.ValueOf(dest).Elem(), buf, "")
+	return decode(reflect.ValueOf(dest).Elem(), buf, "", nil)
+}
+
+// UnmarshalAllowUnknownFields decodes JSON, collecting unknown fields as warnings
+// instead of returning an error. Unknown fields are skipped and their values
+// are discarded. This is used for config file loading to provide forward
+// compatibility when a config file contains fields not recognized by the
+// current binary version.
+func UnmarshalAllowUnknownFields(buf []byte, dest any) ([]string, error) {
+	var warnings []string
+	opts := &decodeOptions{
+		allowUnknownFields: true,
+		warnings:           &warnings,
+	}
+	err := decode(reflect.ValueOf(dest).Elem(), buf, "", opts)
+	return warnings, err
 }

--- a/internal/conf/jsonwrapper/unmarshal_test.go
+++ b/internal/conf/jsonwrapper/unmarshal_test.go
@@ -150,6 +150,43 @@ func TestUnmarshalStructWithCustomUnmarshalerFromString(t *testing.T) {
 	require.Equal(t, &testStructWithUnmarshaler{Field1: "testing"}, &data)
 }
 
+func TestUnmarshalAllowUnknownFields(t *testing.T) {
+	t.Run("collects warnings for unknown fields", func(t *testing.T) {
+		var result testStruct
+		warnings, err := UnmarshalAllowUnknownFields(
+			[]byte(`{"field1": "test", "unknownField": "value", "field2": 456}`), &result)
+		require.NoError(t, err)
+		require.Equal(t, "test", result.Field1)
+		require.Equal(t, 456, result.Field2)
+		require.Equal(t, []string{`json: unknown field "unknownField"`}, warnings)
+	})
+
+	t.Run("no warnings when all fields known", func(t *testing.T) {
+		var result testStruct
+		warnings, err := UnmarshalAllowUnknownFields(
+			[]byte(`{"field1": "test", "field2": 456}`), &result)
+		require.NoError(t, err)
+		require.Equal(t, "test", result.Field1)
+		require.Equal(t, 456, result.Field2)
+		require.Empty(t, warnings)
+	})
+
+	t.Run("nested unknown fields", func(t *testing.T) {
+		type inner struct {
+			Name string `json:"name"`
+		}
+		type outer struct {
+			Inner inner `json:"inner"`
+		}
+		var result outer
+		warnings, err := UnmarshalAllowUnknownFields(
+			[]byte(`{"inner": {"name": "test", "extra": true}}`), &result)
+		require.NoError(t, err)
+		require.Equal(t, "test", result.Inner.Name)
+		require.Equal(t, []string{`json: unknown field "inner.extra"`}, warnings)
+	})
+}
+
 func FuzzUnmarshal(f *testing.F) {
 	f.Fuzz(func(_ *testing.T, buf []byte) {
 		var dest any

--- a/internal/conf/optional_path.go
+++ b/internal/conf/optional_path.go
@@ -54,6 +54,12 @@ func (p *OptionalPath) UnmarshalJSON(b []byte) error {
 	return jsonwrapper.Unmarshal(b, p.Values)
 }
 
+// UnmarshalJSONAllowUnknownFields implements jsonwrapper.TolerantUnmarshaler.
+func (p *OptionalPath) UnmarshalJSONAllowUnknownFields(b []byte) ([]string, error) {
+	p.Values = newOptionalPathValues()
+	return jsonwrapper.UnmarshalAllowUnknownFields(b, p.Values)
+}
+
 // UnmarshalEnv implements env.Unmarshaler.
 func (p *OptionalPath) UnmarshalEnv(prefix string, _ string) error {
 	if p.Values == nil {

--- a/internal/conf/yamlwrapper/unmarshal.go
+++ b/internal/conf/yamlwrapper/unmarshal.go
@@ -107,8 +107,7 @@ func Unmarshal(buf []byte, dest any) error {
 	return jsonwrapper.Unmarshal(jsonBuf, dest)
 }
 
-// UnmarshalAllowUnknownFields loads the configuration from YAML,
-// collecting unknown fields as warnings instead of returning errors.
+// UnmarshalAllowUnknownFields loads the configuration from YAML, collecting unknown fields as warnings.
 func UnmarshalAllowUnknownFields(buf []byte, dest any) ([]string, error) {
 	jsonBuf, err := yamlToJSON(buf)
 	if err != nil {

--- a/internal/conf/yamlwrapper/unmarshal.go
+++ b/internal/conf/yamlwrapper/unmarshal.go
@@ -74,15 +74,14 @@ func convertLegacyBools(node ast.Node) ast.Node {
 	return node
 }
 
-// Unmarshal loads the configuration from YAML.
-func Unmarshal(buf []byte, dest any) error {
+func yamlToJSON(buf []byte) ([]byte, error) {
 	file, err := parser.ParseBytes(buf, parser.ParseComments)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if len(file.Docs) != 1 {
-		return fmt.Errorf("invalid YAML")
+		return nil, fmt.Errorf("invalid YAML")
 	}
 
 	file.Docs[0] = convertLegacyBools(file.Docs[0]).(*ast.DocumentNode)
@@ -91,16 +90,30 @@ func Unmarshal(buf []byte, dest any) error {
 	if file.Docs[0].Body != nil {
 		err = yaml.NodeToValue(file.Docs[0].Body, &temp)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	// convert the generic map into JSON
-	buf, err = json.Marshal(temp)
+	return json.Marshal(temp)
+}
+
+// Unmarshal loads the configuration from YAML.
+func Unmarshal(buf []byte, dest any) error {
+	jsonBuf, err := yamlToJSON(buf)
 	if err != nil {
 		return err
 	}
 
-	// load JSON into destination
-	return jsonwrapper.Unmarshal(buf, dest)
+	return jsonwrapper.Unmarshal(jsonBuf, dest)
+}
+
+// UnmarshalAllowUnknownFields loads the configuration from YAML,
+// collecting unknown fields as warnings instead of returning errors.
+func UnmarshalAllowUnknownFields(buf []byte, dest any) ([]string, error) {
+	jsonBuf, err := yamlToJSON(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonwrapper.UnmarshalAllowUnknownFields(jsonBuf, dest)
 }


### PR DESCRIPTION
When a config file contains fields from a newer version, the binary refuses to start. Users upgrading or downgrading hit a fatal error for fields like `rtspDemuxMpegts` that the current version does not recognize.

Config file loading now logs warnings for unknown fields and continues with defaults. API endpoints still reject unknown fields with errors.

Fixes #5589