### PR TITLE
hls: refresh H264/H265 codec parameters in OnData callback

### DIFF
--- a/internal/protocols/hls/from_stream.go
+++ b/internal/protocols/hls/from_stream.go
@@ -107,12 +107,13 @@ func setupVideoTrack(
 
 	if videoFormatH265 != nil {
 		vps, sps, pps := videoFormatH265.SafeParams()
+		h265Codec := &codecs.H265{
+			VPS: vps,
+			SPS: sps,
+			PPS: pps,
+		}
 		track := &gohlslib.Track{
-			Codec: &codecs.H265{
-				VPS: vps,
-				SPS: sps,
-				PPS: pps,
-			},
+			Codec:     h265Codec,
 			ClockRate: videoFormatH265.ClockRate(),
 		}
 
@@ -123,6 +124,15 @@ func setupVideoTrack(
 			func(u *unit.Unit) error {
 				if u.NilPayload() {
 					return nil
+				}
+
+				// Refresh codec parameters in case they were not yet
+				// available at track creation. With hlsAlwaysRemux=yes
+				// the muxer is built at PathReady time, before the
+				// publisher's read loop has run formatUpdaterH265 to
+				// populate VPS/SPS/PPS from incoming NAL units.
+				if h265Codec.SPS == nil {
+					h265Codec.VPS, h265Codec.SPS, h265Codec.PPS = videoFormatH265.SafeParams()
 				}
 
 				err := muxer.WriteH265(
@@ -145,11 +155,12 @@ func setupVideoTrack(
 
 	if videoFormatH264 != nil {
 		sps, pps := videoFormatH264.SafeParams()
+		h264Codec := &codecs.H264{
+			SPS: sps,
+			PPS: pps,
+		}
 		track := &gohlslib.Track{
-			Codec: &codecs.H264{
-				SPS: sps,
-				PPS: pps,
-			},
+			Codec:     h264Codec,
 			ClockRate: videoFormatH264.ClockRate(),
 		}
 
@@ -160,6 +171,15 @@ func setupVideoTrack(
 			func(u *unit.Unit) error {
 				if u.NilPayload() {
 					return nil
+				}
+
+				// Refresh codec parameters in case they were not yet
+				// available at track creation. With hlsAlwaysRemux=yes
+				// the muxer is built at PathReady time, before the
+				// publisher's read loop has run formatUpdaterH264 to
+				// populate SPS/PPS from incoming NAL units.
+				if h264Codec.SPS == nil {
+					h264Codec.SPS, h264Codec.PPS = videoFormatH264.SafeParams()
 				}
 
 				err := muxer.WriteH264(


### PR DESCRIPTION
### Problem

With `hlsAlwaysRemux: yes` and a source that delivers H264 SPS (or H265 VPS/SPS/PPS) only in the elementary stream — MPEG-TS over SRT/UDP, HLS pull, WebRTC, RTSP without `sprop-parameter-sets` — `/<path>/index.m3u8` returns `500 Internal Server Error` with an empty body.

RTMP and other sources that surface SPS upfront (e.g., from `AVCDecoderConfigurationRecord` or SDP `sprop-parameter-sets`) are not affected. Reproducible on v1.18.0 and v1.18.1.

Repro:

```yaml
# mediamtx.yml
hlsAlwaysRemux: yes
```

```sh
ffmpeg -re -i input.mp4 -c:v libx264 -f mpegts \
  "srt://localhost:8890?streamid=publish:test"

curl -i http://localhost:8888/test/index.m3u8
# HTTP/1.1 500 Internal Server Error
# Content-Length: 0
```

### Root cause

`internal/protocols/hls/from_stream.go` `setupVideoTrack` captures `videoFormatH264.SafeParams()` once at HLS muxer init and stores the result in the `*codecs.H264` passed to gohlslib. With `hlsAlwaysRemux: yes`, the muxer is built on `chPathReady` *before* any unit has flowed through the reader — so for sources that fill SPS in-band (via `formatUpdaterH264` in `internal/stream/format_updater.go`), `codec.SPS` captures nil and is never refreshed. gohlslib's `populateMultivariantPlaylist` then calls `h264.SPS.Unmarshal(nil)` → "not enough bits" → 500 with no body. H265 has the identical pattern with VPS/SPS/PPS.

### Fix

In the H264/H265 OnData callbacks, refresh codec parameters from `SafeParams()` while they're still nil. By the time OnData runs in `subStreamFormat.writeUnitInner`, `formatUpdater` has already scanned the payload and called `SafeSetParams`, so the values are current. The `if codec.SPS == nil` guard short-circuits after the first frame.

### Verification

Tested on Linux amd64 against v1.18.1 + this patch with an SRT/MPEG-TS publisher (4K 4:4:4 from OBS) plus three `runOnReady`-published variant paths:

- Pre-patch: `index.m3u8` → 500, empty body.
- Post-patch: 200, multivariant playlist with correct `RESOLUTION`, `FRAME-RATE`, `CODECS`.
- `hlsAlwaysRemux: no` (previous workaround) still works.
- `internal/protocols/hls` tests pass.

### Concurrency note

The codec slice-header writes on the reader goroutine and the reads in `populateMultivariantPlaylist` on the HTTP handler are unsynchronized. In practice gohlslib's `m.mutex` provides happens-before: the playlist handler waits on `m.cond` until segments exist, which only happens after the OnData callback has run and assigned the codec fields. Happy to add an `RWMutex` to the codec struct if belt-and-braces is preferred.
