### PR TITLE
webrtc: log and drop malformed RTCP packets instead of panicking

### DIFF
--- a/internal/protocols/webrtc/inbound_track.go
+++ b/internal/protocols/webrtc/inbound_track.go
@@ -270,7 +270,8 @@ func (t *InboundTrack) stripTWCCExtension(pkt *rtp.Packet) {
 
 	err := pkt.DelExtension(t.twccExtID)
 	if err != nil {
-		panic(err)
+		t.log.Log(logger.Warn, "error removing TWCC extension: %v", err)
+		return
 	}
 
 	if len(pkt.GetExtensionIDs()) == 0 {
@@ -334,7 +335,8 @@ func (t *InboundTrack) start() {
 
 			pkts, err2 := rtcp.Unmarshal(buf[:n])
 			if err2 != nil {
-				panic(err2)
+				t.log.Log(logger.Warn, "error parsing RTCP packet: %v", err2)
+				continue
 			}
 
 			for _, pkt := range pkts {

--- a/internal/protocols/webrtc/outbound_track.go
+++ b/internal/protocols/webrtc/outbound_track.go
@@ -69,7 +69,7 @@ func (t *OutboundTrack) setup(p *PeerConnection) error {
 
 			_, err2 = rtcp.Unmarshal(buf[:n])
 			if err2 != nil {
-				panic(err2)
+				continue
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #5926.

Three goroutines called panic(err) on tcp.Unmarshal failure with no ecover(). Any WebRTC client that completes a DTLS handshake can crash the entire server process by sending one malformed RTCP packet.

## Changes

**internal/protocols/webrtc/inbound_track.go**

- start(): RTCP read loop -- panic(err2) -> log warning + continue
- stripTWCCExtension(): panic(err) -> log warning + eturn

**internal/protocols/webrtc/outbound_track.go**

- setup(): outbound RTCP drain -- panic(err2) -> continue (result already discarded; no logger on OutboundTrack)

## Verification

`
go build ./internal/protocols/webrtc/...   # clean
go vet ./internal/protocols/webrtc/...     # clean
`

Existing test failures (TestPeerConnectionCandidates, TestPeerConnectionConnectivity) are pre-existing ICE/network issues unrelated to this change (confirmed by running the same tests against upstream HEAD).

---

*Found and fixed as part of a Claude-based security review of the mediamtx codebase.*