### PR TITLE
fix: handle DTS discontinuity by resetting extractor on error

### DIFF
--- a/internal/protocols/mpegts/from_stream.go
+++ b/internal/protocols/mpegts/from_stream.go
@@ -79,7 +79,8 @@ func FromStream(
 
 						dts, err := dtsExtractor.Extract(u.Payload.(unit.PayloadH265), u.PTS)
 						if err != nil {
-							return err
+							dtsExtractor = nil
+							return nil
 						}
 
 						sconn.SetWriteDeadline(time.Now().Add(writeTimeout))
@@ -120,7 +121,8 @@ func FromStream(
 
 						dts, err := dtsExtractor.Extract(u.Payload.(unit.PayloadH264), u.PTS)
 						if err != nil {
-							return err
+							dtsExtractor = nil
+							return nil
 						}
 
 						sconn.SetWriteDeadline(time.Now().Add(writeTimeout))

--- a/internal/protocols/rtmp/from_stream.go
+++ b/internal/protocols/rtmp/from_stream.go
@@ -139,7 +139,8 @@ func FromStream(
 
 							dts, err := videoDTSExtractor.Extract(u.Payload.(unit.PayloadH265), u.PTS)
 							if err != nil {
-								return err
+								videoDTSExtractor = nil
+								return nil
 							}
 
 							nconn.SetWriteDeadline(time.Now().Add(writeTimeout))
@@ -203,7 +204,8 @@ func FromStream(
 
 							dts, err := videoDTSExtractor.Extract(u.Payload.(unit.PayloadH264), u.PTS)
 							if err != nil {
-								return err
+								videoDTSExtractor = nil
+								return nil
 							}
 
 							nconn.SetWriteDeadline(time.Now().Add(writeTimeout))

--- a/internal/recorder/format_fmp4.go
+++ b/internal/recorder/format_fmp4.go
@@ -395,7 +395,8 @@ func (f *formatFMP4) initialize() bool {
 
 						dts, err := dtsExtractor.Extract(u.Payload.(unit.PayloadH265), u.PTS)
 						if err != nil {
-							return err
+							dtsExtractor = nil
+							return nil
 						}
 
 						var sampl fmp4.Sample
@@ -475,7 +476,8 @@ func (f *formatFMP4) initialize() bool {
 
 						dts, err := dtsExtractor.Extract(u.Payload.(unit.PayloadH264), u.PTS)
 						if err != nil {
-							return err
+							dtsExtractor = nil
+							return nil
 						}
 
 						var sampl fmp4.Sample

--- a/internal/recorder/format_mpegts.go
+++ b/internal/recorder/format_mpegts.go
@@ -109,7 +109,8 @@ func (f *formatMPEGTS) initialize() bool {
 
 						dts, err := dtsExtractor.Extract(u.Payload.(unit.PayloadH265), u.PTS)
 						if err != nil {
-							return err
+							dtsExtractor = nil
+							return nil
 						}
 
 						return track.write(
@@ -151,7 +152,8 @@ func (f *formatMPEGTS) initialize() bool {
 
 						dts, err := dtsExtractor.Extract(u.Payload.(unit.PayloadH264), u.PTS)
 						if err != nil {
-							return err
+							dtsExtractor = nil
+							return nil
 						}
 
 						return track.write(


### PR DESCRIPTION
fix: recover from DTS extractor error instead of killing the stream

## Problem

When `DTSExtractor.Extract()` returns an error (e.g., non-monotonic DTS on camera
reconnect, stream discontinuity, or DTS > PTS), mediamtx returns the error which
terminates the entire stream.

This happens frequently with IP cameras that lose signal and reconnect, resetting
their DTS to 0. The stream is killed for a temporary condition.

## Fix

Instead of propagating the error, reset the DTS extractor to nil and drop the frame.
The extractor will be recreated on the next IDR/random access frame, and the stream
continues normally.

## Rationale

- killing the stream on a temporary DTS discontinuity is worse than dropping a single frame
- FFmpeg and GStreamer handle discontinuities the same way: reset timing baseline, continue