### PR TITLE
fix wrong PTS and wrong playback of alwaysAvailableFile (#5436)

### DIFF
--- a/docs/3-publish/01-moq-clients.md
+++ b/docs/3-publish/01-moq-clients.md
@@ -5,7 +5,7 @@
 | **video** | AV1, VP9, VP8, H265, H264 |
 | **audio** | Opus, MPEG-4 Audio (AAC)  |
 
-Media-over-QUIC is a streaming protocol built upon cutting edge protocols (QUIC, HTTP3) and browser APIs (WebTransport, WebCodecs) that can be used to publish and read live media streams. It's slightly faster than WebRTC, has an advanced data recovery mechanism, it supports additional codecs (FLAC and future ones) and is less complicated to route.
+Media-over-QUIC is a streaming protocol built upon cutting edge protocols (QUIC, HTTP3) and browser APIs (WebTransport, WebCodecs) that can be used to publish and read live media streams. It's slightly faster than WebRTC, has an advanced data recovery mechanism, supports additional codecs (FLAC and future ones), supports B-frames and is less complicated to route.
 
 Media-over-QUIC has a wide range of features and variants, most of them in active development. We currently support the following:
 

--- a/docs/4-read/01-moq.md
+++ b/docs/4-read/01-moq.md
@@ -5,7 +5,7 @@
 | **video** | AV1, VP9, VP8, H265, H264                               |
 | **audio** | Opus, FLAC, MPEG-4 Audio (AAC), G711 (PCMA, PCMU), LPCM |
 
-Media-over-QUIC is a streaming protocol built upon cutting edge protocols (QUIC, HTTP3) and browser APIs (WebTransport, WebCodecs) that can be used to publish and read live media streams. It's slightly faster than WebRTC, has an advanced data recovery mechanism, it supports additional codecs (FLAC and future ones) and is less complicated to route.
+Media-over-QUIC is a streaming protocol built upon cutting edge protocols (QUIC, HTTP3) and browser APIs (WebTransport, WebCodecs) that can be used to publish and read live media streams. It's slightly faster than WebRTC, has an advanced data recovery mechanism, supports additional codecs (FLAC and future ones), supports B-frames and is less complicated to route.
 
 There are some limitations and requirements that are listed in [Publish with Media-over-QUIC clients](../3-publish/01-moq-clients.md).
 

--- a/internal/stream/offline_sub_stream_track.go
+++ b/internal/stream/offline_sub_stream_track.go
@@ -253,7 +253,7 @@ func (t *offlineSubStreamTrack) runFile(r io.ReadSeeker, pos int) error {
 	}
 
 	track := presentation.Tracks[pos]
-	var pts int64
+	var dts int64
 	startSystemTime := time.Now()
 
 	for {
@@ -264,6 +264,9 @@ func (t *offlineSubStreamTrack) runFile(r io.ReadSeeker, pos int) error {
 				return err
 			}
 
+			pts := dts + int64(sample.PTSOffset)
+			ptsFormat := multiplyAndDivide(pts, int64(t.format.ClockRate()), int64(track.TimeScale))
+
 			switch track.Codec.(type) {
 			case *mcodecs.AV1:
 				var bs av1.Bitstream
@@ -273,14 +276,14 @@ func (t *offlineSubStreamTrack) runFile(r io.ReadSeeker, pos int) error {
 				}
 
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
-					PTS:     pts,
+					PTS:     ptsFormat,
 					NTP:     time.Time{},
 					Payload: unit.PayloadAV1(bs),
 				})
 
 			case *mcodecs.VP9:
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
-					PTS:     pts,
+					PTS:     ptsFormat,
 					NTP:     time.Time{},
 					Payload: unit.PayloadVP9(payload),
 				})
@@ -293,7 +296,7 @@ func (t *offlineSubStreamTrack) runFile(r io.ReadSeeker, pos int) error {
 				}
 
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
-					PTS:     pts,
+					PTS:     ptsFormat,
 					NTP:     time.Time{},
 					Payload: unit.PayloadH265(avcc),
 				})
@@ -306,38 +309,36 @@ func (t *offlineSubStreamTrack) runFile(r io.ReadSeeker, pos int) error {
 				}
 
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
-					PTS:     pts,
+					PTS:     ptsFormat,
 					NTP:     time.Time{},
 					Payload: unit.PayloadH264(avcc),
 				})
 
 			case *mcodecs.Opus:
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
-					PTS:     pts,
+					PTS:     ptsFormat,
 					NTP:     time.Time{},
 					Payload: unit.PayloadOpus([][]byte{payload}),
 				})
 
 			case *mcodecs.MPEG4Audio:
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
-					PTS:     pts,
+					PTS:     ptsFormat,
 					NTP:     time.Time{},
 					Payload: unit.PayloadMPEG4Audio([][]byte{payload}),
 				})
 
 			case *mcodecs.LPCM:
 				t.subStream.WriteUnit(t.media, t.format, &unit.Unit{
-					PTS:     pts,
+					PTS:     ptsFormat,
 					NTP:     time.Time{},
 					Payload: unit.PayloadLPCM(payload),
 				})
 			}
 
-			pts += multiplyAndDivide(int64(sample.Duration)+int64(sample.PTSOffset),
-				int64(t.format.ClockRate()), int64(track.TimeScale))
-
-			ptsGo := multiplyAndDivide2(time.Duration(pts), time.Second, time.Duration(t.format.ClockRate()))
-			systemTime := startSystemTime.Add(ptsGo)
+			dts += int64(sample.Duration)
+			dtsGo := multiplyAndDivide2(time.Duration(dts), time.Second, time.Duration(track.TimeScale))
+			systemTime := startSystemTime.Add(dtsGo)
 
 			if !t.sleep(systemTime) {
 				return nil


### PR DESCRIPTION
Fixes #5436 

PTS offset of samples was not properly considered, and sleep between samples was PTS-based instead of being DTS-based.