### PR TITLE
Fix deprecated webrtcICEServers parser for IPv6 hosts; document address format

### DIFF
--- a/docs/2-features/05-configuration.md
+++ b/docs/2-features/05-configuration.md
@@ -49,6 +49,32 @@ There are several ways to change configuration parameters:
 
 3. Use the [Control API](22-control-api.md).
 
+## Network addressing
+
+All listener address parameters (e.g. `rtspAddress`, `rtmpAddress`, `hlsAddress`, `webrtcAddress`, etc.) use the `[host]:port` format.
+
+The default form `:port` (empty host) listens on all interfaces. On Linux, where `net.ipv6.bindv6only` defaults to `0`, this creates a dual-stack socket that accepts both IPv4 and IPv6 connections. On systems where IPv6 is disabled or `bindv6only=1`, it falls back to IPv4.
+
+To listen on IPv4 only regardless of system settings, set the host to `0.0.0.0`:
+
+```yaml
+rtspAddress: 0.0.0.0:8554
+rtmpAddress: 0.0.0.0:1935
+```
+
+To explicitly request a dual-stack socket (useful when you want to be sure IPv6 is active and not fall back silently to IPv4):
+
+```yaml
+rtspAddress: "[::]:8554"
+```
+
+To bind to a specific interface:
+
+```yaml
+rtspAddress: 192.0.2.1:8554
+rtspAddress: "[2001:db8::1]:8554"
+```
+
 ## Encrypt the configuration
 
 The configuration file can be entirely encrypted for security purposes by using the `crypto_secretbox` function of the NaCL library. An online tool for performing this operation is [available here](https://play.golang.org/p/rX29jwObNe4).

--- a/docs/2-features/05-configuration.md
+++ b/docs/2-features/05-configuration.md
@@ -62,16 +62,21 @@ rtspAddress: 0.0.0.0:8554
 rtmpAddress: 0.0.0.0:1935
 ```
 
-To explicitly request a dual-stack socket (useful when you want to be sure IPv6 is active and not fall back silently to IPv4):
+To explicitly bind to IPv6 (guarantees IPv6 is active and will not silently fall back to IPv4; dual-stack still requires `bindv6only=0`):
 
 ```yaml
 rtspAddress: "[::]:8554"
 ```
 
-To bind to a specific interface:
+To bind to a specific IPv4 interface:
 
 ```yaml
 rtspAddress: 192.0.2.1:8554
+```
+
+To bind to a specific IPv6 interface:
+
+```yaml
 rtspAddress: "[2001:db8::1]:8554"
 ```
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -995,10 +995,12 @@ func (conf *Conf) Validate(l logger.Writer) error {
 			"and has been replaced with 'webrtcICEServers2'")
 
 		for _, server := range *conf.WebRTCICEServers {
-			parts := strings.Split(server, ":")
-			if len(parts) == 5 {
+			// old format: scheme:username:password:hostport
+			// SplitN 4 keeps hostport intact even if it contains colons (IPv6)
+			parts := strings.SplitN(server, ":", 4)
+			if len(parts) == 4 {
 				conf.WebRTCICEServers2 = append(conf.WebRTCICEServers2, WebRTCICEServer{
-					URL:      parts[0] + ":" + parts[3] + ":" + parts[4],
+					URL:      parts[0] + ":" + parts[3],
 					Username: parts[1],
 					Password: parts[2],
 				})

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -149,6 +149,12 @@ authJWTAudience:
 # Enable the control API server, which allows to control the server.
 api: false
 # Address of the TCP/HTTP listener.
+# Address format: [host]:port
+#   :port          all interfaces, dual-stack on Linux (bindv6only=0 default), IPv4 fallback otherwise
+#   0.0.0.0:port   all IPv4 interfaces only
+#   [::]:port      all IPv6 interfaces, dual-stack when bindv6only=0
+#   192.0.2.1:port specific IPv4 interface
+#   [::1]:port     IPv6 loopback only
 apiAddress: :9997
 # Enable HTTPS.
 apiEncryption: false


### PR DESCRIPTION
Closes #5905

## What changes

**Bug fix** (`internal/conf/conf.go`): the deprecated `webrtcICEServers` parser used `strings.Split` and checked for exactly 5 parts. An IPv6 host contains extra colons, producing the wrong part count and silently dropping credentials. Fixed with `strings.SplitN(s, ":", 4)` -- the hostport token is kept intact regardless of colons.

**Docs** (`mediamtx.yml`, `docs/2-features/05-configuration.md`): added an address format reference explaining the `[host]:port` form, what the empty-host default does on different platforms, and how to restrict to IPv4 only or bind to a specific interface. No address default values are changed.