### PR TITLE
api: add endpoints to start/stop recording on a path at runtime

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -872,6 +872,8 @@ components:
           type: string
           nullable: true
           deprecated: true
+        recording:
+          type: boolean
         source:
           type: object
           allOf:
@@ -3746,6 +3748,87 @@ paths:
                 $ref: "#/components/schemas/Error"
         "404":
           description: connection not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v3/recordings/start/{name}:
+    post:
+      operationId: recordingStart
+      tags: [Recordings]
+      summary: starts recording on a path at runtime, without altering its configuration.
+      description: >-
+        The path must have an active publisher. If the path is already
+        recording, the request succeeds without any effect.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: name of the path.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: the request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OK"
+        "400":
+          description: invalid request, for instance the path has no active publisher.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v3/recordings/stop/{name}:
+    post:
+      operationId: recordingStop
+      tags: [Recordings]
+      summary: stops recording on a path at runtime, without altering its configuration.
+      description: >-
+        The publisher and any reader attached to the path are left untouched.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: name of the path.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: the request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OK"
+        "400":
+          description: invalid request, for instance the path is not recording.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: path not found.
           content:
             application/json:
               schema:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -174,6 +174,8 @@ func (a *API) Initialize() error {
 	group.GET("/recordings/list", a.onRecordingsList)
 	group.GET("/recordings/get/*name", a.onRecordingsGet)
 	group.DELETE("/recordings/deletesegment", a.onRecordingDeleteSegment)
+	group.POST("/recordings/start/*name", a.onRecordingStart)
+	group.POST("/recordings/stop/*name", a.onRecordingStop)
 
 	a.httpServer = &httpp.Server{
 		Address:           a.Address,

--- a/internal/api/api_paths_test.go
+++ b/internal/api/api_paths_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 type testPathManager struct {
-	paths map[string]*defs.APIPath
+	paths             map[string]*defs.APIPath
+	recordingStartErr error
+	recordingStopErr  error
 }
 
 func (m *testPathManager) APIPathsList() (*defs.APIPathList, error) {
@@ -30,6 +32,26 @@ func (m *testPathManager) APIPathsGet(name string) (*defs.APIPath, error) {
 		return nil, conf.ErrPathNotFound
 	}
 	return path, nil
+}
+
+func (m *testPathManager) APIRecordingStart(name string) error {
+	if m.recordingStartErr != nil {
+		return m.recordingStartErr
+	}
+	if _, ok := m.paths[name]; !ok {
+		return conf.ErrPathNotFound
+	}
+	return nil
+}
+
+func (m *testPathManager) APIRecordingStop(name string) error {
+	if m.recordingStopErr != nil {
+		return m.recordingStopErr
+	}
+	if _, ok := m.paths[name]; !ok {
+		return conf.ErrPathNotFound
+	}
+	return nil
 }
 
 func TestPathsList(t *testing.T) {

--- a/internal/api/api_recordings.go
+++ b/internal/api/api_recordings.go
@@ -1,6 +1,7 @@
 package api //nolint:revive
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -112,6 +113,50 @@ func (a *API) onRecordingDeleteSegment(ctx *gin.Context) {
 	err = os.Remove(segmentPath)
 	if err != nil {
 		a.writeError(ctx, http.StatusBadRequest, err)
+		return
+	}
+
+	a.writeOK(ctx)
+}
+
+// onRecordingStart starts recording on a path at runtime, without touching
+// its configuration and without requiring the publisher to reconnect.
+func (a *API) onRecordingStart(ctx *gin.Context) {
+	pathName, ok := paramName(ctx)
+	if !ok {
+		a.writeError(ctx, http.StatusBadRequest, fmt.Errorf("invalid name"))
+		return
+	}
+
+	err := a.PathManager.APIRecordingStart(pathName)
+	if err != nil {
+		if errors.Is(err, conf.ErrPathNotFound) {
+			a.writeError(ctx, http.StatusNotFound, err)
+		} else {
+			a.writeError(ctx, http.StatusBadRequest, err)
+		}
+		return
+	}
+
+	a.writeOK(ctx)
+}
+
+// onRecordingStop stops recording on a path at runtime, without touching
+// its configuration and without disrupting the publisher or any reader.
+func (a *API) onRecordingStop(ctx *gin.Context) {
+	pathName, ok := paramName(ctx)
+	if !ok {
+		a.writeError(ctx, http.StatusBadRequest, fmt.Errorf("invalid name"))
+		return
+	}
+
+	err := a.PathManager.APIRecordingStop(pathName)
+	if err != nil {
+		if errors.Is(err, conf.ErrPathNotFound) {
+			a.writeError(ctx, http.StatusNotFound, err)
+		} else {
+			a.writeError(ctx, http.StatusBadRequest, err)
+		}
 		return
 	}
 

--- a/internal/api/api_recordings_test.go
+++ b/internal/api/api_recordings_test.go
@@ -1,6 +1,7 @@
 package api //nolint:revive
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bluenviron/mediamtx/internal/conf"
+	"github.com/bluenviron/mediamtx/internal/defs"
 	"github.com/bluenviron/mediamtx/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -262,4 +264,104 @@ func TestRecordingsSegmentGetInvalidPath(t *testing.T) {
 	defer resp.Body.Close()
 
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestRecordingStart(t *testing.T) {
+	for _, ca := range []struct {
+		name       string
+		pathName   string
+		pathExists bool
+		startErr   error
+		expStatus  int
+	}{
+		{"success", "mystream", true, nil, http.StatusOK},
+		{"path not found", "missing", false, nil, http.StatusNotFound},
+		{"not publishing", "mystream", true, fmt.Errorf("path 'mystream' is not publishing, unable to start recording"), http.StatusBadRequest},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			pathManager := &testPathManager{
+				paths:             map[string]*defs.APIPath{},
+				recordingStartErr: ca.startErr,
+			}
+			if ca.pathExists {
+				pathManager.paths["mystream"] = &defs.APIPath{Name: "mystream"}
+			}
+
+			api := API{
+				Address:      "localhost:9997",
+				ReadTimeout:  conf.Duration(10 * time.Second),
+				WriteTimeout: conf.Duration(10 * time.Second),
+				AuthManager:  test.NilAuthManager,
+				PathManager:  pathManager,
+				Parent:       &testParent{},
+			}
+			err := api.Initialize()
+			require.NoError(t, err)
+			defer api.Close()
+
+			tr := &http.Transport{}
+			defer tr.CloseIdleConnections()
+			hc := &http.Client{Transport: tr}
+
+			req, err := http.NewRequest(http.MethodPost,
+				"http://localhost:9997/v3/recordings/start/"+ca.pathName, nil)
+			require.NoError(t, err)
+
+			resp, err := hc.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, ca.expStatus, resp.StatusCode)
+		})
+	}
+}
+
+func TestRecordingStop(t *testing.T) {
+	for _, ca := range []struct {
+		name       string
+		pathName   string
+		pathExists bool
+		stopErr    error
+		expStatus  int
+	}{
+		{"success", "mystream", true, nil, http.StatusOK},
+		{"path not found", "missing", false, nil, http.StatusNotFound},
+		{"not recording", "mystream", true, fmt.Errorf("path 'mystream' is not recording"), http.StatusBadRequest},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			pathManager := &testPathManager{
+				paths:            map[string]*defs.APIPath{},
+				recordingStopErr: ca.stopErr,
+			}
+			if ca.pathExists {
+				pathManager.paths["mystream"] = &defs.APIPath{Name: "mystream"}
+			}
+
+			api := API{
+				Address:      "localhost:9997",
+				ReadTimeout:  conf.Duration(10 * time.Second),
+				WriteTimeout: conf.Duration(10 * time.Second),
+				AuthManager:  test.NilAuthManager,
+				PathManager:  pathManager,
+				Parent:       &testParent{},
+			}
+			err := api.Initialize()
+			require.NoError(t, err)
+			defer api.Close()
+
+			tr := &http.Transport{}
+			defer tr.CloseIdleConnections()
+			hc := &http.Client{Transport: tr}
+
+			req, err := http.NewRequest(http.MethodPost,
+				"http://localhost:9997/v3/recordings/stop/"+ca.pathName, nil)
+			require.NoError(t, err)
+
+			resp, err := hc.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, ca.expStatus, resp.StatusCode)
+		})
+	}
 }

--- a/internal/apidocsgen/openapi.template.yaml
+++ b/internal/apidocsgen/openapi.template.yaml
@@ -1818,3 +1818,84 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
+  /v3/recordings/start/{name}:
+    post:
+      operationId: recordingStart
+      tags: [Recordings]
+      summary: starts recording on a path at runtime, without altering its configuration.
+      description: >-
+        The path must have an active publisher. If the path is already
+        recording, the request succeeds without any effect.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: name of the path.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: the request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OK"
+        "400":
+          description: invalid request, for instance the path has no active publisher.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v3/recordings/stop/{name}:
+    post:
+      operationId: recordingStop
+      tags: [Recordings]
+      summary: stops recording on a path at runtime, without altering its configuration.
+      description: >-
+        The publisher and any reader attached to the path are left untouched.
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: name of the path.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: the request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OK"
+        "400":
+          description: invalid request, for instance the path is not recording.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: path not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -67,6 +67,10 @@ type pathAPIPathsGetReq struct {
 	res  chan pathAPIPathsGetRes
 }
 
+type pathAPIRecordingReq struct {
+	res chan error
+}
+
 type path struct {
 	parentCtx         context.Context
 	logLevel          conf.LogLevel
@@ -120,6 +124,8 @@ type path struct {
 	chAddReader               chan defs.PathAddReaderReq
 	chRemoveReader            chan defs.PathRemoveReaderReq
 	chAPIPathsGet             chan pathAPIPathsGetReq
+	chAPIRecordingStart       chan pathAPIRecordingReq
+	chAPIRecordingStop        chan pathAPIRecordingReq
 
 	// out
 	done chan struct{}
@@ -145,6 +151,8 @@ func (pa *path) initialize() {
 	pa.chAddReader = make(chan defs.PathAddReaderReq)
 	pa.chRemoveReader = make(chan defs.PathRemoveReaderReq)
 	pa.chAPIPathsGet = make(chan pathAPIPathsGetReq)
+	pa.chAPIRecordingStart = make(chan pathAPIRecordingReq)
+	pa.chAPIRecordingStop = make(chan pathAPIRecordingReq)
 	pa.done = make(chan struct{})
 
 	pa.Log(logger.Debug, "created")
@@ -341,6 +349,12 @@ func (pa *path) runInner() error {
 
 		case req := <-pa.chAPIPathsGet:
 			pa.doAPIPathsGet(req)
+
+		case req := <-pa.chAPIRecordingStart:
+			pa.doAPIRecordingStart(req)
+
+		case req := <-pa.chAPIRecordingStop:
+			pa.doAPIRecordingStop(req)
 
 		case <-pa.ctx.Done():
 			return fmt.Errorf("terminated")
@@ -668,6 +682,7 @@ func (pa *path) doAPIPathsGet(req pathAPIPathsGetReq) {
 				v := pa.source.APISourceDescribe()
 				return v
 			}(),
+			Recording: pa.recorder != nil,
 			Tracks: func() []defs.APIPathTrackCodec {
 				if !pa.isAvailable() {
 					return []defs.APIPathTrackCodec{}
@@ -986,6 +1001,37 @@ func (pa *path) startRecording() {
 	pa.recorder.Initialize()
 }
 
+// doAPIRecordingStart starts recording on a path that already has an active
+// publisher, regardless of the "record" value in its configuration. If the
+// path is already recording, the request is a no-op and succeeds.
+func (pa *path) doAPIRecordingStart(req pathAPIRecordingReq) {
+	if pa.stream == nil {
+		req.res <- fmt.Errorf("path '%s' is not publishing, unable to start recording", pa.name)
+		return
+	}
+
+	if pa.recorder == nil {
+		pa.startRecording()
+	}
+
+	req.res <- nil
+}
+
+// doAPIRecordingStop stops recording on a path, regardless of the "record"
+// value in its configuration. It does not affect the publisher or any
+// reader attached to the path.
+func (pa *path) doAPIRecordingStop(req pathAPIRecordingReq) {
+	if pa.recorder == nil {
+		req.res <- fmt.Errorf("path '%s' is not recording", pa.name)
+		return
+	}
+
+	pa.recorder.Close()
+	pa.recorder = nil
+
+	req.res <- nil
+}
+
 func (pa *path) executeRemoveReader(r defs.Reader) {
 	delete(pa.readers, r)
 }
@@ -1142,5 +1188,29 @@ func (pa *path) APIPathsGet(req pathAPIPathsGetReq) (*defs.APIPath, error) {
 
 	case <-pa.ctx.Done():
 		return nil, fmt.Errorf("terminated")
+	}
+}
+
+// apiRecordingStart is called by pathManager.
+func (pa *path) apiRecordingStart() error {
+	req := pathAPIRecordingReq{res: make(chan error)}
+	select {
+	case pa.chAPIRecordingStart <- req:
+		return <-req.res
+
+	case <-pa.ctx.Done():
+		return fmt.Errorf("terminated")
+	}
+}
+
+// apiRecordingStop is called by pathManager.
+func (pa *path) apiRecordingStop() error {
+	req := pathAPIRecordingReq{res: make(chan error)}
+	select {
+	case pa.chAPIRecordingStop <- req:
+		return <-req.res
+
+	case <-pa.ctx.Done():
+		return fmt.Errorf("terminated")
 	}
 }

--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -688,3 +688,43 @@ func (pm *pathManager) APIPathsGet(name string) (*defs.APIPath, error) {
 		return nil, fmt.Errorf("terminated")
 	}
 }
+
+// APIRecordingStart implements defs.APIPathManager.
+func (pm *pathManager) APIRecordingStart(name string) error {
+	pa, err := pm.apiFindPath(name)
+	if err != nil {
+		return err
+	}
+
+	return pa.apiRecordingStart()
+}
+
+// APIRecordingStop implements defs.APIPathManager.
+func (pm *pathManager) APIRecordingStop(name string) error {
+	pa, err := pm.apiFindPath(name)
+	if err != nil {
+		return err
+	}
+
+	return pa.apiRecordingStop()
+}
+
+// apiFindPath returns the path with the given name, if it currently exists.
+func (pm *pathManager) apiFindPath(name string) (*path, error) {
+	req := pathAPIPathsGetReq{
+		name: name,
+		res:  make(chan pathAPIPathsGetRes),
+	}
+
+	select {
+	case pm.chAPIPathsGet <- req:
+		res := <-req.res
+		if res.err != nil {
+			return nil, res.err
+		}
+		return res.path, nil
+
+	case <-pm.ctx.Done():
+		return nil, fmt.Errorf("terminated")
+	}
+}

--- a/internal/core/path_test.go
+++ b/internal/core/path_test.go
@@ -881,6 +881,131 @@ func TestPathRecord(t *testing.T) {
 	require.Equal(t, 2, len(files))
 }
 
+func TestPathAPIRecordingStartStop(t *testing.T) {
+	dir := t.TempDir()
+
+	p, ok := newInstance(t, "api: yes\n"+
+		"recordPath: "+filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f")+"\n"+
+		"paths:\n"+
+		"  mystream:\n"+
+		"    record: no\n")
+	require.Equal(t, true, ok)
+	defer p.Close()
+
+	tr := &http.Transport{}
+	defer tr.CloseIdleConnections()
+	hc := &http.Client{Transport: tr}
+
+	// starting recording on a path that exists but has no active publisher fails.
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:9997/v3/recordings/start/mystream", nil)
+	require.NoError(t, err)
+	res, err := hc.Do(req)
+	require.NoError(t, err)
+	res.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+	// starting recording on a nonexistent path returns 404.
+	req, err = http.NewRequest(http.MethodPost, "http://localhost:9997/v3/recordings/start/nonexistent", nil)
+	require.NoError(t, err)
+	res, err = hc.Do(req)
+	require.NoError(t, err)
+	res.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
+
+	media0 := test.UniqueMediaH264()
+
+	source := gortsplib.Client{}
+
+	err = source.StartRecording(
+		"rtsp://localhost:8554/mystream",
+		&description.Session{Medias: []*description.Media{media0}})
+	require.NoError(t, err)
+	defer source.Close()
+
+	writePacket := func(seq int) {
+		err2 := source.WritePacketRTP(media0, &rtp.Packet{
+			Header: rtp.Header{
+				Version:        2,
+				Marker:         true,
+				PayloadType:    96,
+				SequenceNumber: 1123 + uint16(seq),
+				Timestamp:      45343 + 90000*uint32(seq),
+				SSRC:           563423,
+			},
+			Payload: []byte{5},
+		})
+		require.NoError(t, err2)
+	}
+
+	for i := range 4 {
+		writePacket(i)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	// no recording yet, since "record" is false in the config.
+	_, err = os.ReadDir(filepath.Join(dir, "mystream"))
+	require.True(t, os.IsNotExist(err))
+
+	// start recording via the API, without patching the config or reconnecting.
+	req, err = http.NewRequest(http.MethodPost, "http://localhost:9997/v3/recordings/start/mystream", nil)
+	require.NoError(t, err)
+	res, err = hc.Do(req)
+	require.NoError(t, err)
+	res.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	// starting again while already recording is a no-op that still succeeds.
+	req, err = http.NewRequest(http.MethodPost, "http://localhost:9997/v3/recordings/start/mystream", nil)
+	require.NoError(t, err)
+	res, err = hc.Do(req)
+	require.NoError(t, err)
+	res.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var pathData map[string]any
+	httpRequest(t, hc, http.MethodGet, "http://localhost:9997/v3/paths/get/mystream", nil, &pathData)
+	require.Equal(t, true, pathData["recording"])
+
+	for i := 4; i < 8; i++ {
+		writePacket(i)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	files, err := os.ReadDir(filepath.Join(dir, "mystream"))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(files))
+
+	// stop recording via the API.
+	req, err = http.NewRequest(http.MethodPost, "http://localhost:9997/v3/recordings/stop/mystream", nil)
+	require.NoError(t, err)
+	res, err = hc.Do(req)
+	require.NoError(t, err)
+	res.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	httpRequest(t, hc, http.MethodGet, "http://localhost:9997/v3/paths/get/mystream", nil, &pathData)
+	require.Equal(t, false, pathData["recording"])
+
+	// stopping again while not recording fails.
+	req, err = http.NewRequest(http.MethodPost, "http://localhost:9997/v3/recordings/stop/mystream", nil)
+	require.NoError(t, err)
+	res, err = hc.Do(req)
+	require.NoError(t, err)
+	res.Body.Close() //nolint:errcheck
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+	// the publisher and reader are unaffected: further data is not recorded, but the
+	// stream itself is left alone.
+	writePacket(8)
+	time.Sleep(200 * time.Millisecond)
+
+	files, err = os.ReadDir(filepath.Join(dir, "mystream"))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(files))
+}
+
 func TestPathFallback(t *testing.T) {
 	for _, ca := range []string{
 		"absolute",

--- a/internal/defs/api_path.go
+++ b/internal/defs/api_path.go
@@ -8,6 +8,8 @@ import (
 type APIPathManager interface {
 	APIPathsList() (*APIPathList, error)
 	APIPathsGet(string) (*APIPath, error)
+	APIRecordingStart(string) error
+	APIRecordingStop(string) error
 }
 
 // APIPathSourceType is the type of a path source.
@@ -74,6 +76,7 @@ type APIPath struct {
 	Online               bool                `json:"online"`
 	OnlineTime           *time.Time          `json:"onlineTime"`
 	Source               *APIPathSource      `json:"source"`
+	Recording            bool                `json:"recording"`
 	Tracks               []APIPathTrackCodec `json:"tracks" deprecated:"true"`
 	Tracks2              []APIPathTrack      `json:"tracks2"`
 	Readers              []APIPathReader     `json:"readers"`

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -62,6 +62,14 @@ func (dummyPathManager) APIPathsGet(string) (*defs.APIPath, error) {
 	panic("unused")
 }
 
+func (dummyPathManager) APIRecordingStart(string) error {
+	panic("unused")
+}
+
+func (dummyPathManager) APIRecordingStop(string) error {
+	panic("unused")
+}
+
 type dummyHLSServer struct{}
 
 func (dummyHLSServer) APIMuxersList() (*defs.APIHLSMuxerList, error) {
@@ -361,6 +369,14 @@ func (emptyPathManager) APIPathsList() (*defs.APIPathList, error) {
 }
 
 func (emptyPathManager) APIPathsGet(string) (*defs.APIPath, error) {
+	panic("unused")
+}
+
+func (emptyPathManager) APIRecordingStart(string) error {
+	panic("unused")
+}
+
+func (emptyPathManager) APIRecordingStop(string) error {
 	panic("unused")
 }
 


### PR DESCRIPTION
## What

Adds two Control API endpoints to start and stop recording on a path at
runtime, without touching its persisted configuration and without requiring
the publisher to reconnect:

```
POST /v3/recordings/start/{name}
POST /v3/recordings/stop/{name}
```

Closes #3720.

## Why

Today the only way to influence recording is the `record: yes/no` field in a
path's config. Toggling it at runtime means going through
`POST /v3/config/paths/patch/{name}`, which is a config mutation rather than
a dedicated session command. As reported in #3720, this gets awkward when
multiple streams share a single path with `record: yes` — patching the
shared config affects everything matching that path, not just the stream the
caller cares about.

## Design notes / deviation from the issue's proposed shape

The issue proposes a single endpoint toggled by a query parameter:

```
POST /v3/recordings/{streamName}?state=start
POST /v3/recordings/{streamName}?state=stop
```

I went with two explicit endpoints (`/recordings/start/{name}` and
`/recordings/stop/{name}`) instead, to match the existing Control API
convention of encoding the action as a path segment rather than a query
parameter (see `/config/paths/add`, `/patch`, `/replace`, `/delete`, and
`/*sessions/kick`). This keeps the new routes consistent with the rest of
`api.go` and avoids introducing a new "verb-in-query-string" pattern. Happy
to switch to the query-param shape if maintainers prefer to match the issue
literally.

## Behavior

- **Start**: fails with `400` if the path has no active publisher (nothing
  to record). If the path is already recording, the request is a no-op and
  returns `200` — this makes it safe to call from multiple places without
  worrying about interleaved/concurrent calls restarting the recorder and
  cutting a new segment unnecessarily.
- **Stop**: fails with `400` if the path is not currently recording.
- Both return `404` if the path doesn't exist.
- Neither endpoint disturbs the publisher, any attached reader, or the
  stream itself — only the recorder is affected.
- These calls do **not** persist: they act directly on the path's live
  recorder, the same internal mechanism the config-driven `record: yes`
  already uses (`path.startRecording()` / closing `path.recorder`). The
  path's `record` config value is left untouched. A config reload that
  doesn't change `record` won't undo the runtime override; a publisher
  reconnect will re-evaluate `record` from config as it does today, so a
  runtime override doesn't outlive the current publish session unless the
  config is also updated.

## Other changes

- `GET /v3/paths/get/{name}` and `GET /v3/paths/list` now include a
  `recording: bool` field reflecting whether the path currently has an
  active recorder, so callers can check state before/after calling the new
  endpoints without going through `/v3/recordings/get/{name}` (which lists
  historical segments, not live state).
- `api/openapi.yaml` regenerated from `internal/apidocsgen/openapi.template.yaml`
  via `go run ./internal/apidocsgen` (per `scripts/apidocs.mk`).

## Testing

- `internal/api`: table-driven unit tests (`TestRecordingStart`,
  `TestRecordingStop`) covering success, path-not-found, and
  not-publishing/not-recording error cases, following the existing
  `testPathManager` mock pattern.
- `internal/core`: `TestPathAPIRecordingStartStop`, a full integration test
  using a real RTSP publisher (`newInstance` + `gortsplib.Client`), that:
  - confirms starting recording on a non-publishing path returns 400
  - confirms starting on a nonexistent path returns 404
  - publishes a stream with `record: no` in config, verifies no segment is
    written
  - starts recording via the new API mid-stream (no reconnect), verifies a
    segment file appears and `recording: true` is reported via
    `/v3/paths/get`
  - confirms a second start call is idempotent (still 200)
  - stops recording via the API, verifies no further segments are written
    and `recording: false` is reported
  - confirms a second stop call returns 400
  - confirms the publisher/stream keep working after both transitions
- Existing tests (`TestPathRecord`, `TestPathManagerConfigHotReload`,
  `TestPathsList`, `TestPathsGet`, full `internal/core` and `internal/api`
  suites) still pass unmodified in behavior — only mock path managers in
  `internal/metrics` and `internal/api` gained stub implementations of the
  two new `defs.APIPathManager` interface methods.
- `go build ./...`, `go vet ./internal/...`, and the full test suites above
  were run locally against Go 1.26 (this repo's declared toolchain).

## Files touched

- `internal/defs/api_path.go` — extend `APIPathManager` interface with
  `APIRecordingStart`/`APIRecordingStop`; add `Recording` field to `APIPath`
- `internal/core/path.go` — new per-path channels/handlers
  (`doAPIRecordingStart`/`doAPIRecordingStop`) wired into the path's event
  loop, plus exported `apiRecordingStart`/`apiRecordingStop`
- `internal/core/path_manager.go` — `APIRecordingStart`/`APIRecordingStop`
  on `pathManager`, resolving the path via the existing `chAPIPathsGet`
  channel
- `internal/api/api.go` — route registration
- `internal/api/api_recordings.go` — HTTP handlers
- `internal/apidocsgen/openapi.template.yaml`, `api/openapi.yaml` — API docs
- `internal/api/api_paths_test.go`, `internal/api/api_recordings_test.go`,
  `internal/core/path_test.go`, `internal/metrics/metrics_test.go` — tests
  and mock updates

Closes #3720