### PR TITLE
Add max age to HLS CORS preflight responses

### DIFF
--- a/internal/servers/hls/http_server.go
+++ b/internal/servers/hls/http_server.go
@@ -124,6 +124,7 @@ func (s *httpServer) middlewarePreflightRequests(ctx *gin.Context) {
 		ctx.Request.Header.Get("Access-Control-Request-Method") != "" {
 		ctx.Header("Access-Control-Allow-Methods", "OPTIONS, GET")
 		ctx.Header("Access-Control-Allow-Headers", "Authorization, Range")
+		ctx.Header("Access-Control-Max-Age", "86400")
 		ctx.AbortWithStatus(http.StatusNoContent)
 		return
 	}

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -102,6 +102,7 @@ func TestServerPreflightRequest(t *testing.T) {
 	require.Equal(t, "true", res.Header.Get("Access-Control-Allow-Credentials"))
 	require.Equal(t, "OPTIONS, GET", res.Header.Get("Access-Control-Allow-Methods"))
 	require.Equal(t, "Authorization, Range", res.Header.Get("Access-Control-Allow-Headers"))
+	require.Equal(t, "86400", res.Header.Get("Access-Control-Max-Age"))
 	require.Equal(t, byts, []byte{})
 }
 


### PR DESCRIPTION
Fixes #5755.

This adds `Access-Control-Max-Age: 86400` to HLS CORS preflight responses so browsers can cache successful preflight checks instead of sending an OPTIONS request before every segment request.

The existing HLS preflight test now verifies the new header.

Tests:
- `go test ./internal/servers/hls -run TestServerPreflightRequest -count=1`
- `go test ./internal/servers/hls -count=1`