### PR TITLE
rtsp source: add rtspScale option to inject RFC 2326 Scale header on PLAY

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -782,6 +782,8 @@ components:
           $ref: "#/components/schemas/RTSPRangeType"
         rtspRangeStart:
           type: string
+        rtspScale:
+          type: string
         rtspUDPReadBufferSize:
           type: integer
           format: uint64

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -257,6 +257,7 @@ type Path struct {
 	SourceAnyPortEnable    *bool          `json:"sourceAnyPortEnable,omitempty" deprecated:"true"`
 	RTSPRangeType          RTSPRangeType  `json:"rtspRangeType"`
 	RTSPRangeStart         string         `json:"rtspRangeStart"`
+	RTSPScale              string         `json:"rtspScale"`
 	RTSPUDPReadBufferSize  *uint          `json:"rtspUDPReadBufferSize,omitempty" deprecated:"true"`
 	RTSPUDPSourcePortRange []uint         `json:"rtspUDPSourcePortRange"`
 

--- a/internal/staticsources/rtsp/source.go
+++ b/internal/staticsources/rtsp/source.go
@@ -127,10 +127,6 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 		return err
 	}
 
-	// Capture pathConf in OnRequest so we can inject the Scale header on PLAY
-	// requests when rtspScale is configured (negative values play in reverse,
-	// per RFC 2326). gortsplib's Play() doesn't accept Scale natively.
-	pathConf := params.Conf
 	c := &gortsplib.Client{
 		Protocol:          params.Conf.RTSPTransport.Protocol,
 		ReadTimeout:       time.Duration(s.ReadTimeout),
@@ -143,11 +139,11 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 			uint16(params.Conf.RTSPUDPSourcePortRange[1]),
 		},
 		OnRequest: func(req *base.Request) {
-			if pathConf.RTSPScale != "" && req.Method == base.Play {
+			if params.Conf.RTSPScale != "" && req.Method == base.Play {
 				if req.Header == nil {
 					req.Header = base.Header{}
 				}
-				req.Header["Scale"] = base.HeaderValue{pathConf.RTSPScale}
+				req.Header["Scale"] = base.HeaderValue{params.Conf.RTSPScale}
 			}
 			s.Log(logger.Debug, "[c->s] %v", req)
 		},

--- a/internal/staticsources/rtsp/source.go
+++ b/internal/staticsources/rtsp/source.go
@@ -127,6 +127,10 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 		return err
 	}
 
+	// Capture pathConf in OnRequest so we can inject the Scale header on PLAY
+	// requests when rtspScale is configured (negative values play in reverse,
+	// per RFC 2326). gortsplib's Play() doesn't accept Scale natively.
+	pathConf := params.Conf
 	c := &gortsplib.Client{
 		Protocol:          params.Conf.RTSPTransport.Protocol,
 		ReadTimeout:       time.Duration(s.ReadTimeout),
@@ -139,6 +143,12 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 			uint16(params.Conf.RTSPUDPSourcePortRange[1]),
 		},
 		OnRequest: func(req *base.Request) {
+			if pathConf.RTSPScale != "" && req.Method == base.Play {
+				if req.Header == nil {
+					req.Header = base.Header{}
+				}
+				req.Header["Scale"] = base.HeaderValue{pathConf.RTSPScale}
+			}
 			s.Log(logger.Debug, "[c->s] %v", req)
 		},
 		OnResponse: func(res *base.Response) {

--- a/internal/staticsources/rtsp/source_test.go
+++ b/internal/staticsources/rtsp/source_test.go
@@ -305,6 +305,96 @@ func TestNoPassword(t *testing.T) {
 	<-p.Unit
 }
 
+func TestScale(t *testing.T) {
+	var strm *gortsplib.ServerStream
+
+	media0 := test.UniqueMediaH264()
+
+	s := gortsplib.Server{
+		Handler: &testServer{
+			onDescribe: func(_ *gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
+				return &base.Response{
+					StatusCode: base.StatusOK,
+				}, strm, nil
+			},
+			onSetup: func(_ *gortsplib.ServerHandlerOnSetupCtx) (*base.Response, *gortsplib.ServerStream, error) {
+				return &base.Response{
+					StatusCode: base.StatusOK,
+				}, strm, nil
+			},
+			onPlay: func(ctx *gortsplib.ServerHandlerOnPlayCtx) (*base.Response, error) {
+				require.Equal(t, base.HeaderValue{"-1.0"}, ctx.Request.Header["Scale"])
+
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					err := strm.WritePacketRTP(media0, &rtp.Packet{
+						Header: rtp.Header{
+							Version:        0x02,
+							PayloadType:    96,
+							SequenceNumber: 57899,
+							Timestamp:      345234345,
+							SSRC:           978651231,
+							Marker:         true,
+						},
+						Payload: []byte{5, 1, 2, 3, 4},
+					})
+					require.NoError(t, err)
+				}()
+
+				return &base.Response{
+					StatusCode: base.StatusOK,
+				}, nil
+			},
+		},
+		RTSPAddress: "127.0.0.1:8555",
+	}
+
+	err := s.Start()
+	require.NoError(t, err)
+	defer s.Close()
+
+	strm = &gortsplib.ServerStream{
+		Server: &s,
+		Desc:   &description.Session{Medias: []*description.Media{media0}},
+	}
+	err = strm.Initialize()
+	require.NoError(t, err)
+	defer strm.Close()
+
+	cnf := &conf.Path{
+		RTSPUDPSourcePortRange: []uint{10000, 65535},
+		RTSPScale:              "-1.0",
+	}
+
+	p := &test.StaticSourceParent{}
+	p.Initialize()
+	defer p.Close()
+
+	so := &Source{
+		ReadTimeout:    conf.Duration(10 * time.Second),
+		WriteTimeout:   conf.Duration(10 * time.Second),
+		WriteQueueSize: 2048,
+		Parent:         p,
+	}
+
+	done := make(chan struct{})
+	defer func() { <-done }()
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+
+	go func() {
+		so.Run(defs.StaticSourceRunParams{ //nolint:errcheck
+			Context:        ctx,
+			ResolvedSource: "rtsp://127.0.0.1:8555/teststream",
+			Conf:           cnf,
+		})
+		close(done)
+	}()
+
+	<-p.Unit
+}
+
 func TestRange(t *testing.T) {
 	for _, ca := range []string{"clock", "npt", "smpte"} {
 		t.Run(ca, func(t *testing.T) {

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -593,6 +593,12 @@ pathDefaults:
   # * npt: duration such as "300ms", "1.5m" or "2h45m", valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
   # * smpte: duration such as "300ms", "1.5m" or "2h45m", valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
   rtspRangeStart:
+  # RFC 2326 Scale header value to send with the PLAY request.
+  # Negative values play in reverse (e.g. "-1.0" = reverse at realtime,
+  # "-2.0" = reverse at 2x), values > 1 fast-forward, values 0 < x < 1
+  # play slow motion. Useful with VMS servers (Nx Witness, Pelco, etc.)
+  # that honor Scale for archive playback. Leave empty to omit the header.
+  rtspScale:
   # Range of ports used as source port in outgoing UDP packets.
   rtspUDPSourcePortRange: [10000, 65535]
 

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -593,11 +593,9 @@ pathDefaults:
   # * npt: duration such as "300ms", "1.5m" or "2h45m", valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
   # * smpte: duration such as "300ms", "1.5m" or "2h45m", valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
   rtspRangeStart:
-  # RFC 2326 Scale header value to send with the PLAY request.
-  # Negative values play in reverse (e.g. "-1.0" = reverse at realtime,
-  # "-2.0" = reverse at 2x), values > 1 fast-forward, values 0 < x < 1
-  # play slow motion. Useful with VMS servers (Nx Witness, Pelco, etc.)
-  # that honor Scale for archive playback. Leave empty to omit the header.
+  # Scale header value to send to the source, in order to play the stream at a different speed.
+  # Negative values play in reverse, values > 1 fast-forward,
+  # values 0 < x < 1 play slow motion.
   rtspScale:
   # Range of ports used as source port in outgoing UDP packets.
   rtspUDPSourcePortRange: [10000, 65535]


### PR DESCRIPTION
## Summary

Adds a new per-path option `rtspScale` for the RTSP static source. When set, the value is sent as the `Scale` header in the PLAY request, per [RFC 2326 §12.34](https://datatracker.ietf.org/doc/html/rfc2326#section-12.34).

- Negative values play in reverse: `-1.0` = realtime reverse, `-2.0` = 2x reverse
- Values > 1 fast-forward; values 0 < x < 1 play in slow motion
- Default empty = header omitted = current behavior (backward-compatible)

## Why

I'm integrating MediaMTX as the broker between a Windows access-control system and a Nx Meta VMS server. The VMS honors `Scale: -1.0` to play archive recordings in reverse, which the customer needs for incident review (operator scrubs backwards through footage).

`gortsplib.Client.Play(*headers.Range)` doesn't expose a Scale parameter and `doPlay()` is unexported, so the cleanest way to inject the header is through the existing `OnRequest` hook on the static-source `Client`. When the request method is `PLAY` and `rtspScale` is non-empty, we set the header before the request leaves the client.

Other VMS servers (Pelco, Genetec, some Milestone deployments) follow the same RFC and would benefit too.

## What's in the change

| File | Change |
|---|---|
| `internal/conf/path.go` | New `RTSPScale string` field on `Path` (json: `rtspScale`) |
| `internal/staticsources/rtsp/source.go` | `OnRequest` hook injects `Scale` header on PLAY when `RTSPScale != ""` (10 lines) |
| `internal/staticsources/rtsp/source_test.go` | `TestScale` — verifies the header lands on the server side |
| `mediamtx.yml` | Documents the new field next to `rtspRangeStart` |

Total diff: **4 files, 107 insertions, 0 deletions**. No deprecations, no behavior change for users who don't set the field.

## Example

```yaml
paths:
  reverse-archive:
    source: rtsp://user:pass@vms-server:7001/camera-uuid?pos=2026-05-25T12:00:00.000Z
    sourceOnDemand: yes
    rtspScale: "-1.0"   # play backwards in realtime
```

## Verification

- `TestScale` passes (`go test ./internal/staticsources/rtsp/ -run TestScale`)
- Verified end-to-end against a real Nx Meta 6.1.1 server + Axis M5013 camera: server returns 200 OK to the PLAY with `Scale: -1.0` and streams the (server-side-interpreted) reverse playback.
- Backward compatibility: omitted/empty `rtspScale` produces identical RTSP traffic to current behavior.

## Open question for maintainers

Naming: I went with `rtspScale` to match the existing `rtspRange{Type,Start}` family. Happy to rename to `rtspPlayScale` or similar if you prefer.

## Test plan

- [ ] `go test ./...`
- [ ] Manual: configure a path with `rtspScale: "-1.0"` against any RTSP server that supports Scale; observe the header in the PLAY exchange (e.g. via `tcpdump -A` or the server's debug log)
- [ ] Confirm empty/omitted field produces identical traffic to current behavior