### PR TITLE
fix(playback): avoid panic when MP4 muxer flushes with no samples

### DIFF
--- a/internal/playback/muxer_mp4.go
+++ b/internal/playback/muxer_mp4.go
@@ -90,7 +90,7 @@ func (w *muxerMP4) writeFinalDTS(dts int64) {
 }
 
 func (w *muxerMP4) flush() error {
-	if len(w.curTrack.Samples) == 0 || w.curTrack.lastDTS < 0 {
+	if w.curTrack == nil || len(w.curTrack.Samples) == 0 || w.curTrack.lastDTS < 0 {
 		return recordstore.ErrNoSegmentsFound
 	}
 

--- a/internal/playback/muxer_mp4_test.go
+++ b/internal/playback/muxer_mp4_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bluenviron/mediacommon/v2/pkg/formats/fmp4"
 	mcodecs "github.com/bluenviron/mediacommon/v2/pkg/formats/mp4/codecs"
+	"github.com/bluenviron/mediamtx/internal/recordstore"
 	"github.com/bluenviron/mediamtx/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -56,4 +57,31 @@ func TestMuxerMP4EmptyTracks(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Greater(t, buf.Len(), 0)
+}
+
+// Test that flushing without any written sample returns an error instead of panicking
+func TestMuxerMP4NoSamples(t *testing.T) {
+	var buf bytes.Buffer
+
+	mux := &muxerMP4{
+		w: &buf,
+	}
+
+	init := &fmp4.Init{
+		Tracks: []*fmp4.InitTrack{
+			{
+				ID:        1,
+				TimeScale: 90000,
+				Codec: &mcodecs.H264{
+					SPS: test.FormatH264.SPS,
+					PPS: test.FormatH264.PPS,
+				},
+			},
+		},
+	}
+
+	mux.writeInit(init)
+
+	err := mux.flush()
+	require.ErrorIs(t, err, recordstore.ErrNoSegmentsFound)
 }


### PR DESCRIPTION
## Issue

Fixes #5865.

A `GET /get?...&format=mp4` request can crash the **whole process** with a nil-pointer panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
internal/playback.(*muxerMP4).flush()   internal/playback/muxer_mp4.go:93
internal/playback.seekAndMux()          internal/playback/on_get.go:111
internal/playback.(*Server).onGet()     internal/playback/on_get.go:181
```

Because the handler is wrapped in `handlerExitOnPanic`, the panic terminates the process and every active stream/recording is dropped until the service is restarted.

## Root cause

In `seekAndMux`, `m.flush()` is always called after the parts of the requested time range have been processed. `segmentFMP4MuxParts` only calls `m.setTrack()` from the `tfdt` branch, i.e. once per `traf`. When the requested range covers a segment that yields **no samples at all** (for instance an empty / init-only segment that has a `moov` but no `moof`), no `traf` is processed, `setTrack` is never called, and `muxerMP4.curTrack` stays `nil`.

`muxerMP4.flush()` then dereferences `w.curTrack` unconditionally:

```go
if len(w.curTrack.Samples) == 0 || w.curTrack.lastDTS < 0 {
```

→ nil-pointer panic.

The fragmented muxer (`muxerFMP4.flush` → `innerFlush`) does not have this problem: it iterates over `w.tracks` and never touches `curTrack`.

## Fix

Guard `curTrack` in `muxerMP4.flush()`. A `nil` `curTrack` means no sample was written for the range, which is the same "no segments" condition already handled below, so it returns `recordstore.ErrNoSegmentsFound` (HTTP 404) instead of panicking — matching the behaviour of the fragmented-MP4 path.

## Test

Added `TestMuxerMP4NoSamples`: writes an init but no samples, then flushes. It reproduces the exact panic on the current code (`muxer_mp4.go:93`) and passes with the fix, asserting `ErrNoSegmentsFound`.

Verified locally: `go build ./...`, `go vet ./internal/playback/`, `gofmt`, and `go test -run TestMuxerMP4 ./internal/playback/` all pass.