### PR TITLE
use temporary redirects instead of permanent redirects

### DIFF
--- a/internal/servers/hls/http_server.go
+++ b/internal/servers/hls/http_server.go
@@ -177,7 +177,7 @@ func (s *httpServer) onRequest(ctx *gin.Context) {
 
 		if !strings.HasSuffix(dir, "/") {
 			ctx.Header("Location", mergePathAndQuery(ctx.Request.URL.Path+"/", ctx.Request.URL.RawQuery))
-			ctx.Writer.WriteHeader(http.StatusMovedPermanently)
+			ctx.Writer.WriteHeader(http.StatusFound)
 			return
 		}
 

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -146,6 +146,32 @@ func TestServerIndexNotConfigured(t *testing.T) {
 	}, payload)
 }
 
+func TestServerIndexRedirect(t *testing.T) {
+	s := &Server{
+		Address:      "127.0.0.1:8888",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		PathManager:  &dummyPathManager{},
+		Parent:       test.NilLogger,
+	}
+	err := s.Initialize()
+	require.NoError(t, err)
+	defer s.Close()
+
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	res, err := client.Get("http://127.0.0.1:8888/stream")
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusFound, res.StatusCode)
+	require.Equal(t, "/stream/", res.Header.Get("Location"))
+}
+
 func TestServerNotFound(t *testing.T) {
 	for _, ca := range []string{
 		"always remux off",

--- a/internal/servers/rtsp/conn.go
+++ b/internal/servers/rtsp/conn.go
@@ -184,7 +184,7 @@ func (c *conn) onDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx,
 
 	if res.Redirect != "" {
 		return &base.Response{
-			StatusCode: base.StatusMovedPermanently,
+			StatusCode: base.StatusFound,
 			Header: base.Header{
 				"Location": base.HeaderValue{absoluteURL(ctx.Request, res.Redirect)},
 			},

--- a/internal/servers/webrtc/http_server.go
+++ b/internal/servers/webrtc/http_server.go
@@ -404,7 +404,7 @@ func (s *httpServer) onRequest(ctx *gin.Context) {
 
 			case ctx.Request.URL.Path[len(ctx.Request.URL.Path)-1] != '/':
 				ctx.Header("Location", mergePathAndQuery(ctx.Request.URL.Path+"/", ctx.Request.URL.RawQuery))
-				ctx.Writer.WriteHeader(http.StatusMovedPermanently)
+				ctx.Writer.WriteHeader(http.StatusFound)
 
 			default:
 				s.onPage(ctx, ctx.Request.URL.Path[1:len(ctx.Request.URL.Path)-1], false)

--- a/internal/servers/webrtc/server_test.go
+++ b/internal/servers/webrtc/server_test.go
@@ -193,6 +193,24 @@ func TestServerIndexNotConfigured(t *testing.T) {
 	}, payload)
 }
 
+func TestServerIndexRedirect(t *testing.T) {
+	s := initializeTestServer(t)
+	defer s.Close()
+
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	res, err := client.Get("http://127.0.0.1:8886/stream")
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusFound, res.StatusCode)
+	require.Equal(t, "/stream/", res.Header.Get("Location"))
+}
+
 func TestServerOptionsICEServer(t *testing.T) {
 	pathManager := &test.PathManager{
 		FindPathConfImpl: func(req defs.PathFindPathConfReq) (*defs.PathFindPathConfRes, error) {


### PR DESCRIPTION
this prevents unwanted caching.