### PR TITLE
rtsp: restrict UDP port range to 32768-60999 (#5398)

### DIFF
--- a/docs/3-publish/08-rtsp-cameras-and-servers.md
+++ b/docs/3-publish/08-rtsp-cameras-and-servers.md
@@ -45,7 +45,7 @@ paths:
     # It defaults to the default value of the operating system.
     rtspUDPReadBufferSize: 0
     # Range of ports used as source port in outgoing UDP packets.
-    rtspUDPSourcePortRange: [10000, 65535]
+    rtspUDPSourcePortRange: [32768, 60999]
 ```
 
 All available parameters are listed in the [configuration file](../5-references/1-configuration-file.md).

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -54,7 +54,7 @@ func TestConfFromFile(t *testing.T) {
 			RecordMaxPartSize:          50 * 1024 * 1024,
 			RecordSegmentDuration:      3600000000000,
 			RecordDeleteAfter:          86400000000000,
-			RTSPUDPSourcePortRange:     []uint{10000, 65535},
+			RTSPUDPSourcePortRange:     []uint{32768, 60999},
 			WHEPSTUNGatherTimeout:      5 * Duration(time.Second),
 			WHEPHandshakeTimeout:       10 * Duration(time.Second),
 			WHEPTrackGatherTimeout:     2 * Duration(time.Second),

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -375,7 +375,7 @@ func (pconf *Path) setDefaults() {
 	pconf.OverridePublisher = true
 
 	// RTSP source
-	pconf.RTSPUDPSourcePortRange = []uint{10000, 65535}
+	pconf.RTSPUDPSourcePortRange = []uint{32768, 60999}
 
 	// WHEP source
 	pconf.WHEPSTUNGatherTimeout = Duration(5 * time.Second)

--- a/internal/staticsources/rtsp/source_test.go
+++ b/internal/staticsources/rtsp/source_test.go
@@ -148,7 +148,7 @@ func TestSource(t *testing.T) {
 
 			var ur string
 			cnf := &conf.Path{
-				RTSPUDPSourcePortRange: []uint{10000, 65535},
+				RTSPUDPSourcePortRange: []uint{32768, 60999},
 			}
 
 			switch ca {
@@ -296,7 +296,7 @@ func TestNoPassword(t *testing.T) {
 			ResolvedSource: "rtsp://testuser:@127.0.0.1:8555/teststream",
 			Conf: &conf.Path{
 				RTSPTransport:          sp,
-				RTSPUDPSourcePortRange: []uint{10000, 65535},
+				RTSPUDPSourcePortRange: []uint{32768, 60999},
 			},
 		})
 		close(done)
@@ -362,7 +362,7 @@ func TestScale(t *testing.T) {
 	defer strm.Close()
 
 	cnf := &conf.Path{
-		RTSPUDPSourcePortRange: []uint{10000, 65535},
+		RTSPUDPSourcePortRange: []uint{32768, 60999},
 		RTSPScale:              "-1.0",
 	}
 
@@ -463,7 +463,7 @@ func TestRange(t *testing.T) {
 			defer strm.Close()
 
 			cnf := &conf.Path{
-				RTSPUDPSourcePortRange: []uint{10000, 65535},
+				RTSPUDPSourcePortRange: []uint{32768, 60999},
 			}
 
 			switch ca {
@@ -599,7 +599,7 @@ func TestSkipBackChannel(t *testing.T) {
 			ResolvedSource: "rtsp://127.0.0.1:8555/teststream",
 			Conf: &conf.Path{
 				RTSPTransport:          conf.RTSPTransport{Protocol: new(gortsplib.ProtocolTCP)},
-				RTSPUDPSourcePortRange: []uint{10000, 65535},
+				RTSPUDPSourcePortRange: []uint{32768, 60999},
 			},
 		})
 		close(done)
@@ -675,7 +675,7 @@ func TestOnlyBackChannelsError(t *testing.T) {
 		ResolvedSource: "rtsp://127.0.0.1:8555/teststream",
 		Conf: &conf.Path{
 			RTSPTransport:          conf.RTSPTransport{Protocol: new(gortsplib.ProtocolTCP)},
-			RTSPUDPSourcePortRange: []uint{10000, 65535},
+			RTSPUDPSourcePortRange: []uint{32768, 60999},
 		},
 	})
 

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -598,7 +598,7 @@ pathDefaults:
   # values 0 < x < 1 play slow motion.
   rtspScale:
   # Range of ports used as source port in outgoing UDP packets.
-  rtspUDPSourcePortRange: [10000, 65535]
+  rtspUDPSourcePortRange: [32768, 60999]
 
   ###############################################
   # Default path settings -> RTP source (when source is RTP)


### PR DESCRIPTION
Fixes #5398 

this is the default Linux ephemeral port range.