### PR TITLE
rtmp: fix panic when reader contains nil tracks

### DIFF
--- a/internal/protocols/rtmp/to_stream.go
+++ b/internal/protocols/rtmp/to_stream.go
@@ -39,6 +39,9 @@ func ToStream(
 	var medias []*description.Media
 
 	for _, track := range r.Tracks() {
+		if track == nil {
+			continue
+		}
 		switch codec := track.Codec.(type) {
 		case *codecs.AV1:
 			forma := &format.AV1{


### PR DESCRIPTION
Fixes #5724. `gortmplib.Reader.Tracks()` can return entries that are `nil` (for example unsupported multitrack variants where the track map is set to nil), causing `track.Codec` to panic in `ToStream`. Skip nil tracks so static RTMP sources no longer crash.