### PR TITLE
fix(rtsp): tolerate oversized SDP origin identifiers

### DIFF
--- a/internal/staticsources/rtsp/sdp.go
+++ b/internal/staticsources/rtsp/sdp.go
@@ -1,0 +1,57 @@
+package rtsp
+
+import (
+	"math/big"
+	"strconv"
+	"strings"
+)
+
+func normalizeSDPOriginNumericValues(buf []byte) ([]byte, bool) {
+	lines := strings.SplitAfter(string(buf), "\n")
+	changed := false
+
+	for i, line := range lines {
+		lineBody := strings.TrimSuffix(line, "\n")
+		lineEnding := line[len(lineBody):]
+
+		if strings.HasSuffix(lineBody, "\r") {
+			lineBody = strings.TrimSuffix(lineBody, "\r")
+			lineEnding = "\r" + lineEnding
+		}
+
+		if !strings.HasPrefix(lineBody, "o=") {
+			continue
+		}
+
+		fields := strings.Fields(lineBody[2:])
+		if len(fields) != 6 {
+			continue
+		}
+
+		lineChanged := false
+		for _, fieldIndex := range []int{1, 2} {
+			if _, err := strconv.ParseUint(fields[fieldIndex], 10, 64); err == nil {
+				continue
+			}
+
+			value, ok := new(big.Int).SetString(fields[fieldIndex], 10)
+			if !ok || value.Sign() < 0 {
+				continue
+			}
+
+			fields[fieldIndex] = strconv.FormatUint(value.Uint64(), 10)
+			lineChanged = true
+		}
+
+		if lineChanged {
+			lines[i] = "o=" + strings.Join(fields, " ") + lineEnding
+			changed = true
+		}
+	}
+
+	if !changed {
+		return buf, false
+	}
+
+	return []byte(strings.Join(lines, "")), true
+}

--- a/internal/staticsources/rtsp/sdp_test.go
+++ b/internal/staticsources/rtsp/sdp_test.go
@@ -1,0 +1,46 @@
+package rtsp
+
+import (
+	"testing"
+
+	"github.com/bluenviron/gortsplib/v5/pkg/sdp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeSDPOriginNumericValues(t *testing.T) {
+	t.Run("oversized", func(t *testing.T) {
+		input := []byte("v=0\r\n" +
+			"o=- 19599440071187478912 19599440071187478913 IN IP4 192.0.2.1\r\n" +
+			"s=Stream\r\n" +
+			"t=0 0\r\n")
+
+		output, changed := normalizeSDPOriginNumericValues(input)
+		require.True(t, changed)
+		require.Contains(t, string(output),
+			"o=- 1152695997477927296 1152695997477927297 IN IP4 192.0.2.1\r\n")
+
+		var desc sdp.SessionDescription
+		require.NoError(t, desc.Unmarshal(output))
+		require.Equal(t, uint64(1152695997477927296), desc.Origin.SessionID)
+		require.Equal(t, uint64(1152695997477927297), desc.Origin.SessionVersion)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		input := []byte("v=0\n" +
+			"o=- 123 456 IN IP4 192.0.2.1\n" +
+			"s=Stream\n" +
+			"t=0 0\n")
+
+		output, changed := normalizeSDPOriginNumericValues(input)
+		require.False(t, changed)
+		require.Equal(t, input, output)
+	})
+
+	t.Run("invalid origin", func(t *testing.T) {
+		input := []byte("o=- invalid 456 IN IP4 192.0.2.1\n")
+
+		output, changed := normalizeSDPOriginNumericValues(input)
+		require.False(t, changed)
+		require.Equal(t, input, output)
+	})
+}

--- a/internal/staticsources/rtsp/source.go
+++ b/internal/staticsources/rtsp/source.go
@@ -149,6 +149,11 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 		},
 		OnResponse: func(res *base.Response) {
 			s.Log(logger.Debug, "[s->c] %v", res)
+
+			if body, changed := normalizeSDPOriginNumericValues(res.Body); changed {
+				res.Body = body
+				s.Log(logger.Warn, "normalized oversized SDP origin session ID/version")
+			}
 		},
 		OnTransportSwitch: func(err error) {
 			s.Log(logger.Warn, err.Error())


### PR DESCRIPTION
### Summary

This PR makes RTSP static sources tolerate SDP origin (`o=`) session IDs and
session versions that are valid decimal strings but exceed the range of a Go
`uint64`.

### Problem

An RTSP source returned the following numeric value in its SDP origin line:

```text
19599440071187478912
```

MediaMTX rejected the DESCRIBE response with:

```text
ERR [path channel02_sub] [RTSP source] invalid SDP: sdp: invalid numeric value `19599440071187478912`
```

The value is greater than `math.MaxUint64` (`18446744073709551615`). The SDP
parser in `gortsplib` stores the origin session ID and version as `uint64`, so
`strconv.ParseUint(..., 10, 64)` returns an out-of-range error before MediaMTX
can set up the media tracks.

These origin values identify and version the SDP session; they do not describe
codec parameters or RTP packet contents. In the RTSP source path, MediaMTX does
not use them after the SDP has been converted into a media description.

### Solution

Before `gortsplib` parses an RTSP response body, MediaMTX now checks the SDP
origin line and normalizes only oversized decimal session ID/version fields to
their low 64 bits (`value mod 2^64`). For example:

```text
19599440071187478912 -> 1152695997477927296
```

The compatibility handling is deliberately narrow:

- only `o=` lines with the expected six fields are inspected;
- only the session ID and session version fields are considered;
- values already accepted by `uint64` are left unchanged;
- malformed and negative values are left to the existing parser;
- the original response body is returned without allocation when no change is
  required.

When normalization occurs, MediaMTX emits this warning:

```text
normalized oversized SDP origin session ID/version
```

### Tests

Added unit coverage for:

- the reported oversized value with CRLF line endings;
- successful parsing of the normalized SDP by `gortsplib`;
- unchanged valid origin values;
- unchanged malformed origin values.

Verification results:

```text
PASS: go test ./internal/staticsources/rtsp
PASS: GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -o mediamtx.exe .
```

### Compatibility

There is no behavior change for SDP values that already fit in `uint64`. The
change only affects RTSP sources that previously failed during DESCRIBE because
of oversized origin identifiers.