### PR TITLE
normalize authentication error messages (#5421)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -257,15 +257,16 @@ func (a *API) middlewareAuth(ctx *gin.Context) {
 
 	_, err := a.AuthManager.Authenticate(req)
 	if err != nil {
-		auth.DelayBruteForce(err)
+		auth.LogAndDelayError(&logger.InlineWriter{
+			Parent: a,
+			Prefix: fmt.Sprintf("[conn %v]", httpp.RemoteAddr(ctx)),
+		}, err)
 
 		if err.AskCredentials {
 			ctx.Header("WWW-Authenticate", `Basic realm="mediamtx"`)
 			a.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 			return
 		}
-
-		a.Log(logger.Info, "connection %v failed to authenticate: %v", httpp.RemoteAddr(ctx), err.Wrapped)
 
 		a.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 		return

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -186,7 +186,6 @@ func TestAuthJWKSRefresh(t *testing.T) {
 
 func TestAuthError(t *testing.T) {
 	cnf := tempConf(t, "api: yes\n")
-	n := 0
 
 	api := API{
 		Address:      "localhost:9997",
@@ -201,16 +200,7 @@ func TestAuthError(t *testing.T) {
 				return "", &auth.Error{Wrapped: fmt.Errorf("auth error")}
 			},
 		},
-		Parent: &testParent{
-			log: func(l logger.Level, s string, i ...any) {
-				if l == logger.Info {
-					if n == 1 {
-						require.Regexp(t, "failed to authenticate: auth error$", fmt.Sprintf(s, i...))
-					}
-					n++
-				}
-			},
-		},
+		Parent: &testParent{},
 	}
 	err := api.Initialize()
 	require.NoError(t, err)
@@ -235,6 +225,4 @@ func TestAuthError(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 	require.Equal(t, ``, res.Header.Get("WWW-Authenticate"))
 	checkError(t, res.Body, "authentication error")
-
-	require.Equal(t, 2, n)
 }

--- a/internal/auth/error.go
+++ b/internal/auth/error.go
@@ -8,5 +8,5 @@ type Error struct {
 
 // Error implements the error interface.
 func (e *Error) Error() string {
-	return "authentication failed: " + e.Wrapped.Error()
+	return "failed to authenticate: " + e.Wrapped.Error()
 }

--- a/internal/auth/log_and_delay_error.go
+++ b/internal/auth/log_and_delay_error.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"math/big"
 	"time"
+
+	"github.com/bluenviron/mediamtx/internal/logger"
 )
 
 const (
@@ -12,10 +14,12 @@ const (
 	maxPause = 4 * time.Second
 )
 
-// DelayBruteForce delays brute force attacks by waiting some seconds after an authentication error.
-func DelayBruteForce(err error) {
+// LogAndDelayError logs authentication errors and delays brute force attacks by waiting some seconds.
+func LogAndDelayError(author logger.Writer, err error) {
 	if terr, ok := errors.AsType[*Error](err); ok {
 		if !terr.AskCredentials {
+			author.Log(logger.Warn, err.Error())
+
 			var n *big.Int
 			n, err = rand.Int(rand.Reader, big.NewInt(int64(maxPause-minPause)))
 			if err != nil {

--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -529,9 +529,8 @@ func (pm *pathManager) FindPathConf(req defs.PathFindPathConfReq) (*defs.PathFin
 	select {
 	case pm.chFindPathConf <- req:
 		res := <-req.Res
-
 		if res.Err != nil {
-			auth.DelayBruteForce(res.Err)
+			auth.LogAndDelayError(req.Author, res.Err)
 			return nil, res.Err
 		}
 
@@ -549,7 +548,7 @@ func (pm *pathManager) Describe(req defs.PathDescribeReq) (*defs.PathDescribeRes
 	case pm.chDescribe <- req:
 		res1 := <-req.Res
 		if res1.Err != nil {
-			auth.DelayBruteForce(res1.Err)
+			auth.LogAndDelayError(req.Author, res1.Err)
 			return nil, res1.Err
 		}
 
@@ -573,7 +572,7 @@ func (pm *pathManager) AddPublisher(req defs.PathAddPublisherReq) (*defs.PathAdd
 	case pm.chAddPublisher <- req:
 		res1 := <-req.Res
 		if res1.Err != nil {
-			auth.DelayBruteForce(res1.Err)
+			auth.LogAndDelayError(req.Author, res1.Err)
 			return nil, res1.Err
 		}
 
@@ -599,7 +598,7 @@ func (pm *pathManager) AddReader(req defs.PathAddReaderReq) (*defs.PathAddReader
 	case pm.chAddReader <- req:
 		res1 := <-req.Res
 		if res1.Err != nil {
-			auth.DelayBruteForce(res1.Err)
+			auth.LogAndDelayError(req.Author, res1.Err)
 			return nil, res1.Err
 		}
 

--- a/internal/defs/path.go
+++ b/internal/defs/path.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/externalcmd"
+	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/stream"
 )
 
@@ -38,6 +39,7 @@ type PathFindPathConfRes struct {
 
 // PathFindPathConfReq contains arguments of FindPathConf().
 type PathFindPathConfReq struct {
+	Author        logger.Writer
 	AccessRequest PathAccessRequest
 	Res           chan PathFindPathConfRes
 }
@@ -52,6 +54,7 @@ type PathDescribeRes struct {
 
 // PathDescribeReq contains arguments of Describe().
 type PathDescribeReq struct {
+	Author        logger.Writer
 	AccessRequest PathAccessRequest
 	Res           chan PathDescribeRes
 }

--- a/internal/defs/reader.go
+++ b/internal/defs/reader.go
@@ -1,7 +1,10 @@
 package defs
 
+import "github.com/bluenviron/mediamtx/internal/logger"
+
 // Reader is an entity that can read a stream.
 type Reader interface {
+	logger.Writer
 	Close()
 	APIReaderDescribe() *APIPathReader
 }

--- a/internal/logger/writer.go
+++ b/internal/logger/writer.go
@@ -4,3 +4,14 @@ package logger
 type Writer interface {
 	Log(Level, string, ...any)
 }
+
+// InlineWriter is a Writer that can be created inline.
+type InlineWriter struct {
+	Parent Writer
+	Prefix string
+}
+
+// Log implements Writer.
+func (w *InlineWriter) Log(level Level, msg string, args ...any) {
+	w.Parent.Log(level, w.Prefix+" "+msg, args...)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -198,15 +198,16 @@ func (m *Metrics) middlewareAuth(ctx *gin.Context) {
 
 	_, err := m.AuthManager.Authenticate(req)
 	if err != nil {
-		auth.DelayBruteForce(err)
+		auth.LogAndDelayError(&logger.InlineWriter{
+			Parent: m,
+			Prefix: fmt.Sprintf("[conn %v]", httpp.RemoteAddr(ctx)),
+		}, err)
 
 		if err.AskCredentials {
 			ctx.Header("WWW-Authenticate", `Basic realm="mediamtx"`)
 			m.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 			return
 		}
-
-		m.Log(logger.Info, "connection %v failed to authenticate: %v", httpp.RemoteAddr(ctx), err.Wrapped)
 
 		m.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 		return

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/defs"
 	"github.com/bluenviron/mediamtx/internal/formatlabel"
-	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/test"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -1663,8 +1662,6 @@ func TestFilterByType(t *testing.T) {
 }
 
 func TestAuthError(t *testing.T) {
-	n := 0
-
 	m := Metrics{
 		Address:      "localhost:9998",
 		AllowOrigins: []string{"*"},
@@ -1678,14 +1675,7 @@ func TestAuthError(t *testing.T) {
 				return "", &auth.Error{Wrapped: fmt.Errorf("auth error")}
 			},
 		},
-		Parent: test.Logger(func(l logger.Level, s string, i ...any) {
-			if l == logger.Info {
-				if n == 1 {
-					require.Regexp(t, "failed to authenticate: auth error$", fmt.Sprintf(s, i...))
-				}
-				n++
-			}
-		}),
+		Parent: test.NilLogger,
 	}
 	err := m.Initialize()
 	require.NoError(t, err)
@@ -1707,8 +1697,6 @@ func TestAuthError(t *testing.T) {
 	defer res.Body.Close()
 
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-
-	require.Equal(t, 2, n)
 }
 
 func TestMetricsConcurrentSettersAndReads(t *testing.T) {

--- a/internal/playback/server.go
+++ b/internal/playback/server.go
@@ -142,16 +142,16 @@ func (s *Server) doAuth(ctx *gin.Context, pathName string) bool {
 
 	_, err := s.AuthManager.Authenticate(req)
 	if err != nil {
-		auth.DelayBruteForce(err)
+		auth.LogAndDelayError(&logger.InlineWriter{
+			Parent: s,
+			Prefix: fmt.Sprintf("[conn %v]", httpp.RemoteAddr(ctx)),
+		}, err)
 
 		if err.AskCredentials {
 			ctx.Header("WWW-Authenticate", `Basic realm="mediamtx"`)
 			s.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 			return false
 		}
-
-		s.Log(logger.Info, "connection %v failed to authenticate: %v",
-			httpp.RemoteAddr(ctx), err.Wrapped)
 
 		s.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 		return false

--- a/internal/playback/server_test.go
+++ b/internal/playback/server_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/bluenviron/mediamtx/internal/auth"
 	"github.com/bluenviron/mediamtx/internal/conf"
-	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -53,8 +52,6 @@ func TestPreflightRequest(t *testing.T) {
 }
 
 func TestAuthError(t *testing.T) {
-	n := 0
-
 	s := &Server{
 		Address:      "127.0.0.1:9996",
 		ReadTimeout:  conf.Duration(10 * time.Second),
@@ -67,14 +64,7 @@ func TestAuthError(t *testing.T) {
 				return "", &auth.Error{Wrapped: fmt.Errorf("auth error")}
 			},
 		},
-		Parent: test.Logger(func(l logger.Level, s string, i ...any) {
-			if l == logger.Info {
-				if n == 1 {
-					require.Regexp(t, "failed to authenticate: auth error$", fmt.Sprintf(s, i...))
-				}
-				n++
-			}
-		}),
+		Parent: test.NilLogger,
 	}
 	err := s.Initialize()
 	require.NoError(t, err)
@@ -112,6 +102,4 @@ func TestAuthError(t *testing.T) {
 	defer res.Body.Close()
 
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-
-	require.Equal(t, 2, n)
 }

--- a/internal/pprof/pprof.go
+++ b/internal/pprof/pprof.go
@@ -118,15 +118,16 @@ func (pp *PPROF) middlewareAuth(ctx *gin.Context) {
 
 	_, err := pp.AuthManager.Authenticate(req)
 	if err != nil {
-		auth.DelayBruteForce(err)
+		auth.LogAndDelayError(&logger.InlineWriter{
+			Parent: pp,
+			Prefix: fmt.Sprintf("[conn %v]", httpp.RemoteAddr(ctx)),
+		}, err)
 
 		if err.AskCredentials {
 			ctx.Header("WWW-Authenticate", `Basic realm="mediamtx"`)
 			pp.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 			return
 		}
-
-		pp.Log(logger.Info, "connection %v failed to authenticate: %v", httpp.RemoteAddr(ctx), err.Wrapped)
 
 		pp.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 		return

--- a/internal/pprof/pprof_test.go
+++ b/internal/pprof/pprof_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/bluenviron/mediamtx/internal/auth"
 	"github.com/bluenviron/mediamtx/internal/conf"
-	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -95,8 +94,6 @@ func TestPprof(t *testing.T) {
 }
 
 func TestAuthError(t *testing.T) {
-	n := 0
-
 	s := &PPROF{
 		Address:      "127.0.0.1:9999",
 		AllowOrigins: []string{"*"},
@@ -110,14 +107,7 @@ func TestAuthError(t *testing.T) {
 				return "", &auth.Error{Wrapped: fmt.Errorf("auth error")}
 			},
 		},
-		Parent: test.Logger(func(l logger.Level, s string, i ...any) {
-			if l == logger.Info {
-				if n == 1 {
-					require.Regexp(t, "failed to authenticate: auth error$", fmt.Sprintf(s, i...))
-				}
-				n++
-			}
-		}),
+		Parent: test.NilLogger,
 	}
 	err := s.Initialize()
 	require.NoError(t, err)
@@ -145,6 +135,4 @@ func TestAuthError(t *testing.T) {
 	defer res.Body.Close()
 
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-
-	require.Equal(t, 2, n)
 }

--- a/internal/servers/hls/http_server.go
+++ b/internal/servers/hls/http_server.go
@@ -205,6 +205,10 @@ func (s *httpServer) onRequest(ctx *gin.Context) {
 	switch contentTyp {
 	case index:
 		_, err := s.pathManager.FindPathConf(defs.PathFindPathConfReq{
+			Author: &logger.InlineWriter{
+				Parent: s,
+				Prefix: fmt.Sprintf("[conn %v]", httpp.RemoteAddr(ctx)),
+			},
 			AccessRequest: defs.PathAccessRequest{
 				Name:        dir,
 				Query:       ctx.Request.URL.RawQuery,
@@ -221,8 +225,6 @@ func (s *httpServer) onRequest(ctx *gin.Context) {
 					s.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 					return
 				}
-
-				s.Log(logger.Info, "connection %v failed to authenticate: %v", httpp.RemoteAddr(ctx), terr.Wrapped)
 
 				s.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 				return
@@ -337,8 +339,6 @@ func (s *httpServer) onRequest(ctx *gin.Context) {
 					s.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 					return
 				}
-
-				s.Log(logger.Info, "connection %v failed to authenticate: %v", httpp.RemoteAddr(ctx), terr.Wrapped)
 
 				s.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 				return

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/defs"
 	"github.com/bluenviron/mediamtx/internal/externalcmd"
-	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/stream"
 	"github.com/bluenviron/mediamtx/internal/test"
 	"github.com/bluenviron/mediamtx/internal/unit"
@@ -595,8 +594,6 @@ func TestServerDynamicAlwaysRemux(t *testing.T) {
 }
 
 func TestAuthError(t *testing.T) {
-	n := 0
-
 	s := &Server{
 		Address:         "127.0.0.1:8888",
 		Encryption:      false,
@@ -619,14 +616,7 @@ func TestAuthError(t *testing.T) {
 				return nil, &auth.Error{Wrapped: fmt.Errorf("auth error")}
 			},
 		},
-		Parent: test.Logger(func(l logger.Level, s string, i ...any) {
-			if l == logger.Info {
-				if n == 1 {
-					require.Regexp(t, "failed to authenticate: auth error$", fmt.Sprintf(s, i...))
-				}
-				n++
-			}
-		}),
+		Parent: test.NilLogger,
 	}
 	err := s.Initialize()
 	require.NoError(t, err)
@@ -650,8 +640,6 @@ func TestAuthError(t *testing.T) {
 	defer res.Body.Close()
 
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-
-	require.Equal(t, 2, n)
 }
 
 func TestAuthQueryPreservedAcrossRedirect(t *testing.T) {

--- a/internal/servers/hls/session.go
+++ b/internal/servers/hls/session.go
@@ -68,8 +68,10 @@ func (s *session) initialize(ctx *gin.Context) error {
 	}
 	if s.isCDN {
 		accessReq.SkipAuth = true
+		s.Log(logger.Info, "created by %s (CDN)", s.remoteAddr)
 	} else {
 		accessReq.Credentials = httpp.Credentials(ctx.Request)
+		s.Log(logger.Info, "created by %s", s.remoteAddr)
 	}
 
 	res, err := s.pathManager.AddReader(defs.PathAddReaderReq{
@@ -122,11 +124,7 @@ func (s *session) initialize(ctx *gin.Context) error {
 
 	res.Stream.AddReader(s.reader)
 
-	if s.isCDN {
-		s.Log(logger.Info, "created by %s (CDN), reading from muxer '%s'", s.remoteAddr, s.pathName)
-	} else {
-		s.Log(logger.Info, "created by %s, reading from muxer '%s'", s.remoteAddr, s.pathName)
-	}
+	s.Log(logger.Info, "is reading from muxer '%s'", s.pathName)
 
 	s.onUnreadHook = hooks.OnRead(hooks.OnReadParams{
 		Logger:          s,

--- a/internal/servers/moq/http_server.go
+++ b/internal/servers/moq/http_server.go
@@ -172,6 +172,10 @@ func (s *httpServer) writeErrorNoLog(ctx *gin.Context, status int, err error) {
 
 func (s *httpServer) checkAuthOutsideSession(ctx *gin.Context, pathName string, publish bool) bool {
 	_, err := s.pathManager.FindPathConf(defs.PathFindPathConfReq{
+		Author: &logger.InlineWriter{
+			Parent: s,
+			Prefix: fmt.Sprintf("[conn %v]", httpp.RemoteAddr(ctx)),
+		},
 		AccessRequest: defs.PathAccessRequest{
 			Name:        pathName,
 			Query:       ctx.Request.URL.RawQuery,
@@ -188,8 +192,6 @@ func (s *httpServer) checkAuthOutsideSession(ctx *gin.Context, pathName string, 
 				s.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 				return false
 			}
-
-			s.Log(logger.Info, "connection %v failed to authenticate: %v", httpp.RemoteAddr(ctx), terr.Wrapped)
 
 			s.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 			return false

--- a/internal/servers/moq/server_test.go
+++ b/internal/servers/moq/server_test.go
@@ -4,16 +4,20 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	mch264 "github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
+	"github.com/bluenviron/mediamtx/internal/auth"
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/defs"
 	"github.com/bluenviron/mediamtx/internal/externalcmd"
 	"github.com/bluenviron/mediamtx/internal/protocols/moq/catalog"
 	"github.com/bluenviron/mediamtx/internal/protocols/moq/controlmessage"
+	"github.com/bluenviron/mediamtx/internal/protocols/moq/parameter"
 	"github.com/bluenviron/mediamtx/internal/protocols/moq/subgroup"
 	"github.com/bluenviron/mediamtx/internal/stream"
 	"github.com/bluenviron/mediamtx/internal/test"
@@ -30,6 +34,241 @@ func (p *serverDummyPath) SafeConf() *conf.Path                          { retur
 func (p *serverDummyPath) ExternalCmdEnv() externalcmd.Environment       { return externalcmd.Environment{} }
 func (p *serverDummyPath) RemovePublisher(_ defs.PathRemovePublisherReq) {}
 func (p *serverDummyPath) RemoveReader(_ defs.PathRemoveReaderReq)       {}
+
+func TestAuthError(t *testing.T) {
+	serverCertFile := test.CreateTempFile(t, test.TLSCertPub)
+	serverKeyFile := test.CreateTempFile(t, test.TLSCertKey)
+
+	for _, ca := range []string{
+		"read page",
+		"publish page",
+		"subscribe",
+		"publish",
+	} {
+		t.Run(ca, func(t *testing.T) {
+			switch ca {
+			case "read page", "publish page":
+				pm := &test.PathManager{
+					FindPathConfImpl: func(req defs.PathFindPathConfReq) (*defs.PathFindPathConfRes, error) {
+						if req.AccessRequest.Credentials.User == "" && req.AccessRequest.Credentials.Pass == "" {
+							return nil, &auth.Error{AskCredentials: true, Wrapped: fmt.Errorf("auth error")}
+						}
+
+						return nil, &auth.Error{Wrapped: fmt.Errorf("auth error")}
+					},
+				}
+				s := &Server{
+					HTTP2Address:   "127.0.0.1:19895",
+					HTTP3Address:   "127.0.0.1:19896",
+					ServerCert:     serverCertFile,
+					ServerKey:      serverKeyFile,
+					AllowOrigins:   []string{"*"},
+					TrustedProxies: conf.IPNetworks{},
+					ReadTimeout:    conf.Duration(10 * time.Second),
+					WriteTimeout:   conf.Duration(10 * time.Second),
+					PathManager:    pm,
+					Parent:         test.NilLogger,
+				}
+				err := s.Initialize()
+				require.NoError(t, err)
+				defer s.Close()
+
+				tr := &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+				}
+				defer tr.CloseIdleConnections()
+				hc := &http.Client{Transport: tr}
+
+				var req *http.Request
+
+				switch ca {
+				case "read page":
+					req, err = http.NewRequest(http.MethodGet, "https://127.0.0.1:19895/stream/", nil)
+
+				case "publish page":
+					req, err = http.NewRequest(http.MethodGet, "https://127.0.0.1:19895/stream/publish", nil)
+				}
+				require.NoError(t, err)
+
+				res, err := hc.Do(req)
+				require.NoError(t, err)
+				defer res.Body.Close()
+
+				require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+				require.Equal(t, `Basic realm="mediamtx"`, res.Header.Get("WWW-Authenticate"))
+
+				switch ca {
+				case "read page":
+					req, err = http.NewRequest(http.MethodGet, "https://myuser:mypass@127.0.0.1:19895/stream/", nil)
+
+				case "publish page":
+					req, err = http.NewRequest(http.MethodGet, "https://myuser:mypass@127.0.0.1:19895/stream/publish", nil)
+				}
+				require.NoError(t, err)
+
+				res, err = hc.Do(req)
+				require.NoError(t, err)
+				defer res.Body.Close()
+
+				require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+				require.Equal(t, ``, res.Header.Get("WWW-Authenticate"))
+
+			case "subscribe", "publish":
+				pm := &test.PathManager{}
+
+				switch ca {
+				case "subscribe":
+					pm.AddReaderImpl = func(req defs.PathAddReaderReq) (*defs.PathAddReaderRes, error) {
+						if req.AccessRequest.Credentials.User == "" && req.AccessRequest.Credentials.Pass == "" {
+							return nil, &auth.Error{AskCredentials: true, Wrapped: fmt.Errorf("auth error")}
+						}
+
+						return nil, &auth.Error{Wrapped: fmt.Errorf("auth error")}
+					}
+
+				case "publish":
+					pm.AddPublisherImpl = func(req defs.PathAddPublisherReq) (*defs.PathAddPublisherRes, error) {
+						if req.AccessRequest.Credentials.User == "" && req.AccessRequest.Credentials.Pass == "" {
+							return nil, &auth.Error{AskCredentials: true, Wrapped: fmt.Errorf("auth error")}
+						}
+
+						return nil, &auth.Error{Wrapped: fmt.Errorf("auth error")}
+					}
+				}
+
+				s := &Server{
+					HTTP2Address:   "127.0.0.1:19895",
+					HTTP3Address:   "127.0.0.1:19896",
+					ServerCert:     serverCertFile,
+					ServerKey:      serverKeyFile,
+					AllowOrigins:   []string{"*"},
+					TrustedProxies: conf.IPNetworks{},
+					ReadTimeout:    conf.Duration(10 * time.Second),
+					WriteTimeout:   conf.Duration(10 * time.Second),
+					PathManager:    pm,
+					Parent:         test.NilLogger,
+				}
+				err := s.Initialize()
+				require.NoError(t, err)
+				defer s.Close()
+
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				d := &webtransport.Dialer{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+					QUICConfig: &quic.Config{
+						EnableDatagrams:                  true,
+						EnableStreamResetPartialDelivery: true,
+					},
+					ApplicationProtocols: []string{"moqt-18"},
+				}
+				defer d.Close() //nolint:errcheck
+
+				res, sx, err := d.Dial(ctx, "https://127.0.0.1:19896/teststream/moq", nil)
+				require.NoError(t, err)
+				defer sx.CloseWithError(0, "") //nolint:errcheck
+				defer res.Body.Close()         //nolint:errcheck
+
+				setupStream, err := sx.AcceptUniStream(ctx)
+				require.NoError(t, err)
+
+				setupMsg, err := controlmessage.Read(setupStream)
+				require.NoError(t, err)
+
+				_, ok := setupMsg.(*controlmessage.Setup)
+				require.True(t, ok)
+
+				clientSetup, err := sx.OpenUniStreamSync(ctx)
+				require.NoError(t, err)
+
+				_, err = clientSetup.Write(controlmessage.Setup{}.Marshal())
+				require.NoError(t, err)
+
+				switch ca {
+				case "subscribe":
+					var catalogBidi *webtransport.Stream
+					catalogBidi, err = sx.OpenStreamSync(ctx)
+					require.NoError(t, err)
+
+					_, err = catalogBidi.Write(controlmessage.Subscribe{
+						RequestID: 1,
+						TrackName: ".catalog",
+						Parameters: parameter.Parameters{
+							&parameter.AuthorizationToken{
+								AliasType:  parameter.AuthorizationTokenAliasTypeUseValue,
+								TokenType:  1,
+								TokenValue: []byte("Basic bXl1c2VyOm15cGFzcw=="),
+							},
+						},
+					}.Marshal())
+					require.NoError(t, err)
+
+					var msg controlmessage.Message
+					msg, err = controlmessage.Read(catalogBidi)
+					require.NoError(t, err)
+
+					require.Equal(t, &controlmessage.RequestError{
+						Code:   controlmessage.RequestErrorCodeUnauthorized,
+						Reason: "failed to authenticate: auth error",
+					}, msg)
+
+					catalogBidi.Close() //nolint:errcheck
+
+				case "publish":
+					var catalogData *webtransport.SendStream
+					catalogData, err = sx.OpenUniStreamSync(ctx)
+					require.NoError(t, err)
+
+					var cat []byte
+					cat, err = json.Marshal(catalog.Catalog{Version: 1, Tracks: []catalog.Track{{
+						Name:      "0",
+						Packaging: "loc",
+						IsLive:    true,
+						Codec:     "avc3.640028",
+					}}})
+					require.NoError(t, err)
+
+					_, err = catalogData.Write((&subgroup.SubGroup{
+						Header:  subgroup.Header{FirstObject: true, TrackAlias: 0, GroupID: 0},
+						Objects: []subgroup.Object{{Payload: cat}},
+					}).Marshal())
+					require.NoError(t, err)
+					catalogData.Close() //nolint:errcheck
+
+					var catalogBidi *webtransport.Stream
+					catalogBidi, err = sx.OpenStreamSync(ctx)
+					require.NoError(t, err)
+
+					_, err = catalogBidi.Write(controlmessage.Publish{
+						RequestID:  1,
+						TrackName:  ".catalog",
+						TrackAlias: 0,
+						Parameters: parameter.Parameters{
+							&parameter.AuthorizationToken{
+								AliasType:  parameter.AuthorizationTokenAliasTypeUseValue,
+								TokenType:  1,
+								TokenValue: []byte("Basic bXl1c2VyOm15cGFzcw=="),
+							},
+						},
+					}.Marshal())
+					require.NoError(t, err)
+
+					var msg controlmessage.Message
+					msg, err = controlmessage.Read(catalogBidi)
+					require.NoError(t, err)
+
+					require.Equal(t, &controlmessage.RequestError{
+						Code:   controlmessage.RequestErrorCodeUnauthorized,
+						Reason: "failed to authenticate: auth error",
+					}, msg)
+
+					catalogBidi.Close() //nolint:errcheck
+				}
+			}
+		})
+	}
+}
 
 func TestServer(t *testing.T) {
 	desc := &description.Session{Medias: []*description.Media{test.UniqueMediaH264()}}
@@ -100,18 +339,20 @@ func TestServer(t *testing.T) {
 
 	setupStream, err := sx.AcceptUniStream(ctx)
 	require.NoError(t, err)
+
 	setupMsg, err := controlmessage.Read(setupStream)
 	require.NoError(t, err)
-	_, ok := setupMsg.(*controlmessage.Setup)
-	require.True(t, ok)
+	require.Equal(t, &controlmessage.Setup{}, setupMsg)
 
 	clientSetup, err := sx.OpenUniStreamSync(ctx)
 	require.NoError(t, err)
+
 	_, err = clientSetup.Write(controlmessage.Setup{}.Marshal())
 	require.NoError(t, err)
 
 	catalogBidi, err := sx.OpenStreamSync(ctx)
 	require.NoError(t, err)
+
 	_, err = catalogBidi.Write(controlmessage.Subscribe{
 		RequestID: 1,
 		TrackName: ".catalog",
@@ -120,12 +361,11 @@ func TestServer(t *testing.T) {
 
 	catalogOkMsg, err := controlmessage.Read(catalogBidi)
 	require.NoError(t, err)
-	catalogOk, ok := catalogOkMsg.(*controlmessage.SubscribeOk)
-	require.True(t, ok)
-	require.Equal(t, uint64(1), catalogOk.TrackAlias)
+	require.Equal(t, &controlmessage.SubscribeOk{TrackAlias: 1}, catalogOkMsg)
 
 	catalogDataStream, err := sx.AcceptUniStream(ctx)
 	require.NoError(t, err)
+
 	var catalogSG subgroup.SubGroup
 	err = catalogSG.Read(catalogDataStream)
 	require.NoError(t, err)
@@ -146,6 +386,7 @@ func TestServer(t *testing.T) {
 
 	trackBidi, err := sx.OpenStreamSync(ctx)
 	require.NoError(t, err)
+
 	_, err = trackBidi.Write(controlmessage.Subscribe{
 		RequestID: 2,
 		TrackName: "0",
@@ -154,9 +395,7 @@ func TestServer(t *testing.T) {
 
 	trackOkMsg, err := controlmessage.Read(trackBidi)
 	require.NoError(t, err)
-	trackOk, ok := trackOkMsg.(*controlmessage.SubscribeOk)
-	require.True(t, ok)
-	require.Equal(t, uint64(2), trackOk.TrackAlias)
+	require.Equal(t, &controlmessage.SubscribeOk{TrackAlias: 2}, trackOkMsg)
 
 	go func() {
 		time.Sleep(200 * time.Millisecond)
@@ -168,6 +407,7 @@ func TestServer(t *testing.T) {
 
 	frameStream, err := sx.AcceptUniStream(ctx)
 	require.NoError(t, err)
+
 	var frameSG subgroup.SubGroup
 	err = frameSG.Read(frameStream)
 	require.NoError(t, err)

--- a/internal/servers/rtmp/server_test.go
+++ b/internal/servers/rtmp/server_test.go
@@ -3,6 +3,7 @@ package rtmp
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/url"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	"github.com/pires/go-proxyproto"
 
+	"github.com/bluenviron/mediamtx/internal/auth"
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/defs"
 	"github.com/bluenviron/mediamtx/internal/externalcmd"
@@ -40,6 +42,96 @@ func (p *dummyPath) RemovePublisher(_ defs.PathRemovePublisherReq) {
 }
 
 func (p *dummyPath) RemoveReader(_ defs.PathRemoveReaderReq) {
+}
+
+func TestAuthError(t *testing.T) {
+	for _, ca := range []struct {
+		name    string
+		publish bool
+	}{
+		{name: "read", publish: false},
+		{name: "publish", publish: true},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			for _, rawURL := range []string{
+				"rtmp://127.0.0.1:1939/teststream",
+				"rtmp://127.0.0.1:1939/teststream?user=myuser&pass=mypass",
+			} {
+				func() {
+					called := make(chan struct{})
+					pathManager := &test.PathManager{}
+					if ca.publish {
+						pathManager.AddPublisherImpl = func(req defs.PathAddPublisherReq) (*defs.PathAddPublisherRes, error) {
+							close(called)
+							if req.AccessRequest.Credentials.User == "" && req.AccessRequest.Credentials.Pass == "" {
+								return nil, &auth.Error{AskCredentials: true, Wrapped: fmt.Errorf("auth error")}
+							}
+							return nil, &auth.Error{Wrapped: fmt.Errorf("auth error")}
+						}
+					} else {
+						pathManager.AddReaderImpl = func(req defs.PathAddReaderReq) (*defs.PathAddReaderRes, error) {
+							close(called)
+							if req.AccessRequest.Credentials.User == "" && req.AccessRequest.Credentials.Pass == "" {
+								return nil, &auth.Error{AskCredentials: true, Wrapped: fmt.Errorf("auth error")}
+							}
+							return nil, &auth.Error{Wrapped: fmt.Errorf("auth error")}
+						}
+					}
+
+					s := &Server{
+						Address:             "127.0.0.1:1939",
+						ReadTimeout:         conf.Duration(10 * time.Second),
+						WriteTimeout:        conf.Duration(10 * time.Second),
+						RTSPAddress:         "",
+						RunOnConnect:        "",
+						RunOnConnectRestart: false,
+						RunOnDisconnect:     "",
+						ExternalCmdPool:     nil,
+						PathManager:         pathManager,
+						Parent:              test.NilLogger,
+					}
+					err := s.Initialize()
+					require.NoError(t, err)
+					defer s.Close()
+
+					u, err := url.Parse(rawURL)
+					require.NoError(t, err)
+
+					conn := &gortmplib.Client{
+						URL:     u,
+						Publish: ca.publish,
+					}
+					err = conn.Initialize(context.Background())
+					require.NoError(t, err)
+					defer conn.Close()
+
+					if ca.publish {
+						track := &gortmplib.Track{Codec: &codecs.H264{
+							SPS: test.FormatH264.SPS,
+							PPS: test.FormatH264.PPS,
+						}}
+						w := &gortmplib.Writer{
+							Conn:   conn,
+							Tracks: []*gortmplib.Track{track},
+						}
+						err = w.Initialize()
+						require.NoError(t, err)
+						_ = w.WriteH264(track, 2*time.Second, 2*time.Second, [][]byte{{5, 2, 3, 4}})
+					} else {
+						r := &gortmplib.Reader{Conn: conn}
+						err = r.Initialize()
+						require.Error(t, err)
+					}
+
+					select {
+					case <-called:
+					case <-time.After(2 * time.Second):
+						t.Fatal("auth callback not reached")
+					}
+				}()
+			}
+		})
+	}
 }
 
 func TestServerPublish(t *testing.T) {

--- a/internal/servers/rtsp/conn.go
+++ b/internal/servers/rtsp/conn.go
@@ -152,6 +152,7 @@ func (c *conn) onDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx,
 	}
 
 	res, err := c.pathManager.Describe(defs.PathDescribeReq{
+		Author: c,
 		AccessRequest: defs.PathAccessRequest{
 			Name:             ctx.Path,
 			Query:            ctx.Query,

--- a/internal/servers/rtsp/server_test.go
+++ b/internal/servers/rtsp/server_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,7 +23,6 @@ import (
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/defs"
 	"github.com/bluenviron/mediamtx/internal/externalcmd"
-	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/stream"
 	"github.com/bluenviron/mediamtx/internal/test"
 	"github.com/bluenviron/mediamtx/internal/unit"
@@ -686,23 +684,13 @@ func TestAuthError(t *testing.T) {
 		},
 	}
 
-	var n atomic.Int64
-	done := make(chan struct{})
-
 	s := &Server{
 		Address:        "127.0.0.1:8557",
 		ReadTimeout:    conf.Duration(10 * time.Second),
 		WriteTimeout:   conf.Duration(10 * time.Second),
 		WriteQueueSize: 512,
 		PathManager:    pathManager,
-		Parent: test.Logger(func(l logger.Level, s string, i ...any) {
-			if l == logger.Info {
-				if n.Add(1) == 3 {
-					require.Regexp(t, "authentication failed: auth error$", fmt.Sprintf(s, i...))
-					close(done)
-				}
-			}
-		}),
+		Parent:         test.NilLogger,
 	}
 	err := s.Initialize()
 	require.NoError(t, err)
@@ -722,6 +710,4 @@ func TestAuthError(t *testing.T) {
 
 	_, _, err = reader.Describe(u)
 	require.EqualError(t, err, "bad status code: 401 (Unauthorized)")
-
-	<-done
 }

--- a/internal/servers/rtsp/session.go
+++ b/internal/servers/rtsp/session.go
@@ -202,6 +202,7 @@ func (s *session) onAnnounce(c *conn, ctx *gortsplib.ServerHandlerOnAnnounceCtx)
 	}
 
 	res, err := s.pathManager.FindPathConf(defs.PathFindPathConfReq{
+		Author: s,
 		AccessRequest: defs.PathAccessRequest{
 			Name:             ctx.Path,
 			Query:            ctx.Query,

--- a/internal/servers/srt/conn.go
+++ b/internal/servers/srt/conn.go
@@ -134,6 +134,7 @@ func (c *conn) runInner() error {
 
 func (c *conn) runPublish(streamID *streamID) error {
 	res, err := c.pathManager.FindPathConf(defs.PathFindPathConfReq{
+		Author: c,
 		AccessRequest: defs.PathAccessRequest{
 			Name:    streamID.path,
 			Query:   streamID.query,

--- a/internal/servers/srt/server_test.go
+++ b/internal/servers/srt/server_test.go
@@ -2,12 +2,14 @@ package srt
 
 import (
 	"bufio"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	"github.com/bluenviron/mediacommon/v2/pkg/formats/mpegts"
 	tscodecs "github.com/bluenviron/mediacommon/v2/pkg/formats/mpegts/codecs"
+	"github.com/bluenviron/mediamtx/internal/auth"
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/defs"
 	"github.com/bluenviron/mediamtx/internal/externalcmd"
@@ -36,6 +38,71 @@ func (p *dummyPath) RemovePublisher(_ defs.PathRemovePublisherReq) {
 }
 
 func (p *dummyPath) RemoveReader(_ defs.PathRemoveReaderReq) {
+}
+
+func TestAuthError(t *testing.T) {
+	for _, ca := range []struct {
+		name string
+		url  string
+		pm   *test.PathManager
+	}{
+		{
+			name: "publish",
+			url:  "srt://127.0.0.1:8890?streamid=publish:teststream",
+			pm: &test.PathManager{
+				FindPathConfImpl: func(req defs.PathFindPathConfReq) (*defs.PathFindPathConfRes, error) {
+					if req.AccessRequest.Credentials.User == "" && req.AccessRequest.Credentials.Pass == "" {
+						return nil, &auth.Error{AskCredentials: true, Wrapped: fmt.Errorf("auth error")}
+					}
+					return nil, &auth.Error{Wrapped: fmt.Errorf("auth error")}
+				},
+			},
+		},
+		{
+			name: "read",
+			url:  "srt://127.0.0.1:8890?streamid=read:teststream",
+			pm: &test.PathManager{
+				AddReaderImpl: func(req defs.PathAddReaderReq) (*defs.PathAddReaderRes, error) {
+					if req.AccessRequest.Credentials.User == "" && req.AccessRequest.Credentials.Pass == "" {
+						return nil, &auth.Error{AskCredentials: true, Wrapped: fmt.Errorf("auth error")}
+					}
+					return nil, &auth.Error{Wrapped: fmt.Errorf("auth error")}
+				},
+			},
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			s := &Server{
+				Address:             "127.0.0.1:8890",
+				RTSPAddress:         "",
+				ReadTimeout:         conf.Duration(10 * time.Second),
+				WriteTimeout:        conf.Duration(10 * time.Second),
+				UDPMaxPayloadSize:   1472,
+				RunOnConnect:        "",
+				RunOnConnectRestart: false,
+				RunOnDisconnect:     "",
+				ExternalCmdPool:     nil,
+				PathManager:         ca.pm,
+				Parent:              test.NilLogger,
+			}
+			err := s.Initialize()
+			require.NoError(t, err)
+			defer s.Close()
+
+			for _, rawURL := range []string{ca.url, ca.url + ":myuser:mypass:param=value"} {
+				srtConf := srt.DefaultConfig()
+				var address string
+				address, err = srtConf.UnmarshalURL(rawURL)
+				require.NoError(t, err)
+
+				err = srtConf.Validate()
+				require.NoError(t, err)
+
+				_, err = srt.Dial("srt", address, srtConf)
+				require.Error(t, err)
+			}
+		})
+	}
 }
 
 func TestServerPublish(t *testing.T) {

--- a/internal/servers/webrtc/http_server.go
+++ b/internal/servers/webrtc/http_server.go
@@ -138,6 +138,10 @@ func (s *httpServer) writeErrorNoLog(ctx *gin.Context, status int, err error) {
 
 func (s *httpServer) checkAuthOutsideSession(ctx *gin.Context, pathName string, publish bool) bool {
 	_, err := s.pathManager.FindPathConf(defs.PathFindPathConfReq{
+		Author: &logger.InlineWriter{
+			Parent: s,
+			Prefix: fmt.Sprintf("[conn %v]", httpp.RemoteAddr(ctx)),
+		},
 		AccessRequest: defs.PathAccessRequest{
 			Name:        pathName,
 			Query:       ctx.Request.URL.RawQuery,
@@ -155,8 +159,6 @@ func (s *httpServer) checkAuthOutsideSession(ctx *gin.Context, pathName string, 
 				s.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 				return false
 			}
-
-			s.Log(logger.Info, "connection %v failed to authenticate: %v", httpp.RemoteAddr(ctx), terr.Wrapped)
 
 			s.writeErrorNoLog(ctx, http.StatusUnauthorized, fmt.Errorf("authentication error"))
 			return false

--- a/internal/servers/webrtc/server_test.go
+++ b/internal/servers/webrtc/server_test.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"regexp"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,7 +18,6 @@ import (
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/defs"
 	"github.com/bluenviron/mediamtx/internal/externalcmd"
-	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/protocols/webrtc"
 	"github.com/bluenviron/mediamtx/internal/protocols/whip"
 	"github.com/bluenviron/mediamtx/internal/stream"
@@ -1161,8 +1158,6 @@ func TestAuthError(t *testing.T) {
 		"whip post",
 	} {
 		t.Run(ca, func(t *testing.T) {
-			var authFailed atomic.Bool
-
 			s := &Server{
 				Address:      "127.0.0.1:8886",
 				ReadTimeout:  conf.Duration(10 * time.Second),
@@ -1176,15 +1171,7 @@ func TestAuthError(t *testing.T) {
 						return nil, &auth.Error{Wrapped: fmt.Errorf("auth error")}
 					},
 				},
-				Parent: test.Logger(func(_ logger.Level, s string, i ...any) {
-					if ca == "whip post" {
-						if regexp.MustCompile("authentication failed: auth error$").MatchString(fmt.Sprintf(s, i...)) {
-							authFailed.Store(true)
-						}
-					} else if regexp.MustCompile("failed to authenticate: auth error$").MatchString(fmt.Sprintf(s, i...)) {
-						authFailed.Store(true)
-					}
-				}),
+				Parent: test.NilLogger,
 			}
 			err := s.Initialize()
 			require.NoError(t, err)
@@ -1258,8 +1245,6 @@ func TestAuthError(t *testing.T) {
 			defer res.Body.Close()
 
 			require.Equal(t, http.StatusUnauthorized, res.StatusCode)
-
-			require.True(t, authFailed.Load())
 		})
 	}
 }

--- a/internal/servers/webrtc/session.go
+++ b/internal/servers/webrtc/session.go
@@ -338,6 +338,7 @@ func (s *session) runPublish(req *initialRequestReq) (int, error) {
 	ip, _, _ := net.SplitHostPort(s.remoteAddr)
 
 	res1, err := s.pathManager.FindPathConf(defs.PathFindPathConfReq{
+		Author: s,
 		AccessRequest: defs.PathAccessRequest{
 			Name:        s.pathName,
 			Query:       s.httpRequest.URL.RawQuery,

--- a/internal/staticsources/rpicamera/source_arm_.go
+++ b/internal/staticsources/rpicamera/source_arm_.go
@@ -29,6 +29,9 @@ type secondaryReader struct {
 	ctxCancel func()
 }
 
+func (r *secondaryReader) Log(level logger.Level, format string, args ...interface{}) {
+}
+
 // Close implements reader.
 func (r *secondaryReader) Close() {
 	r.ctxCancel()


### PR DESCRIPTION
Fixes #5421 

Log authentication errors as soon as possible, use the "warn" level, use the same message whatever the author or protocol.