### PR TITLE
recorder: prevent a stream-time discontinuity from inflating fMP4 segment duration

### DIFF
--- a/internal/recorder/format_fmp4_track.go
+++ b/internal/recorder/format_fmp4_track.go
@@ -75,14 +75,6 @@ func (t *formatFMP4Track) write(sample *formatFMP4Sample) error {
 		return nil
 	}
 
-	duration := t.nextSample.dts - sample.dts
-	if duration < 0 {
-		t.nextSample.dts = sample.dts
-		duration = 0
-	}
-
-	sample.Duration = uint32(duration)
-
 	dts := timestampToDuration(sample.dts, int(t.initTrack.TimeScale))
 
 	if !t.startInitialized {
@@ -95,6 +87,28 @@ func (t *formatFMP4Track) write(sample *formatFMP4Sample) error {
 			return fmt.Errorf("detected drift between recording duration and absolute time, resetting")
 		}
 	}
+
+	duration := t.nextSample.dts - sample.dts
+	if duration < 0 {
+		t.nextSample.dts = sample.dts
+		duration = 0
+	} else {
+		// This sample's duration is the gap until the next sample. When the
+		// next sample's stream time has drifted from absolute time (e.g. an RTP
+		// timestamp jump after packet loss) that gap can be arbitrarily large,
+		// and it would inflate the segment duration by the size of the gap: the
+		// drift is only caught on the following call, by which time the inflated
+		// segment has already been flushed and reported. Zero the duration so
+		// the segment isn't inflated; the drift detector above then resets the
+		// recording when the next sample is processed.
+		nextDTS := timestampToDuration(t.nextSample.dts, int(t.initTrack.TimeScale))
+		nextDrift := t.nextSample.ntp.Sub(t.startNTP) - (nextDTS - t.startDTS)
+		if nextDrift < -ntpDriftTolerance || nextDrift > ntpDriftTolerance {
+			duration = 0
+		}
+	}
+
+	sample.Duration = uint32(duration)
 
 	if t.f.currentSegment == nil {
 		t.f.currentSegment = &formatFMP4Segment{

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -597,6 +598,118 @@ func TestRecorderFMP4NegativeDTSDiff(t *testing.T) {
 			},
 		}},
 	}}, parts)
+}
+
+// TestRecorderFMP4TimestampJump reproduces a stream-time discontinuity (e.g. an
+// RTP timestamp jump after packet loss) while absolute time keeps advancing
+// normally. The sample preceding the jump must not be given a duration equal to
+// the size of the jump, which would otherwise make the recorder report (and
+// stamp into the fMP4 header) a multi-hour segment duration before the drift
+// detector resets the recording on the following sample.
+func TestRecorderFMP4TimestampJump(t *testing.T) {
+	desc := &description.Session{Medias: []*description.Media{
+		{
+			Type: description.MediaTypeVideo,
+			Formats: []rtspformat.Format{&rtspformat.H264{
+				PayloadTyp:        96,
+				PacketizationMode: 1,
+			}},
+		},
+	}}
+
+	strm := &stream.Stream{
+		OrigDesc:          desc,
+		WriteQueueSize:    512,
+		RTPMaxPayloadSize: 1450,
+		Parent:            test.NilLogger,
+	}
+	err := strm.Initialize()
+	require.NoError(t, err)
+	defer strm.Close()
+
+	subStream := &stream.SubStream{
+		Stream:        strm,
+		UseRTPPackets: false,
+	}
+	err = subStream.Initialize()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	recordPath := filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f")
+
+	segDone := make(chan struct{}, 10)
+	var mutex sync.Mutex
+	var reported []time.Duration
+
+	w := &Recorder{
+		PathFormat:      recordPath,
+		Format:          conf.RecordFormatFMP4,
+		PartDuration:    100 * time.Millisecond,
+		MaxPartSize:     50 * 1024 * 1024,
+		SegmentDuration: 1 * time.Second,
+		PathName:        "mypath",
+		Stream:          strm,
+		OnSegmentComplete: func(_ string, d time.Duration) {
+			mutex.Lock()
+			reported = append(reported, d)
+			mutex.Unlock()
+			select {
+			case segDone <- struct{}{}:
+			default:
+			}
+		},
+		Parent:       test.NilLogger,
+		restartPause: 10 * time.Millisecond,
+	}
+	w.Initialize()
+
+	startNTP := time.Date(2008, 5, 20, 22, 15, 25, 0, time.UTC)
+
+	writeSample := func(dts int64, ntp time.Time) {
+		subStream.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], &unit.Unit{
+			PTS: dts,
+			NTP: ntp,
+			Payload: unit.PayloadH264{
+				test.FormatH264.SPS,
+				test.FormatH264.PPS,
+				{5}, // IDR
+			},
+		})
+	}
+
+	const step = int64(90000 / 10) // 100ms at 90kHz
+
+	// 15 samples, 100ms apart in both stream time and absolute time: crosses the
+	// 1s segment boundary, so a well-formed ~1s segment is completed.
+	for i := range 15 {
+		writeSample(int64(i)*step, startNTP.Add(time.Duration(i)*100*time.Millisecond))
+	}
+
+	// A sample whose stream time jumps ~2h ahead while absolute time advances
+	// normally -- the RTP-discontinuity signature.
+	jumpDTS := int64(15)*step + int64(2*3600)*90000
+	writeSample(jumpDTS, startNTP.Add(1600*time.Millisecond))
+
+	// Two further samples to drive the drift-reset path.
+	writeSample(jumpDTS+step, startNTP.Add(1700*time.Millisecond))
+	writeSample(jumpDTS+2*step, startNTP.Add(1800*time.Millisecond))
+
+	select {
+	case <-segDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for a completed segment")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	w.Close()
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	require.NotEmpty(t, reported)
+	for _, d := range reported {
+		require.Less(t, d, 5*time.Second,
+			"segment duration inflated by timestamp jump: %v", d)
+	}
 }
 
 func TestRecorderSkipTracksPartial(t *testing.T) {


### PR DESCRIPTION
### Problem

With `recordFormat: fmp4`, a single RTP-timestamp discontinuity (e.g. after a burst of packet loss) makes the recorder emit one segment whose **reported duration is wildly inflated** — a normal ~1-minute segment reported as multiple hours. The video bytes are fine; only the duration is wrong. It shows up in:

- the `MTX_SEGMENT_DURATION` passed to `runOnRecordSegmentComplete`, and
- the `mvhd` duration written into the segment (`ffprobe` reports hours).

Real-world log from the moment it happens (H.264, no audio):

```
INF [path left] [recorder] runOnRecordSegmentComplete command launched
ERR [path left] [recorder] detected drift between recording duration and absolute time, resetting
WAR [path left] [RTP source] 21132 RTP packets lost
```

The `runOnRecordSegmentComplete` hook fires with a ~2h22m duration for a file that is really ~1 minute long; the drift reset happens immediately after, but the corrupt segment has already been finalized and reported.

### Root cause

In `internal/recorder/format_fmp4_track.go`, a sample's duration is the gap to the next sample:

```go
sample.Duration = uint32(t.nextSample.dts - sample.dts)
```

When `nextSample` is the first sample after a discontinuity, `nextSample.dts` has jumped far ahead of stream time, so this gap is enormous. It is written as the current sample's duration, which pushes the segment's `endDTS` forward by the size of the gap — and `endDTS - startDTS` is exactly what gets stamped into the `mvhd` header and reported to `onSegmentComplete`.

The NTP-vs-stream-time drift detector added in #5239 would catch this, but it runs against the sample being written, so it only fires on the **following** call — by which point the inflated segment has already been flushed and reported.

### Fix

Establish the drift baseline first, then — mirroring the existing negative-diff clamp added in #5126 — when the **next** sample's stream time has drifted from absolute time beyond `ntpDriftTolerance`, zero the current sample's duration so
the segment cannot be inflated. The drift detector then resets the recording on the following sample, exactly as before.

The check uses NTP-vs-stream-time drift rather than raw gap size, so legitimate low-frame-rate streams (large but consistent inter-sample gaps) are not affected. `mpegts` is unaffected — it checks drift against the current sample
before touching the segment, so a discontinuity there never reaches segment finalization.

### Tests

Adds `TestRecorderFMP4TimestampJump`: writes normal samples across a segment boundary, then one sample whose stream time jumps ~2h ahead while absolute time advances normally, and asserts no segment is reported with an inflated
duration. It fails on `main` (reports `2h0m0.5s`) and passes with this change; `TestRecorderTimeDriftDetector` and `TestRecorderFMP4NegativeDTSDiff` continue to pass.

### Related

- #5126 — same code path (negative diff / overflow guard)
- #5239 — the drift-reset mechanism this extends
- #4188 looks related but is a distinct, gradual growth rather than a
  discontinuity jump.
