### PR TITLE
moq: prevent excessive CPU consumption in reorderer

### DIFF
--- a/internal/protocols/moq/reorderer/reorderer.go
+++ b/internal/protocols/moq/reorderer/reorderer.go
@@ -2,6 +2,7 @@
 package reorderer
 
 import (
+	"slices"
 	"sync"
 
 	"github.com/bluenviron/mediamtx/internal/logger"
@@ -67,14 +68,22 @@ func (r *Reorderer) Push(sg *subgroup.SubGroup) ([]*subgroup.SubGroup, error) {
 }
 
 func (r *Reorderer) flushUpTo(maxGroupID uint64) []*subgroup.SubGroup {
-	out := make([]*subgroup.SubGroup, 0, len(r.pending))
-	for i := r.curGroupID + 1; i <= maxGroupID; i++ {
-		if e, ok := r.pending[i]; ok {
-			out = append(out, e)
-			delete(r.pending, i)
+	ids := make([]uint64, 0, len(r.pending))
+	for id := range r.pending {
+		if id > r.curGroupID && id <= maxGroupID {
+			ids = append(ids, id)
 		}
 	}
+	slices.Sort(ids)
+
+	out := make([]*subgroup.SubGroup, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, r.pending[id])
+		delete(r.pending, id)
+	}
+
 	r.curGroupID = maxGroupID
+
 	for {
 		next, ok := r.pending[r.curGroupID+1]
 		if !ok {
@@ -84,5 +93,6 @@ func (r *Reorderer) flushUpTo(maxGroupID uint64) []*subgroup.SubGroup {
 		delete(r.pending, r.curGroupID+1)
 		r.curGroupID++
 	}
+
 	return out
 }


### PR DESCRIPTION
do not iterate by maxGroupID (passed by user) but iterate by internal pending packets (uncontrolled by user).