### PR TITLE
docs: clarify codec availability for secondary stream

### DIFF
--- a/docs/3-publish/12-raspberry-pi-cameras.md
+++ b/docs/3-publish/12-raspberry-pi-cameras.md
@@ -91,7 +91,7 @@ The resulting stream will be available on path `/cam_with_audio`.
 
 ## Secondary stream
 
-It is possible to enable a secondary stream from the same camera, with a different resolution, FPS and codec. Configuration is the same of a primary stream, with `rpiCameraSecondary` set to `true` and parameters adjusted accordingly:
+It is possible to enable a secondary stream from the same camera, with a different resolution, FPS and codec. Only the M-JPEG codec is currently available for a secondary stream. Configuration is the same of a primary stream, with `rpiCameraSecondary` set to `true` and parameters adjusted accordingly:
 
 ```yml
 paths:


### PR DESCRIPTION
Clarify the availability of codecs for secondary stream. At present, the H264 codecs are not available to a secondary stream. Current language about defaults here does not make this evident, though it can be inferred from documentation in complete configuration file. See #4485. 