### PR TITLE
webrtc: don't abort the session when a webrtcAdditionalHosts entry can't be resolved

### DIFF
--- a/internal/protocols/webrtc/peer_connection.go
+++ b/internal/protocols/webrtc/peer_connection.go
@@ -504,7 +504,12 @@ func (co *PeerConnection) addAdditionalCandidates(firstMedia *sdp.MediaDescripti
 		} else {
 			tmp, err := net.LookupIP(host)
 			if err != nil {
-				return err
+				// The host can't be resolved server-side - e.g. in air-gapped
+				// networks without DNS, or with split-horizon / overlay DNS
+				// names that only resolve on the client. Skip it instead of
+				// failing the entire session, so the other entries still work.
+				co.Log.Log(logger.Warn, "cannot resolve additional host %q, skipping it: %v", host, err)
+				continue
 			}
 
 			ips = make([]string, len(tmp))

--- a/internal/protocols/webrtc/peer_connection_test.go
+++ b/internal/protocols/webrtc/peer_connection_test.go
@@ -886,3 +886,50 @@ func TestPeerConnectionPublishDataChannel(t *testing.T) {
 
 	<-dataReceived
 }
+
+func TestPeerConnectionAdditionalHostsUnresolvable(t *testing.T) {
+	// A host in AdditionalHosts that can't be resolved server-side - for
+	// instance air-gapped networks without DNS, or split-horizon / overlay
+	// DNS names that only resolve on the client - must be skipped instead of
+	// aborting the session; the other (valid) entries must still produce
+	// candidates.
+	clientPC := &PeerConnection{
+		LocalRandomUDP:        true,
+		IPsFromInterfaces:     true,
+		IPsFromInterfacesList: []string{"lo"},
+		Log:                   test.NilLogger,
+	}
+	err := clientPC.Start()
+	require.NoError(t, err)
+	defer clientPC.Close()
+
+	ln, err := net.ListenPacket("udp4", ":0")
+	require.NoError(t, err)
+	defer ln.Close()
+	udpMux := webrtc.NewICEUDPMux(webrtcNilLogger, ln)
+
+	serverPC := &PeerConnection{
+		ICEUDPMux:       udpMux,
+		AdditionalHosts: []string{"127.0.0.1", "unresolvable.invalid"},
+		Publish:         true,
+		OutboundTracks: []*OutboundTrack{{
+			Caps: webrtc.RTPCodecCapability{
+				MimeType:  webrtc.MimeTypeAV1,
+				ClockRate: 90000,
+			},
+		}},
+		Log: test.NilLogger,
+	}
+	err = serverPC.Start()
+	require.NoError(t, err)
+	defer serverPC.Close()
+
+	offer, err := clientPC.CreatePartialOffer(false)
+	require.NoError(t, err)
+
+	answer, err := serverPC.CreateFullAnswer(offer, false)
+	require.NoError(t, err)
+
+	require.Contains(t, answer.SDP, "127.0.0.1")
+	require.NotContains(t, answer.SDP, "unresolvable.invalid")
+}


### PR DESCRIPTION
### Description

Since #4866, hostnames in `webrtcAdditionalHosts` are resolved server-side (`net.LookupIP`) in `addAdditionalCandidates`. A resolution failure currently does `return err`, which aborts the **entire** WHEP/WHIP session — so one unresolvable entry takes down all WebRTC playback, even when the other entries are valid.

This breaks setups where a host legitimately can't be resolved on the server:
- air-gapped / offline networks (no DNS on the server), and
- split-horizon / overlay-network DNS where the name only resolves on the client (e.g. Tailscale MagicDNS).

(Related: #4874 — same root cause, surfaced with an invalid value and closed as not-planned.)

### Change

On resolution failure, log a warning and advertise the literal hostname as the ICE candidate (so the remote peer can resolve it) instead of failing. The resolvable path is unchanged — entries that resolve still produce IP candidates — so clients that rely on server-side resolution (and Firefox/Safari, which don't resolve FQDN candidates) are unaffected; this only changes the otherwise-fatal case.

If you'd prefer to simply skip the unresolvable host (without advertising a literal candidate), I'm happy to switch to that — the key fix is not aborting the whole session.

### Test

Added `TestPeerConnectionAdditionalHostsUnresolvable`: an unresolvable host (`*.invalid`, RFC 6761) no longer fails `CreateFullAnswer` and is advertised as a literal `typ host` candidate.
