### PR TITLE
always-available: support disabling recording when source is offline

### DIFF
--- a/docs/2-features/08-always-available.md
+++ b/docs/2-features/08-always-available.md
@@ -26,3 +26,15 @@ paths:
     alwaysAvailable: true
     alwaysAvailableFile: "./h264.mp4"
 ```
+
+By default, the stream is recorded even when no source is connected and the offline segment is playing. To record only when a source is connected, set `alwaysAvailableRecorded` to `false`:
+
+```yml
+paths:
+  mypath:
+    alwaysAvailable: true
+    alwaysAvailableRecorded: false
+    record: true
+    alwaysAvailableTracks:
+      - codec: H264
+```

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -48,6 +48,7 @@ func TestConfFromFile(t *testing.T) {
 			SourceOnDemandCloseAfter:     10 * Duration(time.Second),
 			OverridePublisher:            true,
 			AlwaysAvailableTracks:        []AlwaysAvailableTrack{},
+			AlwaysAvailableRecorded:      true,
 			RecordPath:                   "./recordings/%path/%Y-%m-%d_%H-%M-%S-%f",
 			RecordFormat:                 RecordFormatFMP4,
 			RecordPartDuration:           Duration(1 * time.Second),

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -193,9 +193,10 @@ type Path struct {
 	UseAbsoluteTimestamp       bool     `json:"useAbsoluteTimestamp"`
 
 	// Always available
-	AlwaysAvailable       bool                   `json:"alwaysAvailable"`
-	AlwaysAvailableTracks []AlwaysAvailableTrack `json:"alwaysAvailableTracks"`
-	AlwaysAvailableFile   string                 `json:"alwaysAvailableFile"`
+	AlwaysAvailable         bool                   `json:"alwaysAvailable"`
+	AlwaysAvailableTracks   []AlwaysAvailableTrack `json:"alwaysAvailableTracks"`
+	AlwaysAvailableFile     string                 `json:"alwaysAvailableFile"`
+	AlwaysAvailableRecorded bool                   `json:"alwaysAvailableRecorded"`
 
 	// Record
 	Record                bool         `json:"record"`
@@ -319,6 +320,9 @@ func (pconf *Path) setDefaults() {
 	pconf.Source = "publisher"
 	pconf.SourceOnDemandStartTimeout = 10 * Duration(time.Second)
 	pconf.SourceOnDemandCloseAfter = 10 * Duration(time.Second)
+
+	// Always available
+	pconf.AlwaysAvailableRecorded = true
 
 	// Record
 	pconf.RecordPath = "./recordings/%path/%Y-%m-%d_%H-%M-%S-%f"

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -404,12 +404,14 @@ func (pa *path) doReloadConf(newConf *conf.Path) {
 			newConf.RecordPartDuration != oldConf.RecordPartDuration ||
 			newConf.RecordMaxPartSize != oldConf.RecordMaxPartSize ||
 			newConf.RecordSegmentDuration != oldConf.RecordSegmentDuration ||
-			newConf.RecordDeleteAfter != oldConf.RecordDeleteAfter) {
+			newConf.RecordDeleteAfter != oldConf.RecordDeleteAfter ||
+			newConf.AlwaysAvailableRecorded != oldConf.AlwaysAvailableRecorded) {
 		pa.recorder.Close()
 		pa.recorder = nil
 	}
 
-	if newConf.Record && pa.stream != nil && pa.recorder == nil {
+	if newConf.Record && pa.stream != nil && pa.recorder == nil &&
+		(!newConf.AlwaysAvailable || newConf.AlwaysAvailableRecorded || pa.source != nil) {
 		pa.startRecording()
 	}
 }
@@ -563,6 +565,10 @@ func (pa *path) doAddPublisher(req defs.PathAddPublisherReq) {
 
 	if pa.conf.AlwaysAvailable {
 		pa.onlineTime = time.Now()
+
+		if pa.conf.Record && !pa.conf.AlwaysAvailableRecorded && pa.recorder == nil {
+			pa.startRecording()
+		}
 	}
 
 	if pa.conf.HasOnDemandPublisher() && pa.onDemandPublisherState != pathOnDemandStateInitial {
@@ -840,7 +846,7 @@ func (pa *path) setAvailable(
 		pa.onlineTime = time.Now()
 	}
 
-	if pa.conf.Record {
+	if pa.conf.Record && (!pa.conf.AlwaysAvailable || pa.conf.AlwaysAvailableRecorded) {
 		pa.startRecording()
 	}
 
@@ -957,6 +963,11 @@ func (pa *path) executeRemovePublisher() {
 	if !pa.conf.AlwaysAvailable {
 		pa.setNotAvailable()
 	} else {
+		if pa.conf.Record && !pa.conf.AlwaysAvailableRecorded && pa.recorder != nil {
+			pa.recorder.Close()
+			pa.recorder = nil
+		}
+
 		err := pa.stream.StartOfflineSubStream()
 		if err != nil {
 			panic("should not happen")


### PR DESCRIPTION
## Summary

Add `alwaysAvailableRecorded` parameter that controls whether recording happens during offline periods for always-available paths. When set to `false`, recording only starts when a real source is connected and stops when it disconnects.

Default is `true`, preserving current behavior.

Closes #5587

## Changes

- `internal/conf/path.go`: Add `AlwaysAvailableRecorded` config field (default: `true`)
- `internal/core/path.go`: Conditional recording start/stop based on the new flag in `setAvailable()`, `doAddPublisher()`, `executeRemovePublisher()`, and `doReloadConf()`
- `internal/conf/conf_test.go`: Update test expected struct
- `docs/2-features/08-always-available.md`: Document the new parameter

## Testing

- All config tests pass (`go test ./internal/conf/...`)
- Core tests pass (pre-existing SRT flaky test is unrelated)
- Build succeeds (`go build ./...`)