### PR TITLE
webrtc: drop stale mux candidates after network change

### DIFF
--- a/internal/protocols/webrtc/peer_connection.go
+++ b/internal/protocols/webrtc/peer_connection.go
@@ -469,8 +469,20 @@ func (co *PeerConnection) removeUnwantedCandidates(firstMedia *sdp.MediaDescript
 		}
 	}
 
-	var newAttributes []sdp.Attribute //nolint:prealloc
+	// When using the shared UDP mux with no explicit interface filter and no
+	// additional hosts, fetch current live IPs to detect stale candidates
+	// left over from a prior network configuration (e.g. after a WiFi change).
+	var liveIPs []string
+	if co.ICEUDPMux != nil && !co.IPsFromInterfaces && len(co.AdditionalHosts) == 0 {
+		var err error
+		liveIPs, err = interfaceIPs(nil)
+		if err != nil {
+			co.Log.Log(logger.Warn,
+				"failed to query live interface IPs, skipping stale candidate filter: %v", err)
+		}
+	}
 
+	var newAttributes []sdp.Attribute //nolint:prealloc
 	for _, attr := range firstMedia.Attributes {
 		if attr.Key == "candidate" {
 			parts := strings.Split(attr.Value, " ")
@@ -480,17 +492,27 @@ func (co *PeerConnection) removeUnwantedCandidates(firstMedia *sdp.MediaDescript
 				continue
 			}
 
-			// hide disallowed IPs
-			if parts[7] == "host" && !slices.Contains(allowedIPs, parts[4]) {
-				continue
+			if parts[7] == "host" {
+				if len(liveIPs) > 0 && parts[2] == "udp" {
+					// drop stale mux candidates whose IP no longer exists
+					// on any live interface (network-change fix)
+					if !slices.Contains(liveIPs, parts[4]) {
+						co.Log.Log(logger.Debug,
+							"dropping stale mux candidate %s: IP %s not found on current interfaces",
+							attr.Value, parts[4])
+						continue
+					}
+				} else {
+					// hide IPs not in the allowed interface list
+					if !slices.Contains(allowedIPs, parts[4]) {
+						continue
+					}
+				}
 			}
 		}
-
 		newAttributes = append(newAttributes, attr)
 	}
-
 	firstMedia.Attributes = newAttributes
-
 	return nil
 }
 

--- a/internal/protocols/webrtc/peer_connection_test.go
+++ b/internal/protocols/webrtc/peer_connection_test.go
@@ -18,6 +18,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type fakeUDPMux struct{}
+
+func (f *fakeUDPMux) Close() error                                     { return nil }
+func (f *fakeUDPMux) GetConn(string, net.Addr) (net.PacketConn, error) { return nil, nil }
+func (f *fakeUDPMux) RemoveConnByUfrag(string)                         {}
+func (f *fakeUDPMux) GetListenAddresses() []net.Addr                   { return nil }
+
 type nilWriter struct{}
 
 func (nilWriter) Write(p []byte) (int, error) {
@@ -885,4 +892,27 @@ func TestPeerConnectionPublishDataChannel(t *testing.T) {
 	pc2.OutgoingDataChannels[0].Write([]byte("test data"))
 
 	<-dataReceived
+}
+
+func TestRemoveUnwantedCandidatesStaleIP(t *testing.T) {
+	// Simulates a candidate whose IP is no longer present on any interface
+	// (e.g. after a WiFi network change). It should be dropped.
+	co := &PeerConnection{
+		ICEUDPMux: &fakeUDPMux{}, // non-nil triggers the liveIPs check
+		Log:       test.NilLogger,
+	}
+
+	staleIP := "10.99.99.99" // guaranteed not on any real interface
+	media := &sdp.MediaDescription{
+		Attributes: []sdp.Attribute{
+			{Key: "candidate", Value: "123 1 udp 2130706431 " + staleIP + " 8189 typ host generation 0"},
+			{Key: "candidate", Value: "456 1 udp 2130706431 127.0.0.1 8189 typ host generation 0"},
+		},
+	}
+
+	err := co.removeUnwantedCandidates(media)
+	require.NoError(t, err)
+
+	require.Len(t, media.Attributes, 1)
+	require.Contains(t, media.Attributes[0].Value, "127.0.0.1")
 }


### PR DESCRIPTION
Fixes #5097

### Problem

When `webrtcLocalUDPAddress` is set (the default), a single `UDPMuxDefault`
is created at server startup. Pion collects local interface addresses once at
that point and caches them inside the mux. When the server's network changes
(e.g. the host switches WiFi networks), the mux keeps advertising the
startup-time IP as a host candidate in every new SDP answer. The new network
IP is never added, so ICE negotiation on the new network fails and the stream
cannot recover without a full server restart.

### Fix

`removeUnwantedCandidates` already has the right place to intercept this.
When `ICEUDPMux` is set and the caller has not configured `IPsFromInterfaces`
or `AdditionalHosts` (both of which have their own filtering logic), call
`net.Interfaces()` fresh for each new session and drop any host UDP candidate
whose IP is no longer present on a live interface.

The call is cheap — one syscall per session at SDP answer time — and
completely non-fatal: if the query fails, a warning is logged and the filter
is skipped rather than rejecting the session.

### Tested

Reproduced the bug by switching WiFi networks while mediamtx was running and
observing the stale IP in the SDP answer. After the fix the stale candidate
is dropped and the new session negotiates successfully on the new network.

Before (stale `192.168.0.9` advertised to client on new network):

```
a=candidate:... 127.0.0.1 8189 typ host
a=candidate:... 192.168.0.9 8189 typ host
a=candidate:... 172.18.0.1 8189 typ host
```

After (stale candidate dropped, connection succeeds via `172.18.0.1`):

```
a=candidate:... 127.0.0.1 8189 typ host
a=candidate:... 172.18.0.1 8189 typ host
```

A unit test covering this code path is included in `peer_connection_test.go`.