### PR TITLE
Add wall-clock alignment for recording segments

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -970,6 +970,8 @@ components:
           type: string
         recordSegmentDuration:
           type: string
+        recordSegmentDurationAligned:
+          type: boolean
         rpiCameraAWB:
           type: string
         rpiCameraAWBGains:

--- a/docs/2-features/09-record.md
+++ b/docs/2-features/09-record.md
@@ -40,6 +40,10 @@ pathDefaults:
   recordMaxPartSize: 50M
   # Minimum duration of each segment.
   recordSegmentDuration: 1h
+  # Whether to align segment starts to wall-clock boundaries based on recordSegmentDuration.
+  # The first segment after startup or reconnection can be shorter than recordSegmentDuration.
+  # Segments are switched near aligned boundaries, on the first available random access point.
+  recordSegmentDurationAligned: false
   # Delete segments after this timespan.
   # Set to 0s to disable automatic deletion.
   recordDeleteAfter: 1d

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -523,6 +523,22 @@ func TestConfErrors(t *testing.T) {
 			`'recordDeleteAfter' cannot be lower than 'recordSegmentDuration'`,
 		},
 		{
+			"invalid record segment duration aligned with zero duration",
+			"paths:\n" +
+				"  my_path:\n" +
+				"    recordSegmentDuration: 0s\n" +
+				"    recordSegmentDurationAligned: true\n",
+			`'recordSegmentDuration' must be greater than zero when 'recordSegmentDurationAligned' is true`,
+		},
+		{
+			"invalid record segment duration aligned with non-divisor duration",
+			"paths:\n" +
+				"  my_path:\n" +
+				"    recordSegmentDuration: 7m\n" +
+				"    recordSegmentDurationAligned: true\n",
+			`'recordSegmentDuration' must divide 1 day when 'recordSegmentDurationAligned' is true`,
+		},
+		{
 			"missing rtpAddress with UDP and no encryption",
 			"rtspEncryption: \"no\"\n" +
 				"rtspTransports: [udp]\n" +

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -227,14 +227,15 @@ type Path struct {
 	AlwaysAvailableFile   string                 `json:"alwaysAvailableFile"`
 
 	// Record
-	Record                bool         `json:"record"`
-	Playback              *bool        `json:"playback,omitempty" deprecated:"true"`
-	RecordPath            string       `json:"recordPath"`
-	RecordFormat          RecordFormat `json:"recordFormat"`
-	RecordPartDuration    Duration     `json:"recordPartDuration"`
-	RecordMaxPartSize     StringSize   `json:"recordMaxPartSize"`
-	RecordSegmentDuration Duration     `json:"recordSegmentDuration"`
-	RecordDeleteAfter     Duration     `json:"recordDeleteAfter"`
+	Record                       bool         `json:"record"`
+	Playback                     *bool        `json:"playback,omitempty" deprecated:"true"`
+	RecordPath                   string       `json:"recordPath"`
+	RecordFormat                 RecordFormat `json:"recordFormat"`
+	RecordPartDuration           Duration     `json:"recordPartDuration"`
+	RecordMaxPartSize            StringSize   `json:"recordMaxPartSize"`
+	RecordSegmentDuration        Duration     `json:"recordSegmentDuration"`
+	RecordSegmentDurationAligned bool         `json:"recordSegmentDurationAligned"`
+	RecordDeleteAfter            Duration     `json:"recordDeleteAfter"`
 
 	// Authentication (deprecated)
 	PublishUser *Credential `json:"publishUser,omitempty" deprecated:"true"`
@@ -846,6 +847,16 @@ func (pconf *Path) validate(
 
 	if pconf.RecordSegmentDuration > Duration(24*time.Hour) { // avoid overflowing DurationV0 of mvhd
 		return fmt.Errorf("maximum segment duration is 1 day")
+	}
+
+	if pconf.RecordSegmentDurationAligned {
+		if pconf.RecordSegmentDuration <= 0 {
+			return fmt.Errorf("'recordSegmentDuration' must be greater than zero when 'recordSegmentDurationAligned' is true")
+		}
+
+		if (24*time.Hour)%time.Duration(pconf.RecordSegmentDuration) != 0 {
+			return fmt.Errorf("'recordSegmentDuration' must divide 1 day when 'recordSegmentDurationAligned' is true")
+		}
 	}
 
 	if pconf.RecordDeleteAfter != 0 && pconf.RecordDeleteAfter < pconf.RecordSegmentDuration {

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -404,6 +404,7 @@ func (pa *path) doReloadConf(newConf *conf.Path) {
 			newConf.RecordPartDuration != oldConf.RecordPartDuration ||
 			newConf.RecordMaxPartSize != oldConf.RecordMaxPartSize ||
 			newConf.RecordSegmentDuration != oldConf.RecordSegmentDuration ||
+			newConf.RecordSegmentDurationAligned != oldConf.RecordSegmentDurationAligned ||
 			newConf.RecordDeleteAfter != oldConf.RecordDeleteAfter) {
 		pa.recorder.Close()
 		pa.recorder = nil
@@ -915,13 +916,14 @@ func (pa *path) setNotAvailable() {
 
 func (pa *path) startRecording() {
 	pa.recorder = &recorder.Recorder{
-		PathFormat:      pa.conf.RecordPath,
-		Format:          pa.conf.RecordFormat,
-		PartDuration:    time.Duration(pa.conf.RecordPartDuration),
-		MaxPartSize:     pa.conf.RecordMaxPartSize,
-		SegmentDuration: time.Duration(pa.conf.RecordSegmentDuration),
-		PathName:        pa.name,
-		Stream:          pa.stream,
+		PathFormat:             pa.conf.RecordPath,
+		Format:                 pa.conf.RecordFormat,
+		PartDuration:           time.Duration(pa.conf.RecordPartDuration),
+		MaxPartSize:            pa.conf.RecordMaxPartSize,
+		SegmentDuration:        time.Duration(pa.conf.RecordSegmentDuration),
+		SegmentDurationAligned: pa.conf.RecordSegmentDurationAligned,
+		PathName:               pa.name,
+		Stream:                 pa.stream,
 		OnSegmentCreate: func(segmentPath string) {
 			if pa.conf.RunOnRecordSegmentCreate != "" {
 				env := pa.ExternalCmdEnv()

--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -28,6 +28,7 @@ func pathConfCanBeUpdated(oldPathConf *conf.Path, newPathConf *conf.Path) bool {
 	clone.RecordPartDuration = newPathConf.RecordPartDuration
 	clone.RecordMaxPartSize = newPathConf.RecordMaxPartSize
 	clone.RecordSegmentDuration = newPathConf.RecordSegmentDuration
+	clone.RecordSegmentDurationAligned = newPathConf.RecordSegmentDurationAligned
 	clone.RecordDeleteAfter = newPathConf.RecordDeleteAfter
 
 	clone.RPICameraBrightness = newPathConf.RPICameraBrightness

--- a/internal/recorder/format_fmp4_track.go
+++ b/internal/recorder/format_fmp4_track.go
@@ -119,7 +119,13 @@ func (t *formatFMP4Track) write(sample *formatFMP4Sample) error {
 
 	if (!t.f.hasVideo || t.initTrack.Codec.IsVideo()) &&
 		!t.nextSample.IsNonSyncSample &&
-		(nextDTS-t.f.currentSegment.startDTS) >= t.f.ri.segmentDuration {
+		segmentDurationReached(
+			t.f.currentSegment.startNTP,
+			nextDTS-t.f.currentSegment.startDTS,
+			t.f.ri.segmentDuration,
+			t.f.ri.segmentDurationAligned,
+			t.nextSample.ntp,
+		) {
 		err = t.f.currentSegment.close()
 		if err != nil {
 			return err

--- a/internal/recorder/format_mpegts_track.go
+++ b/internal/recorder/format_mpegts_track.go
@@ -63,7 +63,13 @@ func (t *formatMPEGTSTrack) write(
 
 	case (!t.f.hasVideo || isVideo) &&
 		randomAccess &&
-		(dts-t.f.currentSegment.startDTS) >= t.f.ri.segmentDuration:
+		segmentDurationReached(
+			t.f.currentSegment.startNTP,
+			dts-t.f.currentSegment.startDTS,
+			t.f.ri.segmentDuration,
+			t.f.ri.segmentDurationAligned,
+			ntp,
+		):
 		t.f.currentSegment.lastDTS = dts
 		err := t.f.currentSegment.close()
 		if err != nil {

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -21,16 +21,17 @@ type OnSegmentCompleteFunc = func(path string, duration time.Duration)
 
 // Recorder writes recordings to disk.
 type Recorder struct {
-	PathFormat        string
-	Format            conf.RecordFormat
-	PartDuration      time.Duration
-	MaxPartSize       conf.StringSize
-	SegmentDuration   time.Duration
-	PathName          string
-	Stream            *stream.Stream
-	OnSegmentCreate   OnSegmentCreateFunc
-	OnSegmentComplete OnSegmentCompleteFunc
-	Parent            logger.Writer
+	PathFormat             string
+	Format                 conf.RecordFormat
+	PartDuration           time.Duration
+	MaxPartSize            conf.StringSize
+	SegmentDuration        time.Duration
+	SegmentDurationAligned bool
+	PathName               string
+	Stream                 *stream.Stream
+	OnSegmentCreate        OnSegmentCreateFunc
+	OnSegmentComplete      OnSegmentCompleteFunc
+	Parent                 logger.Writer
 
 	restartPause time.Duration
 
@@ -58,16 +59,17 @@ func (r *Recorder) Initialize() {
 	r.done = make(chan struct{})
 
 	r.currentInstance = &recorderInstance{
-		pathFormat:        r.PathFormat,
-		format:            r.Format,
-		partDuration:      r.PartDuration,
-		maxPartSize:       r.MaxPartSize,
-		segmentDuration:   r.SegmentDuration,
-		pathName:          r.PathName,
-		stream:            r.Stream,
-		onSegmentCreate:   r.OnSegmentCreate,
-		onSegmentComplete: r.OnSegmentComplete,
-		parent:            r,
+		pathFormat:             r.PathFormat,
+		format:                 r.Format,
+		partDuration:           r.PartDuration,
+		maxPartSize:            r.MaxPartSize,
+		segmentDuration:        r.SegmentDuration,
+		segmentDurationAligned: r.SegmentDurationAligned,
+		pathName:               r.PathName,
+		stream:                 r.Stream,
+		onSegmentCreate:        r.OnSegmentCreate,
+		onSegmentComplete:      r.OnSegmentComplete,
+		parent:                 r,
 	}
 	r.currentInstance.initialize()
 
@@ -105,16 +107,17 @@ func (r *Recorder) run() {
 		}
 
 		r.currentInstance = &recorderInstance{
-			pathFormat:        r.PathFormat,
-			format:            r.Format,
-			partDuration:      r.PartDuration,
-			maxPartSize:       r.MaxPartSize,
-			segmentDuration:   r.SegmentDuration,
-			pathName:          r.PathName,
-			stream:            r.Stream,
-			onSegmentCreate:   r.OnSegmentCreate,
-			onSegmentComplete: r.OnSegmentComplete,
-			parent:            r,
+			pathFormat:             r.PathFormat,
+			format:                 r.Format,
+			partDuration:           r.PartDuration,
+			maxPartSize:            r.MaxPartSize,
+			segmentDuration:        r.SegmentDuration,
+			segmentDurationAligned: r.SegmentDurationAligned,
+			pathName:               r.PathName,
+			stream:                 r.Stream,
+			onSegmentCreate:        r.OnSegmentCreate,
+			onSegmentComplete:      r.OnSegmentComplete,
+			parent:                 r,
 		}
 		r.currentInstance.initialize()
 	}

--- a/internal/recorder/recorder_instance.go
+++ b/internal/recorder/recorder_instance.go
@@ -13,16 +13,17 @@ import (
 )
 
 type recorderInstance struct {
-	pathFormat        string
-	format            conf.RecordFormat
-	partDuration      time.Duration
-	maxPartSize       conf.StringSize
-	segmentDuration   time.Duration
-	pathName          string
-	stream            *stream.Stream
-	onSegmentCreate   OnSegmentCreateFunc
-	onSegmentComplete OnSegmentCompleteFunc
-	parent            logger.Writer
+	pathFormat             string
+	format                 conf.RecordFormat
+	partDuration           time.Duration
+	maxPartSize            conf.StringSize
+	segmentDuration        time.Duration
+	segmentDurationAligned bool
+	pathName               string
+	stream                 *stream.Stream
+	onSegmentCreate        OnSegmentCreateFunc
+	onSegmentComplete      OnSegmentCompleteFunc
+	parent                 logger.Writer
 
 	streamID    uuid.UUID
 	pathFormat2 string
@@ -32,6 +33,20 @@ type recorderInstance struct {
 
 	terminate chan struct{}
 	done      chan struct{}
+}
+
+func segmentDurationReached(
+	startNTP time.Time,
+	elapsed time.Duration,
+	duration time.Duration,
+	aligned bool,
+	nextNTP time.Time,
+) bool {
+	if !aligned {
+		return elapsed >= duration
+	}
+
+	return !nextNTP.Before(startNTP.Truncate(duration).Add(duration))
 }
 
 // Log implements logger.Writer.

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -847,6 +847,87 @@ func TestRecorderFMP4SegmentSwitch(t *testing.T) {
 	require.Equal(t, 2, n)
 }
 
+func TestRecorderSegmentDurationAligned(t *testing.T) {
+	for _, ca := range []string{"fmp4", "mpegts"} {
+		t.Run(ca, func(t *testing.T) {
+			desc := &description.Session{Medias: []*description.Media{
+				{
+					Type:    description.MediaTypeVideo,
+					Formats: []rtspformat.Format{test.FormatH264},
+				},
+			}}
+
+			strm := &stream.Stream{
+				OrigDesc:          desc,
+				WriteQueueSize:    512,
+				RTPMaxPayloadSize: 1450,
+				Parent:            test.NilLogger,
+			}
+			err := strm.Initialize()
+			require.NoError(t, err)
+			defer strm.Close()
+
+			subStream := &stream.SubStream{
+				Stream:        strm,
+				UseRTPPackets: false,
+			}
+			err = subStream.Initialize()
+			require.NoError(t, err)
+
+			dir := t.TempDir()
+
+			var f conf.RecordFormat
+			ext := "mp4"
+			if ca == "mpegts" {
+				f = conf.RecordFormatMPEGTS
+				ext = "ts"
+			} else {
+				f = conf.RecordFormatFMP4
+			}
+
+			created := make(chan string, 4)
+
+			w := &Recorder{
+				PathFormat:             filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
+				Format:                 f,
+				PartDuration:           100 * time.Millisecond,
+				MaxPartSize:            50 * 1024 * 1024,
+				SegmentDuration:        1 * time.Minute,
+				SegmentDurationAligned: true,
+				PathName:               "mypath",
+				Stream:                 strm,
+				OnSegmentCreate: func(segPath string) {
+					created <- segPath
+				},
+				Parent: test.NilLogger,
+			}
+			w.Initialize()
+
+			for _, ntp := range []time.Time{
+				time.Date(2008, 5, 20, 22, 15, 25, 0, time.UTC),
+				time.Date(2008, 5, 20, 22, 15, 30, 0, time.UTC),
+				time.Date(2008, 5, 20, 22, 16, 0, 0, time.UTC),
+				time.Date(2008, 5, 20, 22, 16, 5, 0, time.UTC),
+			} {
+				pts := ntp.Sub(time.Date(2008, 5, 20, 22, 15, 0, 0, time.UTC))
+				subStream.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], &unit.Unit{
+					PTS: int64(pts) * 90000 / int64(time.Second),
+					NTP: ntp,
+					Payload: unit.PayloadH264{
+						{5}, // IDR
+					},
+				})
+			}
+
+			time.Sleep(100 * time.Millisecond)
+			w.Close()
+
+			require.Equal(t, filepath.Join(dir, "mypath", "2008-05-20_22-15-25-000000."+ext), <-created)
+			require.Equal(t, filepath.Join(dir, "mypath", "2008-05-20_22-16-00-000000."+ext), <-created)
+		})
+	}
+}
+
 func TestRecorderTimeDriftDetector(t *testing.T) {
 	for _, ca := range []string{"fmp4", "mpegts"} {
 		t.Run(ca, func(t *testing.T) {

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -557,6 +557,10 @@ pathDefaults:
   recordMaxPartSize: 50M
   # Minimum duration of each segment.
   recordSegmentDuration: 1h
+  # Whether to align segment starts to wall-clock boundaries based on recordSegmentDuration.
+  # The first segment after startup or reconnection can be shorter than recordSegmentDuration.
+  # Segments are switched near aligned boundaries, on the first available random access point.
+  recordSegmentDurationAligned: false
   # Delete segments after this timespan.
   # Set to 0s to disable automatic deletion.
   recordDeleteAfter: 1d


### PR DESCRIPTION
Recording segments are currently split relative to the moment recording starts. For example, with `recordSegmentDuration: 1h`, if a stream starts or reconnects at 12:13, segments are created
  around 12:13-13:13, 13:13-14:13, and so on.

  For archival recording, it is often more useful to split files on wall-clock boundaries, such as 12:00-13:00, 13:00-14:00, or 12:00-12:05, 12:05-12:10. This makes recorded files easier to
  browse, correlate with external systems, export, and manage with retention or post-processing jobs.

  This PR adds an optional `recordSegmentDurationAligned` setting. When enabled, segment rotation is aligned to wall-clock boundaries based on `recordSegmentDuration`. The default remains
  unchanged, so existing configurations keep the current behavior.

  The first segment after startup or reconnection can be shorter than `recordSegmentDuration`, and actual segment switches still happen on the first suitable random access point near the aligned
  boundary.