### PR TITLE
Allow configuration of behaviour if each server fails to start

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -273,126 +273,137 @@ type Conf struct {
 	AuthJWTAudience           string                       `json:"authJWTAudience"`
 
 	// Control API
-	API               bool       `json:"api"`
-	APIAddress        string     `json:"apiAddress"`
-	APIEncryption     bool       `json:"apiEncryption"`
-	APIServerKey      string     `json:"apiServerKey"`
-	APIServerCert     string     `json:"apiServerCert"`
-	APIAllowOrigin    *string    `json:"apiAllowOrigin,omitempty" deprecated:"true"`
-	APIAllowOrigins   []string   `json:"apiAllowOrigins"`
-	APITrustedProxies IPNetworks `json:"apiTrustedProxies"`
+	API               bool                  `json:"api"`
+	APIAddress        string                `json:"apiAddress"`
+	APIEncryption     bool                  `json:"apiEncryption"`
+	APIServerKey      string                `json:"apiServerKey"`
+	APIServerCert     string                `json:"apiServerCert"`
+	APIAllowOrigin    *string               `json:"apiAllowOrigin,omitempty" deprecated:"true"`
+	APIAllowOrigins   []string              `json:"apiAllowOrigins"`
+	APITrustedProxies IPNetworks            `json:"apiTrustedProxies"`
+	APIFailurePolicy  ListenerFailurePolicy `json:"apiFailurePolicy"`
 
 	// Metrics
-	Metrics               bool       `json:"metrics"`
-	MetricsAddress        string     `json:"metricsAddress"`
-	MetricsEncryption     bool       `json:"metricsEncryption"`
-	MetricsServerKey      string     `json:"metricsServerKey"`
-	MetricsServerCert     string     `json:"metricsServerCert"`
-	MetricsAllowOrigin    *string    `json:"metricsAllowOrigin,omitempty" deprecated:"true"`
-	MetricsAllowOrigins   []string   `json:"metricsAllowOrigins"`
-	MetricsTrustedProxies IPNetworks `json:"metricsTrustedProxies"`
+	Metrics               bool                  `json:"metrics"`
+	MetricsAddress        string                `json:"metricsAddress"`
+	MetricsEncryption     bool                  `json:"metricsEncryption"`
+	MetricsServerKey      string                `json:"metricsServerKey"`
+	MetricsServerCert     string                `json:"metricsServerCert"`
+	MetricsAllowOrigin    *string               `json:"metricsAllowOrigin,omitempty" deprecated:"true"`
+	MetricsAllowOrigins   []string              `json:"metricsAllowOrigins"`
+	MetricsTrustedProxies IPNetworks            `json:"metricsTrustedProxies"`
+	MetricsFailurePolicy  ListenerFailurePolicy `json:"metricsFailurePolicy"`
 
 	// PPROF
-	PPROF               bool       `json:"pprof"`
-	PPROFAddress        string     `json:"pprofAddress"`
-	PPROFEncryption     bool       `json:"pprofEncryption"`
-	PPROFServerKey      string     `json:"pprofServerKey"`
-	PPROFServerCert     string     `json:"pprofServerCert"`
-	PPROFAllowOrigin    *string    `json:"pprofAllowOrigin,omitempty" deprecated:"true"`
-	PPROFAllowOrigins   []string   `json:"pprofAllowOrigins"`
-	PPROFTrustedProxies IPNetworks `json:"pprofTrustedProxies"`
+	PPROF               bool                  `json:"pprof"`
+	PPROFAddress        string                `json:"pprofAddress"`
+	PPROFEncryption     bool                  `json:"pprofEncryption"`
+	PPROFServerKey      string                `json:"pprofServerKey"`
+	PPROFServerCert     string                `json:"pprofServerCert"`
+	PPROFAllowOrigin    *string               `json:"pprofAllowOrigin,omitempty" deprecated:"true"`
+	PPROFAllowOrigins   []string              `json:"pprofAllowOrigins"`
+	PPROFTrustedProxies IPNetworks            `json:"pprofTrustedProxies"`
+	PPROFFailurePolicy  ListenerFailurePolicy `json:"pprofFailurePolicy"`
 
 	// Playback
-	Playback               bool       `json:"playback"`
-	PlaybackAddress        string     `json:"playbackAddress"`
-	PlaybackEncryption     bool       `json:"playbackEncryption"`
-	PlaybackServerKey      string     `json:"playbackServerKey"`
-	PlaybackServerCert     string     `json:"playbackServerCert"`
-	PlaybackAllowOrigin    *string    `json:"playbackAllowOrigin,omitempty" deprecated:"true"`
-	PlaybackAllowOrigins   []string   `json:"playbackAllowOrigins"`
-	PlaybackTrustedProxies IPNetworks `json:"playbackTrustedProxies"`
+	Playback               bool                  `json:"playback"`
+	PlaybackAddress        string                `json:"playbackAddress"`
+	PlaybackEncryption     bool                  `json:"playbackEncryption"`
+	PlaybackServerKey      string                `json:"playbackServerKey"`
+	PlaybackServerCert     string                `json:"playbackServerCert"`
+	PlaybackAllowOrigin    *string               `json:"playbackAllowOrigin,omitempty" deprecated:"true"`
+	PlaybackAllowOrigins   []string              `json:"playbackAllowOrigins"`
+	PlaybackTrustedProxies IPNetworks            `json:"playbackTrustedProxies"`
+	PlaybackFailurePolicy  ListenerFailurePolicy `json:"playbackFailurePolicy"`
 
 	// RTSP server
-	RTSP                  bool             `json:"rtsp"`
-	RTSPDisable           *bool            `json:"rtspDisable,omitempty" deprecated:"true"`
-	Protocols             *RTSPTransports  `json:"protocols,omitempty" deprecated:"true"`
-	RTSPTransports        RTSPTransports   `json:"rtspTransports"`
-	Encryption            *Encryption      `json:"encryption,omitempty" deprecated:"true"`
-	RTSPEncryption        Encryption       `json:"rtspEncryption"`
-	RTSPAddress           string           `json:"rtspAddress"`
-	RTSPSAddress          string           `json:"rtspsAddress"`
-	RTPAddress            string           `json:"rtpAddress"`
-	RTCPAddress           string           `json:"rtcpAddress"`
-	MulticastIPRange      string           `json:"multicastIPRange"`
-	MulticastRTPPort      int              `json:"multicastRTPPort"`
-	MulticastRTCPPort     int              `json:"multicastRTCPPort"`
-	SRTPAddress           string           `json:"srtpAddress"`
-	SRTCPAddress          string           `json:"srtcpAddress"`
-	MulticastSRTPPort     int              `json:"multicastSRTPPort"`
-	MulticastSRTCPPort    int              `json:"multicastSRTCPPort"`
-	ServerKey             *string          `json:"serverKey,omitempty"`
-	ServerCert            *string          `json:"serverCert,omitempty"`
-	RTSPServerKey         string           `json:"rtspServerKey"`
-	RTSPServerCert        string           `json:"rtspServerCert"`
-	AuthMethods           *RTSPAuthMethods `json:"authMethods,omitempty" deprecated:"true"`
-	RTSPAuthMethods       RTSPAuthMethods  `json:"rtspAuthMethods"`
-	RTSPUDPReadBufferSize *uint            `json:"rtspUDPReadBufferSize,omitempty" deprecated:"true"`
+	RTSP                  bool                  `json:"rtsp"`
+	RTSPDisable           *bool                 `json:"rtspDisable,omitempty" deprecated:"true"`
+	Protocols             *RTSPTransports       `json:"protocols,omitempty" deprecated:"true"`
+	RTSPTransports        RTSPTransports        `json:"rtspTransports"`
+	Encryption            *Encryption           `json:"encryption,omitempty" deprecated:"true"`
+	RTSPEncryption        Encryption            `json:"rtspEncryption"`
+	RTSPAddress           string                `json:"rtspAddress"`
+	RTSPSAddress          string                `json:"rtspsAddress"`
+	RTPAddress            string                `json:"rtpAddress"`
+	RTCPAddress           string                `json:"rtcpAddress"`
+	MulticastIPRange      string                `json:"multicastIPRange"`
+	MulticastRTPPort      int                   `json:"multicastRTPPort"`
+	MulticastRTCPPort     int                   `json:"multicastRTCPPort"`
+	SRTPAddress           string                `json:"srtpAddress"`
+	SRTCPAddress          string                `json:"srtcpAddress"`
+	MulticastSRTPPort     int                   `json:"multicastSRTPPort"`
+	MulticastSRTCPPort    int                   `json:"multicastSRTCPPort"`
+	ServerKey             *string               `json:"serverKey,omitempty"`
+	ServerCert            *string               `json:"serverCert,omitempty"`
+	RTSPServerKey         string                `json:"rtspServerKey"`
+	RTSPServerCert        string                `json:"rtspServerCert"`
+	AuthMethods           *RTSPAuthMethods      `json:"authMethods,omitempty" deprecated:"true"`
+	RTSPAuthMethods       RTSPAuthMethods       `json:"rtspAuthMethods"`
+	RTSPUDPReadBufferSize *uint                 `json:"rtspUDPReadBufferSize,omitempty" deprecated:"true"`
+	RTSPFailurePolicy     ListenerFailurePolicy `json:"rtspFailurePolicy"`
+	RTSPSFailurePolicy    ListenerFailurePolicy `json:"rtspsFailurePolicy"`
 
 	// RTMP server
-	RTMP           bool       `json:"rtmp"`
-	RTMPDisable    *bool      `json:"rtmpDisable,omitempty" deprecated:"true"`
-	RTMPEncryption Encryption `json:"rtmpEncryption"`
-	RTMPAddress    string     `json:"rtmpAddress"`
-	RTMPSAddress   string     `json:"rtmpsAddress"`
-	RTMPServerKey  string     `json:"rtmpServerKey"`
-	RTMPServerCert string     `json:"rtmpServerCert"`
+	RTMP               bool                  `json:"rtmp"`
+	RTMPDisable        *bool                 `json:"rtmpDisable,omitempty" deprecated:"true"`
+	RTMPEncryption     Encryption            `json:"rtmpEncryption"`
+	RTMPAddress        string                `json:"rtmpAddress"`
+	RTMPSAddress       string                `json:"rtmpsAddress"`
+	RTMPServerKey      string                `json:"rtmpServerKey"`
+	RTMPServerCert     string                `json:"rtmpServerCert"`
+	RTMPFailurePolicy  ListenerFailurePolicy `json:"rtmpFailurePolicy"`
+	RTMPSFailurePolicy ListenerFailurePolicy `json:"rtmpsFailurePolicy"`
 
 	// HLS server
-	HLS                bool       `json:"hls"`
-	HLSDisable         *bool      `json:"hlsDisable,omitempty" deprecated:"true"`
-	HLSAddress         string     `json:"hlsAddress"`
-	HLSEncryption      bool       `json:"hlsEncryption"`
-	HLSServerKey       string     `json:"hlsServerKey"`
-	HLSServerCert      string     `json:"hlsServerCert"`
-	HLSAllowOrigin     *string    `json:"hlsAllowOrigin,omitempty" deprecated:"true"`
-	HLSAllowOrigins    []string   `json:"hlsAllowOrigins"`
-	HLSTrustedProxies  IPNetworks `json:"hlsTrustedProxies"`
-	HLSAlwaysRemux     bool       `json:"hlsAlwaysRemux"`
-	HLSVariant         HLSVariant `json:"hlsVariant"`
-	HLSSegmentCount    int        `json:"hlsSegmentCount"`
-	HLSSegmentDuration Duration   `json:"hlsSegmentDuration"`
-	HLSPartDuration    Duration   `json:"hlsPartDuration"`
-	HLSSegmentMaxSize  StringSize `json:"hlsSegmentMaxSize"`
-	HLSDirectory       string     `json:"hlsDirectory"`
-	HLSMuxerCloseAfter Duration   `json:"hlsMuxerCloseAfter"`
+	HLS                bool                  `json:"hls"`
+	HLSDisable         *bool                 `json:"hlsDisable,omitempty" deprecated:"true"`
+	HLSAddress         string                `json:"hlsAddress"`
+	HLSEncryption      bool                  `json:"hlsEncryption"`
+	HLSServerKey       string                `json:"hlsServerKey"`
+	HLSServerCert      string                `json:"hlsServerCert"`
+	HLSAllowOrigin     *string               `json:"hlsAllowOrigin,omitempty" deprecated:"true"`
+	HLSAllowOrigins    []string              `json:"hlsAllowOrigins"`
+	HLSTrustedProxies  IPNetworks            `json:"hlsTrustedProxies"`
+	HLSAlwaysRemux     bool                  `json:"hlsAlwaysRemux"`
+	HLSVariant         HLSVariant            `json:"hlsVariant"`
+	HLSSegmentCount    int                   `json:"hlsSegmentCount"`
+	HLSSegmentDuration Duration              `json:"hlsSegmentDuration"`
+	HLSPartDuration    Duration              `json:"hlsPartDuration"`
+	HLSSegmentMaxSize  StringSize            `json:"hlsSegmentMaxSize"`
+	HLSDirectory       string                `json:"hlsDirectory"`
+	HLSMuxerCloseAfter Duration              `json:"hlsMuxerCloseAfter"`
+	HLSFailurePolicy   ListenerFailurePolicy `json:"hlsFailurePolicy"`
 
 	// WebRTC server
-	WebRTC                      bool              `json:"webrtc"`
-	WebRTCDisable               *bool             `json:"webrtcDisable,omitempty" deprecated:"true"`
-	WebRTCAddress               string            `json:"webrtcAddress"`
-	WebRTCEncryption            bool              `json:"webrtcEncryption"`
-	WebRTCServerKey             string            `json:"webrtcServerKey"`
-	WebRTCServerCert            string            `json:"webrtcServerCert"`
-	WebRTCAllowOrigin           *string           `json:"webrtcAllowOrigin,omitempty" deprecated:"true"`
-	WebRTCAllowOrigins          []string          `json:"webrtcAllowOrigins"`
-	WebRTCTrustedProxies        IPNetworks        `json:"webrtcTrustedProxies"`
-	WebRTCLocalUDPAddress       string            `json:"webrtcLocalUDPAddress"`
-	WebRTCLocalTCPAddress       string            `json:"webrtcLocalTCPAddress"`
-	WebRTCIPsFromInterfaces     bool              `json:"webrtcIPsFromInterfaces"`
-	WebRTCIPsFromInterfacesList []string          `json:"webrtcIPsFromInterfacesList"`
-	WebRTCAdditionalHosts       []string          `json:"webrtcAdditionalHosts"`
-	WebRTCICEServers2           []WebRTCICEServer `json:"webrtcICEServers2"`
-	WebRTCSTUNGatherTimeout     Duration          `json:"webrtcSTUNGatherTimeout"`
-	WebRTCHandshakeTimeout      Duration          `json:"webrtcHandshakeTimeout"`
-	WebRTCTrackGatherTimeout    Duration          `json:"webrtcTrackGatherTimeout"`
-	WebRTCICEUDPMuxAddress      *string           `json:"webrtcICEUDPMuxAddress,omitempty" deprecated:"true"`
-	WebRTCICETCPMuxAddress      *string           `json:"webrtcICETCPMuxAddress,omitempty" deprecated:"true"`
-	WebRTCICEHostNAT1To1IPs     *[]string         `json:"webrtcICEHostNAT1To1IPs,omitempty" deprecated:"true"`
-	WebRTCICEServers            *[]string         `json:"webrtcICEServers,omitempty" deprecated:"true"`
+	WebRTC                      bool                  `json:"webrtc"`
+	WebRTCDisable               *bool                 `json:"webrtcDisable,omitempty" deprecated:"true"`
+	WebRTCAddress               string                `json:"webrtcAddress"`
+	WebRTCEncryption            bool                  `json:"webrtcEncryption"`
+	WebRTCServerKey             string                `json:"webrtcServerKey"`
+	WebRTCServerCert            string                `json:"webrtcServerCert"`
+	WebRTCAllowOrigin           *string               `json:"webrtcAllowOrigin,omitempty" deprecated:"true"`
+	WebRTCAllowOrigins          []string              `json:"webrtcAllowOrigins"`
+	WebRTCTrustedProxies        IPNetworks            `json:"webrtcTrustedProxies"`
+	WebRTCLocalUDPAddress       string                `json:"webrtcLocalUDPAddress"`
+	WebRTCLocalTCPAddress       string                `json:"webrtcLocalTCPAddress"`
+	WebRTCIPsFromInterfaces     bool                  `json:"webrtcIPsFromInterfaces"`
+	WebRTCIPsFromInterfacesList []string              `json:"webrtcIPsFromInterfacesList"`
+	WebRTCAdditionalHosts       []string              `json:"webrtcAdditionalHosts"`
+	WebRTCICEServers2           []WebRTCICEServer     `json:"webrtcICEServers2"`
+	WebRTCSTUNGatherTimeout     Duration              `json:"webrtcSTUNGatherTimeout"`
+	WebRTCHandshakeTimeout      Duration              `json:"webrtcHandshakeTimeout"`
+	WebRTCTrackGatherTimeout    Duration              `json:"webrtcTrackGatherTimeout"`
+	WebRTCICEUDPMuxAddress      *string               `json:"webrtcICEUDPMuxAddress,omitempty" deprecated:"true"`
+	WebRTCICETCPMuxAddress      *string               `json:"webrtcICETCPMuxAddress,omitempty" deprecated:"true"`
+	WebRTCICEHostNAT1To1IPs     *[]string             `json:"webrtcICEHostNAT1To1IPs,omitempty" deprecated:"true"`
+	WebRTCICEServers            *[]string             `json:"webrtcICEServers,omitempty" deprecated:"true"`
+	WebRTCFailurePolicy         ListenerFailurePolicy `json:"webrtcFailurePolicy"`
 
 	// SRT server
-	SRT        bool   `json:"srt"`
-	SRTAddress string `json:"srtAddress"`
+	SRT              bool                  `json:"srt"`
+	SRTAddress       string                `json:"srtAddress"`
+	SRTFailurePolicy ListenerFailurePolicy `json:"srtFailurePolicy"`
 
 	// Record (deprecated)
 	Record                *bool         `json:"record,omitempty" deprecated:"true"`
@@ -443,24 +454,28 @@ func (conf *Conf) setDefaults() {
 	conf.APIServerKey = "server.key"
 	conf.APIServerCert = "server.crt"
 	conf.APIAllowOrigins = []string{"*"}
+	conf.APIFailurePolicy = ListenerFailurePolicyFatal
 
 	// Metrics
 	conf.MetricsAddress = ":9998"
 	conf.MetricsServerKey = "server.key"
 	conf.MetricsServerCert = "server.crt"
 	conf.MetricsAllowOrigins = []string{"*"}
+	conf.MetricsFailurePolicy = ListenerFailurePolicyFatal
 
 	// PPROF
 	conf.PPROFAddress = ":9999"
 	conf.PPROFServerKey = "server.key"
 	conf.PPROFServerCert = "server.crt"
 	conf.PPROFAllowOrigins = []string{"*"}
+	conf.PPROFFailurePolicy = ListenerFailurePolicyFatal
 
 	// Playback server
 	conf.PlaybackAddress = ":9996"
 	conf.PlaybackServerKey = "server.key"
 	conf.PlaybackServerCert = "server.crt"
 	conf.PlaybackAllowOrigins = []string{"*"}
+	conf.PlaybackFailurePolicy = ListenerFailurePolicyFatal
 
 	// RTSP server
 	conf.RTSP = true
@@ -484,6 +499,8 @@ func (conf *Conf) setDefaults() {
 	conf.RTSPServerKey = "server.key"
 	conf.RTSPServerCert = "server.crt"
 	conf.RTSPAuthMethods = RTSPAuthMethods{RTSPAuthMethod(auth.VerifyMethodBasic)}
+	conf.RTSPFailurePolicy = ListenerFailurePolicyFatal
+	conf.RTSPSFailurePolicy = ListenerFailurePolicyFatal
 
 	// RTMP server
 	conf.RTMP = true
@@ -492,6 +509,8 @@ func (conf *Conf) setDefaults() {
 	conf.RTMPSAddress = ":1936"
 	conf.RTMPServerKey = "server.key"
 	conf.RTMPServerCert = "server.crt"
+	conf.RTMPFailurePolicy = ListenerFailurePolicyFatal
+	conf.RTMPSFailurePolicy = ListenerFailurePolicyFatal
 
 	// HLS
 	conf.HLS = true
@@ -505,6 +524,7 @@ func (conf *Conf) setDefaults() {
 	conf.HLSPartDuration = 200 * Duration(time.Millisecond)
 	conf.HLSSegmentMaxSize = 50 * 1024 * 1024
 	conf.HLSMuxerCloseAfter = 60 * Duration(time.Second)
+	conf.HLSFailurePolicy = ListenerFailurePolicyFatal
 
 	// WebRTC server
 	conf.WebRTC = true
@@ -517,10 +537,12 @@ func (conf *Conf) setDefaults() {
 	conf.WebRTCSTUNGatherTimeout = 5 * Duration(time.Second)
 	conf.WebRTCHandshakeTimeout = 10 * Duration(time.Second)
 	conf.WebRTCTrackGatherTimeout = 2 * Duration(time.Second)
+	conf.WebRTCFailurePolicy = ListenerFailurePolicyFatal
 
 	// SRT server
 	conf.SRT = true
 	conf.SRTAddress = ":8890"
+	conf.SRTFailurePolicy = ListenerFailurePolicyFatal
 
 	conf.PathDefaults.setDefaults()
 }

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -202,6 +202,53 @@ func TestConfEncryption(t *testing.T) {
 	require.Equal(t, true, ok)
 }
 
+func TestConfListenerFailurePolicy(t *testing.T) {
+	// default (field absent) is Fatal
+	func() {
+		tmpf, err := createTempFile([]byte(""))
+		require.NoError(t, err)
+		defer os.Remove(tmpf)
+
+		conf, _, err := Load(tmpf, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, ListenerFailurePolicyFatal, conf.RTSPFailurePolicy)
+		require.Equal(t, ListenerFailurePolicyFatal, conf.HLSFailurePolicy)
+		require.Equal(t, ListenerFailurePolicyFatal, conf.APIFailurePolicy)
+	}()
+
+	// "fatal" parses to Fatal
+	func() {
+		tmpf, err := createTempFile([]byte("hlsFailurePolicy: fatal\n"))
+		require.NoError(t, err)
+		defer os.Remove(tmpf)
+
+		conf, _, err := Load(tmpf, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, ListenerFailurePolicyFatal, conf.HLSFailurePolicy)
+	}()
+
+	// "warn" parses to Warn
+	func() {
+		tmpf, err := createTempFile([]byte("hlsFailurePolicy: warn\n"))
+		require.NoError(t, err)
+		defer os.Remove(tmpf)
+
+		conf, _, err := Load(tmpf, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, ListenerFailurePolicyWarn, conf.HLSFailurePolicy)
+	}()
+
+	// unknown value is rejected
+	func() {
+		tmpf, err := createTempFile([]byte("hlsFailurePolicy: bogus\n"))
+		require.NoError(t, err)
+		defer os.Remove(tmpf)
+
+		_, _, err = Load(tmpf, nil, nil)
+		require.Error(t, err)
+	}()
+}
+
 func TestConfDeprecatedAuth(t *testing.T) {
 	tmpf, err := createTempFile([]byte(
 		"paths:\n" +

--- a/internal/conf/listenerfailurepolicy.go
+++ b/internal/conf/listenerfailurepolicy.go
@@ -1,0 +1,39 @@
+package conf
+
+import (
+	"fmt"
+
+	"github.com/bluenviron/mediamtx/internal/conf/jsonwrapper"
+)
+
+// ListenerFailurePolicy controls what happens when a protocol listener
+// fails to start (e.g. its port is already in use).
+type ListenerFailurePolicy string
+
+// values.
+const (
+	ListenerFailurePolicyFatal ListenerFailurePolicy = "fatal"
+	ListenerFailurePolicyWarn  ListenerFailurePolicy = "warn"
+)
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (d *ListenerFailurePolicy) UnmarshalJSON(b []byte) error {
+	type alias ListenerFailurePolicy
+	if err := jsonwrapper.Unmarshal(b, (*alias)(d)); err != nil {
+		return err
+	}
+
+	switch *d {
+	case ListenerFailurePolicyFatal, ListenerFailurePolicyWarn:
+
+	default:
+		return fmt.Errorf("invalid listener failure policy: '%s'", *d)
+	}
+
+	return nil
+}
+
+// UnmarshalEnv implements env.Unmarshaler.
+func (d *ListenerFailurePolicy) UnmarshalEnv(_ string, v string) error {
+	return d.UnmarshalJSON([]byte(`"` + v + `"`))
+}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -367,9 +367,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.MetricsFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "metrics listener failed to start, continuing without it: %v", err)
+		} else {
+			p.metrics = i
 		}
-		p.metrics = i
 	}
 
 	if p.conf.PPROF &&
@@ -389,9 +393,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.PPROFFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "pprof listener failed to start, continuing without it: %v", err)
+		} else {
+			p.pprof = i
 		}
-		p.pprof = i
 	}
 
 	if p.recordCleaner == nil &&
@@ -421,9 +429,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.PlaybackFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "playback listener failed to start, continuing without it: %v", err)
+		} else {
+			p.playbackServer = i
 		}
-		p.playbackServer = i
 	}
 
 	if p.pathManager == nil {
@@ -485,9 +497,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.RTSPFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "RTSP listener failed to start, continuing without it: %v", err)
+		} else {
+			p.rtspServer = i
 		}
-		p.rtspServer = i
 	}
 
 	if p.conf.RTSP &&
@@ -528,9 +544,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.RTSPSFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "RTSPS listener failed to start, continuing without it: %v", err)
+		} else {
+			p.rtspsServer = i
 		}
-		p.rtspsServer = i
 	}
 
 	if p.conf.RTMP &&
@@ -556,9 +576,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.RTMPFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "RTMP listener failed to start, continuing without it: %v", err)
+		} else {
+			p.rtmpServer = i
 		}
-		p.rtmpServer = i
 	}
 
 	if p.conf.RTMP &&
@@ -584,9 +608,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.RTMPSFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "RTMPS listener failed to start, continuing without it: %v", err)
+		} else {
+			p.rtmpsServer = i
 		}
-		p.rtmpsServer = i
 	}
 
 	if p.conf.HLS &&
@@ -615,9 +643,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.HLSFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "HLS listener failed to start, continuing without it: %v", err)
+		} else {
+			p.hlsServer = i
 		}
-		p.hlsServer = i
 	}
 
 	if p.conf.WebRTC &&
@@ -649,9 +681,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.WebRTCFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "WebRTC listener failed to start, continuing without it: %v", err)
+		} else {
+			p.webRTCServer = i
 		}
-		p.webRTCServer = i
 	}
 
 	if p.conf.SRT &&
@@ -672,9 +708,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.SRTFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "SRT listener failed to start, continuing without it: %v", err)
+		} else {
+			p.srtServer = i
 		}
-		p.srtServer = i
 	}
 
 	if p.conf.API &&
@@ -705,9 +745,13 @@ func (p *Core) createResources(initial bool) error {
 		}
 		err = i.Initialize()
 		if err != nil {
-			return err
+			if p.conf.APIFailurePolicy == conf.ListenerFailurePolicyFatal {
+				return err
+			}
+			p.Log(logger.Warn, "API listener failed to start, continuing without it: %v", err)
+		} else {
+			p.api = i
 		}
-		p.api = i
 	}
 
 	if initial && p.confPath != "" {

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -177,6 +177,8 @@ apiAllowOrigins: ['*']
 # These proxies can use the X-Forwarded-For header to set the real IP of clients,
 # and the X-Forwarded-Proto header to set the original protocol.
 apiTrustedProxies: []
+# Behavior if the listener fails to start. Available values are 'fatal' or 'warn'.
+apiFailurePolicy: fatal
 
 ###############################################
 # Global settings -> Metrics
@@ -201,6 +203,8 @@ metricsAllowOrigins: ['*']
 # These proxies can use the X-Forwarded-For header to set the real IP of clients,
 # and the X-Forwarded-Proto header to set the original protocol.
 metricsTrustedProxies: []
+# Behavior if the listener fails to start. Available values are 'fatal' or 'warn'.
+metricsFailurePolicy: fatal
 
 ###############################################
 # Global settings -> PPROF
@@ -225,6 +229,8 @@ pprofAllowOrigins: ['*']
 # These proxies can use the X-Forwarded-For header to set the real IP of clients,
 # and the X-Forwarded-Proto header to set the original protocol.
 pprofTrustedProxies: []
+# Behavior if the listener fails to start. Available values are 'fatal' or 'warn'.
+pprofFailurePolicy: fatal
 
 ###############################################
 # Global settings -> Playback server
@@ -249,6 +255,8 @@ playbackAllowOrigins: ['*']
 # These proxies can use the X-Forwarded-For header to set the real IP of clients,
 # and the X-Forwarded-Proto header to set the original protocol.
 playbackTrustedProxies: []
+# Behavior if the listener fails to start. Available values are 'fatal' or 'warn'.
+playbackFailurePolicy: fatal
 
 ###############################################
 # Global settings -> RTSP server
@@ -292,6 +300,10 @@ rtspServerCert: server.crt
 # Authentication methods. Available are "basic" and "digest".
 # "digest" doesn't provide any additional security and is available for compatibility only.
 rtspAuthMethods: [basic]
+# Behavior if the RTSP listener fails to start. Available values are 'fatal' or 'warn'.
+rtspFailurePolicy: fatal
+# Behavior if the RTSPS listener fails to start. Available values are 'fatal' or 'warn'.
+rtspsFailurePolicy: fatal
 
 ###############################################
 # Global settings -> RTMP server
@@ -312,6 +324,10 @@ rtmpsAddress: :1936
 rtmpServerKey: server.key
 # Path to the server certificate. This is needed only when encryption is "strict" or "optional".
 rtmpServerCert: server.crt
+# Behavior if the RTMP listener fails to start. Available values are 'fatal' or 'warn'.
+rtmpFailurePolicy: fatal
+# Behavior if the RTMPS listener fails to start. Available values are 'fatal' or 'warn'.
+rtmpsFailurePolicy: fatal
 
 ###############################################
 # Global settings -> HLS server
@@ -371,6 +387,8 @@ hlsDirectory: ''
 # The muxer will be closed when there are no
 # reader requests and this amount of time has passed.
 hlsMuxerCloseAfter: 60s
+# Behavior if the listener fails to start. Available values are 'fatal' or 'warn'.
+hlsFailurePolicy: fatal
 
 ###############################################
 # Global settings -> WebRTC server
@@ -428,6 +446,8 @@ webrtcSTUNGatherTimeout: 5s
 webrtcHandshakeTimeout: 10s
 # Maximum time to gather tracks.
 webrtcTrackGatherTimeout: 2s
+# Behavior if the listener fails to start. Available values are 'fatal' or 'warn'.
+webrtcFailurePolicy: fatal
 
 ###############################################
 # Global settings -> SRT server
@@ -436,6 +456,8 @@ webrtcTrackGatherTimeout: 2s
 srt: true
 # Address of the SRT listener.
 srtAddress: :8890
+# Behavior if the listener fails to start. Available values are 'fatal' or 'warn'.
+srtFailurePolicy: fatal
 
 ###############################################
 # Default path settings


### PR DESCRIPTION
On a production system, you might prefer to allow the system to at least start with the mandatory ports running and not completely shut down if one inconsequential server fails to start because the port is in use.