### PR TITLE
webrtc: add ability to exclude interfaces

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -553,6 +553,10 @@ components:
           type: array
           items:
             type: string
+        webrtcIPsFromInterfacesExcludeList:
+          type: array
+          items:
+            type: string
         webrtcAdditionalHosts:
           type: array
           items:

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -379,8 +379,9 @@ type Conf struct {
 	WebRTCLocalUDPAddress       string            `json:"webrtcLocalUDPAddress"`
 	WebRTCLocalTCPAddress       string            `json:"webrtcLocalTCPAddress"`
 	WebRTCIPsFromInterfaces     bool              `json:"webrtcIPsFromInterfaces"`
-	WebRTCIPsFromInterfacesList []string          `json:"webrtcIPsFromInterfacesList"`
-	WebRTCAdditionalHosts       []string          `json:"webrtcAdditionalHosts"`
+	WebRTCIPsFromInterfacesList        []string          `json:"webrtcIPsFromInterfacesList"`
+	WebRTCIPsFromInterfacesExcludeList []string          `json:"webrtcIPsFromInterfacesExcludeList"`
+	WebRTCAdditionalHosts              []string          `json:"webrtcAdditionalHosts"`
 	WebRTCICEServers2           []WebRTCICEServer `json:"webrtcICEServers2"`
 	WebRTCSTUNGatherTimeout     Duration          `json:"webrtcSTUNGatherTimeout"`
 	WebRTCHandshakeTimeout      Duration          `json:"webrtcHandshakeTimeout"`

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -653,8 +653,9 @@ func (p *Core) createResources(initial bool) error {
 			LocalUDPAddress:       p.conf.WebRTCLocalUDPAddress,
 			LocalTCPAddress:       p.conf.WebRTCLocalTCPAddress,
 			IPsFromInterfaces:     p.conf.WebRTCIPsFromInterfaces,
-			IPsFromInterfacesList: p.conf.WebRTCIPsFromInterfacesList,
-			AdditionalHosts:       p.conf.WebRTCAdditionalHosts,
+			IPsFromInterfacesList:        p.conf.WebRTCIPsFromInterfacesList,
+			IPsFromInterfacesExcludeList: p.conf.WebRTCIPsFromInterfacesExcludeList,
+			AdditionalHosts:              p.conf.WebRTCAdditionalHosts,
 			ICEServers:            p.conf.WebRTCICEServers2,
 			STUNGatherTimeout:     p.conf.WebRTCSTUNGatherTimeout,
 			HandshakeTimeout:      p.conf.WebRTCHandshakeTimeout,
@@ -950,6 +951,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.WebRTCLocalTCPAddress != p.conf.WebRTCLocalTCPAddress ||
 		newConf.WebRTCIPsFromInterfaces != p.conf.WebRTCIPsFromInterfaces ||
 		!reflect.DeepEqual(newConf.WebRTCIPsFromInterfacesList, p.conf.WebRTCIPsFromInterfacesList) ||
+		!reflect.DeepEqual(newConf.WebRTCIPsFromInterfacesExcludeList, p.conf.WebRTCIPsFromInterfacesExcludeList) ||
 		!reflect.DeepEqual(newConf.WebRTCAdditionalHosts, p.conf.WebRTCAdditionalHosts) ||
 		!reflect.DeepEqual(newConf.WebRTCICEServers2, p.conf.WebRTCICEServers2) ||
 		newConf.WebRTCSTUNGatherTimeout != p.conf.WebRTCSTUNGatherTimeout ||

--- a/internal/protocols/webrtc/peer_connection.go
+++ b/internal/protocols/webrtc/peer_connection.go
@@ -26,7 +26,7 @@ const (
 	twccExtensionURI = "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
 )
 
-func interfaceIPs(interfaceList []string) ([]string, error) {
+func interfaceIPs(interfaceList []string, excludeList []string) ([]string, error) {
 	intfs, err := net.Interfaces()
 	if err != nil {
 		return nil, err
@@ -35,6 +35,9 @@ func interfaceIPs(interfaceList []string) ([]string, error) {
 	var ips []string
 
 	for _, intf := range intfs {
+		if slices.Contains(excludeList, intf.Name) {
+			continue
+		}
 		if len(interfaceList) == 0 || slices.Contains(interfaceList, intf.Name) {
 			var addrs []net.Addr
 			addrs, err = intf.Addrs()
@@ -157,8 +160,9 @@ type PeerConnection struct {
 	ICETCPMux             *TCPMuxWrapper
 	ICEServers            []webrtc.ICEServer
 	IPsFromInterfaces     bool
-	IPsFromInterfacesList []string
-	AdditionalHosts       []string
+	IPsFromInterfacesList        []string
+	IPsFromInterfacesExcludeList []string
+	AdditionalHosts              []string
 	STUNGatherTimeout     time.Duration
 	Publish               bool
 	OutgoingTracks        []*OutgoingTrack
@@ -463,7 +467,7 @@ func (co *PeerConnection) removeUnwantedCandidates(firstMedia *sdp.MediaDescript
 	var allowedIPs []string
 	if co.IPsFromInterfaces {
 		var err error
-		allowedIPs, err = interfaceIPs(co.IPsFromInterfacesList)
+		allowedIPs, err = interfaceIPs(co.IPsFromInterfacesList, co.IPsFromInterfacesExcludeList)
 		if err != nil {
 			return err
 		}

--- a/internal/servers/webrtc/server.go
+++ b/internal/servers/webrtc/server.go
@@ -201,8 +201,9 @@ type Server struct {
 	LocalUDPAddress       string
 	LocalTCPAddress       string
 	IPsFromInterfaces     bool
-	IPsFromInterfacesList []string
-	AdditionalHosts       []string
+	IPsFromInterfacesList        []string
+	IPsFromInterfacesExcludeList []string
+	AdditionalHosts              []string
 	ICEServers            []conf.WebRTCICEServer
 	STUNGatherTimeout     conf.Duration
 	HandshakeTimeout      conf.Duration
@@ -362,8 +363,9 @@ outer:
 				udpReadBufferSize:     s.UDPReadBufferSize,
 				parentCtx:             s.ctx,
 				ipsFromInterfaces:     s.IPsFromInterfaces,
-				ipsFromInterfacesList: s.IPsFromInterfacesList,
-				additionalHosts:       s.AdditionalHosts,
+				ipsFromInterfacesList:        s.IPsFromInterfacesList,
+				ipsFromInterfacesExcludeList: s.IPsFromInterfacesExcludeList,
+				additionalHosts:              s.AdditionalHosts,
 				iceUDPMux:             s.iceUDPMux,
 				iceTCPMux:             s.iceTCPMux,
 				stunGatherTimeout:     s.STUNGatherTimeout,

--- a/internal/servers/webrtc/session.go
+++ b/internal/servers/webrtc/session.go
@@ -227,9 +227,10 @@ type sessionParent interface {
 type session struct {
 	udpReadBufferSize     uint
 	parentCtx             context.Context
-	ipsFromInterfaces     bool
-	ipsFromInterfacesList []string
-	additionalHosts       []string
+	ipsFromInterfaces             bool
+	ipsFromInterfacesList         []string
+	ipsFromInterfacesExcludeList  []string
+	additionalHosts               []string
 	iceUDPMux             ice.UDPMux
 	iceTCPMux             *webrtc.TCPMuxWrapper
 	stunGatherTimeout     conf.Duration
@@ -349,16 +350,17 @@ func (s *session) runPublish() (int, error) {
 	}
 
 	pc := &webrtc.PeerConnection{
-		UDPReadBufferSize:     s.udpReadBufferSize,
-		ICEUDPMux:             s.iceUDPMux,
-		ICETCPMux:             s.iceTCPMux,
-		ICEServers:            iceServers,
-		IPsFromInterfaces:     s.ipsFromInterfaces,
-		IPsFromInterfacesList: s.ipsFromInterfacesList,
-		AdditionalHosts:       s.additionalHosts,
-		STUNGatherTimeout:     time.Duration(s.stunGatherTimeout),
-		Publish:               false,
-		Log:                   s,
+		UDPReadBufferSize:            s.udpReadBufferSize,
+		ICEUDPMux:                    s.iceUDPMux,
+		ICETCPMux:                    s.iceTCPMux,
+		ICEServers:                   iceServers,
+		IPsFromInterfaces:            s.ipsFromInterfaces,
+		IPsFromInterfacesList:        s.ipsFromInterfacesList,
+		IPsFromInterfacesExcludeList: s.ipsFromInterfacesExcludeList,
+		AdditionalHosts:              s.additionalHosts,
+		STUNGatherTimeout:            time.Duration(s.stunGatherTimeout),
+		Publish:                      false,
+		Log:                          s,
 	}
 	err = pc.Start()
 	if err != nil {
@@ -495,16 +497,17 @@ func (s *session) runRead() (int, error) {
 	}
 
 	pc := &webrtc.PeerConnection{
-		UDPReadBufferSize:     s.udpReadBufferSize,
-		ICEUDPMux:             s.iceUDPMux,
-		ICETCPMux:             s.iceTCPMux,
-		ICEServers:            iceServers,
-		IPsFromInterfaces:     s.ipsFromInterfaces,
-		IPsFromInterfacesList: s.ipsFromInterfacesList,
-		AdditionalHosts:       s.additionalHosts,
-		STUNGatherTimeout:     time.Duration(s.stunGatherTimeout),
-		Publish:               true,
-		Log:                   s,
+		UDPReadBufferSize:            s.udpReadBufferSize,
+		ICEUDPMux:                    s.iceUDPMux,
+		ICETCPMux:                    s.iceTCPMux,
+		ICEServers:                   iceServers,
+		IPsFromInterfaces:            s.ipsFromInterfaces,
+		IPsFromInterfacesList:        s.ipsFromInterfacesList,
+		IPsFromInterfacesExcludeList: s.ipsFromInterfacesExcludeList,
+		AdditionalHosts:              s.additionalHosts,
+		STUNGatherTimeout:            time.Duration(s.stunGatherTimeout),
+		Publish:                      true,
+		Log:                          s,
 	}
 
 	r := &stream.Reader{Parent: s}

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -414,6 +414,9 @@ webrtcIPsFromInterfaces: true
 # Interfaces whose IPs will be sent to clients.
 # An empty value means to use all available interfaces.
 webrtcIPsFromInterfacesList: []
+# Interfaces whose IPs will NOT be sent to clients.
+# This is useful to exclude specific interfaces (e.g. VPN tunnels) while using all others.
+webrtcIPsFromInterfacesExcludeList: []
 # Additional hosts or IPs to send to clients.
 webrtcAdditionalHosts: []
 # ICE servers. Needed only when local listeners can't be reached by clients.


### PR DESCRIPTION
Adds the ability to automatically use all interfaces except some for WebRTC PeerConnection host candidates by adding a new configuration parameter `webrtcIPsFromInterfacesExcludeList`. This is useful for example for only excluding VPN interfaces while allowing all others.

Explicitly defining interfaces to use using `webrtcIPsFromInterfacesList` can be cumbersome for excluding because interface names can vary between machines and change.