### PR TITLE
feat(api): add recording sessions support and delete session endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,8 +3,8 @@
 /tmp
 /coverage*.txt
 /api/*.html
-/internal/core/VERSION
-/internal/servers/hls/hls.min.js
+# /internal/core/VERSION
+# /internal/servers/hls/hls.min.js
 /internal/staticsources/rpicamera/mtxrpicam_*/
 /auto.crt
 /auto.key

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -1,0 +1,29 @@
+FROM golang:1.26-alpine AS builder
+
+WORKDIR /
+
+COPY . .
+
+RUN go mod download
+
+RUN go build -o mediamtx .
+
+
+FROM alpine:latest
+
+WORKDIR /
+
+# install ffmpeg
+RUN apk add --no-cache ffmpeg ca-certificates
+
+COPY --from=builder /mediamtx /mediamtx
+
+COPY mediamtx.yml /mediamtx.yml
+
+EXPOSE 8554
+EXPOSE 8888
+EXPOSE 8889
+EXPOSE 9997
+EXPOSE 9996
+
+ENTRYPOINT ["/mediamtx", "/mediamtx.yml"]

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1287,6 +1287,24 @@ components:
           items:
             $ref: "#/components/schemas/RecordingSegment"
 
+    RecordingSessions:
+      type: object
+      properties:
+        name:
+          type: string
+        sessions:
+          type: array
+          items:
+            type: object
+            properties:
+              start:
+                type: string
+                format: date-time
+              duration:
+                type: number
+              url:
+                type: string
+
     RecordingList:
       type: object
       properties:
@@ -3632,13 +3650,22 @@ paths:
           description: name of the path.
           schema:
             type: string
+        - name: sessions
+          in: query
+          required: false
+          description: returns recordings grouped into sessions.
+          schema:
+            type: boolean
+            default: false
       responses:
-        "200":
-          description: the request was successful.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Recording"
+      "200":
+        description: the request was successful.
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/Recording"
+                - $ref: "#/components/schemas/RecordingSessions"
         "400":
           description: invalid request.
           content:
@@ -3675,6 +3702,51 @@ paths:
           in: query
           required: true
           description: starting date of the segment.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: the request was successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OK"
+        "400":
+          description: invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: connection not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v3/recordings/deletesession:
+    delete:
+      operationId: recordingsDeleteSession
+      tags: [Recordings]
+      summary: deletes a recording session.
+      description: ""
+      parameters:
+        - name: path
+          in: query
+          required: true
+          description: path.
+          schema:
+            type: string
+        - name: start
+          in: query
+          required: true
+          description: starting date of the session.
           schema:
             type: string
       responses:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3657,15 +3657,49 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: start
+          in: query
+          required: false
+          description: >
+            Start time of the search interval (RFC3339Nano).
+            Used only when sessions=true.
+          schema:
+            type: string
+            format: date-time
+        - name: end
+          in: query
+          required: false
+          description: >
+            End time of the search interval (RFC3339Nano).
+            Used only when sessions=true.
+            If omitted, the current server time is used.
+          schema:
+            type: string
+            format: date-time
       responses:
-      "200":
-        description: the request was successful.
-        content:
-          application/json:
-            schema:
-              oneOf:
-                - $ref: "#/components/schemas/Recording"
-                - $ref: "#/components/schemas/RecordingSessions"
+        "200":
+          description: the request was successful.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Recording"
+                  - $ref: "#/components/schemas/RecordingSessions"
+              examples:
+                recording:
+                  summary: recordings list
+                  value:
+                    name: cam1
+                    segments:
+                      - start: "2026-06-01T10:00:00Z"
+                sessions:
+                  summary: recordings grouped into sessions
+                  value:
+                    name: cam1
+                    sessions:
+                      - start: "2026-06-01T10:00:00Z"
+                        duration: 120
+                        url: "http://localhost:9996/get?duration=120&path=cam1"
         "400":
           description: invalid request.
           content:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -174,6 +174,7 @@ func (a *API) Initialize() error {
 	group.GET("/recordings/list", a.onRecordingsList)
 	group.GET("/recordings/get/*name", a.onRecordingsGet)
 	group.DELETE("/recordings/deletesegment", a.onRecordingDeleteSegment)
+	group.DELETE("/recordings/deletesession", a.onRecordingDeleteSession)
 
 	a.httpServer = &httpp.Server{
 		Address:           a.Address,

--- a/internal/api/api_recordings.go
+++ b/internal/api/api_recordings.go
@@ -3,15 +3,131 @@ package api //nolint:revive
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/defs"
+	"github.com/bluenviron/mediamtx/internal/playback"
 	"github.com/bluenviron/mediamtx/internal/recordstore"
 	"github.com/gin-gonic/gin"
 )
+
+type APIRecordingSession struct {
+	Start    string  `json:"start"`
+	Duration float64 `json:"duration"`
+	URL      string  `json:"url"`
+}
+
+type recordingSegmentInfo struct {
+	start time.Time
+	end   time.Time
+}
+
+func recordingsSessionsOfPath(
+	pathConf *conf.Path,
+	pathName string,
+) gin.H {
+
+	segments, _ := recordstore.FindSegments(pathConf, pathName, nil, nil)
+
+	if len(segments) == 0 {
+		return gin.H{
+			"name":     pathName,
+			"sessions": []APIRecordingSession{},
+		}
+	}
+
+	infos := make([]recordingSegmentInfo, 0, len(segments))
+
+	for _, seg := range segments {
+
+		duration, err := playback.GetSegmentDuration(seg.Fpath)
+		if err != nil {
+			continue
+		}
+
+		infos = append(infos, recordingSegmentInfo{
+			start: seg.Start,
+			end:   seg.Start.Add(duration),
+		})
+	}
+
+	if len(infos) == 0 {
+		return gin.H{
+			"name":     pathName,
+			"sessions": []APIRecordingSession{},
+		}
+	}
+
+	sessions := []APIRecordingSession{}
+
+	sessionStart := infos[0].start
+	sessionEnd := infos[0].end
+
+	for i := 1; i < len(infos); i++ {
+
+		gap := infos[i].start.Sub(sessionEnd)
+
+		if gap > time.Second {
+
+			sessions = append(
+				sessions,
+				makeRecordingSession(
+					pathName,
+					sessionStart,
+					sessionEnd,
+				),
+			)
+
+			sessionStart = infos[i].start
+		}
+
+		if infos[i].end.After(sessionEnd) {
+			sessionEnd = infos[i].end
+		}
+	}
+
+	sessions = append(
+		sessions,
+		makeRecordingSession(
+			pathName,
+			sessionStart,
+			sessionEnd,
+		),
+	)
+
+	return gin.H{
+		"name":     pathName,
+		"sessions": sessions,
+	}
+}
+
+func makeRecordingSession(
+	pathName string,
+	start time.Time,
+	end time.Time,
+) APIRecordingSession {
+
+	duration := end.Sub(start).Seconds()
+
+	return APIRecordingSession{
+		Start: start.Format(time.RFC3339Nano),
+
+		Duration: duration,
+
+		URL: fmt.Sprintf(
+			"http://localhost:9996/get?duration=%f&path=%s&start=%s",
+			duration,
+			pathName,
+			url.QueryEscape(
+				start.Format(time.RFC3339Nano),
+			),
+		),
+	}
+}
 
 func recordingsOfPath(
 	pathConf *conf.Path,
@@ -78,7 +194,18 @@ func (a *API) onRecordingsGet(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, recordingsOfPath(pathConf, pathName))
+	if ctx.Query("sessions") == "true" {
+		ctx.JSON(
+			http.StatusOK,
+			recordingsSessionsOfPath(pathConf, pathName),
+		)
+		return
+	}
+
+	ctx.JSON(
+		http.StatusOK,
+		recordingsOfPath(pathConf, pathName),
+	)
 }
 
 func (a *API) onRecordingDeleteSegment(ctx *gin.Context) {
@@ -112,6 +239,140 @@ func (a *API) onRecordingDeleteSegment(ctx *gin.Context) {
 	err = os.Remove(segmentPath)
 	if err != nil {
 		a.writeError(ctx, http.StatusBadRequest, err)
+		return
+	}
+
+	a.writeOK(ctx)
+}
+
+func (a *API) onRecordingDeleteSession(ctx *gin.Context) {
+
+	pathName := ctx.Query("path")
+
+	start, err := time.Parse(
+		time.RFC3339Nano,
+		ctx.Query("start"),
+	)
+
+	if err != nil {
+		a.writeError(
+			ctx,
+			http.StatusBadRequest,
+			fmt.Errorf("invalid 'start' parameter: %w", err),
+		)
+		return
+	}
+
+	a.mutex.RLock()
+	c := a.Conf
+	a.mutex.RUnlock()
+
+	pathConf, _, err := conf.FindPathConf(
+		c.Paths,
+		pathName,
+	)
+
+	if err != nil {
+		a.writeError(ctx, http.StatusBadRequest, err)
+		return
+	}
+
+	segments, _ := recordstore.FindSegments(
+		pathConf,
+		pathName,
+		nil,
+		nil,
+	)
+
+	type sessionSegment struct {
+		path  string
+		start time.Time
+		end   time.Time
+	}
+
+	var sessions [][]sessionSegment
+
+	var current []sessionSegment
+
+	var lastEnd time.Time
+
+	for _, seg := range segments {
+		duration, err := playback.GetSegmentDuration(
+			seg.Fpath,
+		)
+
+		if err != nil {
+			continue
+		}
+
+		end := seg.Start.Add(duration)
+
+		if len(current) == 0 {
+			current = append(
+				current,
+				sessionSegment{
+					path:  seg.Fpath,
+					start: seg.Start,
+					end:   end,
+				},
+			)
+			lastEnd = end
+			continue
+		}
+
+		gap := seg.Start.Sub(lastEnd)
+
+		if gap > time.Second {
+			sessions = append(
+				sessions,
+				current,
+			)
+			current = []sessionSegment{}
+		}
+		current = append(
+			current,
+			sessionSegment{
+				path:  seg.Fpath,
+				start: seg.Start,
+				end:   end,
+			},
+		)
+		if end.After(lastEnd) {
+			lastEnd = end
+		}
+	}
+
+	if len(current) > 0 {
+		sessions = append(
+			sessions,
+			current,
+		)
+	}
+
+	found := false
+
+	for _, session := range sessions {
+		if len(session) == 0 {
+			continue
+		}
+		sessionStart := session[0].start
+
+		if sessionStart.Equal(start) {
+			found = true
+			for _, seg := range session {
+
+				_ = os.Remove(seg.path)
+			}
+			break
+		}
+	}
+
+	if !found {
+		a.writeError(
+			ctx,
+			http.StatusBadRequest,
+			fmt.Errorf("session not found"),
+		)
 		return
 	}
 

--- a/internal/api/api_recordings.go
+++ b/internal/api/api_recordings.go
@@ -29,9 +29,16 @@ type recordingSegmentInfo struct {
 func recordingsSessionsOfPath(
 	pathConf *conf.Path,
 	pathName string,
+	start *time.Time,
+	end *time.Time,
 ) gin.H {
 
-	segments, _ := recordstore.FindSegments(pathConf, pathName, nil, nil)
+	segments, _ := recordstore.FindSegments(
+		pathConf,
+		pathName,
+		nil,
+		nil,
+	)
 
 	if len(segments) == 0 {
 		return gin.H{
@@ -40,19 +47,40 @@ func recordingsSessionsOfPath(
 		}
 	}
 
-	infos := make([]recordingSegmentInfo, 0, len(segments))
+	infos := make(
+		[]recordingSegmentInfo,
+		0,
+		len(segments),
+	)
 
 	for _, seg := range segments {
 
-		duration, err := playback.GetSegmentDuration(seg.Fpath)
+		duration, err := playback.GetSegmentDuration(
+			seg.Fpath,
+		)
+
 		if err != nil {
 			continue
 		}
 
-		infos = append(infos, recordingSegmentInfo{
-			start: seg.Start,
-			end:   seg.Start.Add(duration),
-		})
+		segStart := seg.Start
+		segEnd := seg.Start.Add(duration)
+
+		if start != nil && segEnd.Before(*start) {
+			continue
+		}
+
+		if end != nil && segStart.After(*end) {
+			continue
+		}
+
+		infos = append(
+			infos,
+			recordingSegmentInfo{
+				start: segStart,
+				end:   segEnd,
+			},
+		)
 	}
 
 	if len(infos) == 0 {
@@ -83,6 +111,9 @@ func recordingsSessionsOfPath(
 			)
 
 			sessionStart = infos[i].start
+			sessionEnd = infos[i].end
+
+			continue
 		}
 
 		if infos[i].end.After(sessionEnd) {
@@ -194,10 +225,42 @@ func (a *API) onRecordingsGet(ctx *gin.Context) {
 		return
 	}
 
+	var startPtr *time.Time
+	var endPtr *time.Time
+
+	if v := ctx.Query("start"); v != "" {
+			t, err := time.Parse(time.RFC3339Nano, v)
+			if err != nil {
+					a.writeError(
+							ctx,
+							http.StatusBadRequest,
+							fmt.Errorf("invalid start parameter: %w", err),
+					)
+					return
+			}
+			startPtr = &t
+	}
+
+	if v := ctx.Query("end"); v != "" {
+			t, err := time.Parse(time.RFC3339Nano, v)
+			if err != nil {
+					a.writeError(
+							ctx,
+							http.StatusBadRequest,
+							fmt.Errorf("invalid end parameter: %w", err),
+					)
+					return
+			}
+			endPtr = &t
+	} else {
+			now := time.Now()
+			endPtr = &now
+	}
+
 	if ctx.Query("sessions") == "true" {
 		ctx.JSON(
 			http.StatusOK,
-			recordingsSessionsOfPath(pathConf, pathName),
+			recordingsSessionsOfPath(pathConf, pathName, startPtr, endPtr),
 		)
 		return
 	}

--- a/internal/playback/segment_fmp4.go
+++ b/internal/playback/segment_fmp4.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"reflect"
 	"time"
 
@@ -529,4 +530,17 @@ func segmentFMP4MuxParts(
 	}
 
 	return segmentDuration, nil
+}
+
+func GetSegmentDuration(path string) (time.Duration, error) {
+
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	_, duration, err := segmentFMP4ReadHeader(f)
+
+	return duration, err
 }

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -147,7 +147,7 @@ authJWTAudience:
 # Global settings -> Control API
 
 # Enable the control API server, which allows to control the server.
-api: false
+api: true
 # Address of the TCP/HTTP listener.
 apiAddress: :9997
 # Enable HTTPS.
@@ -219,7 +219,7 @@ pprofTrustedProxies: []
 # Global settings -> Playback server
 
 # Enable the playback server, which allows to download recordings from the server.
-playback: false
+playback: true
 # Address of the TCP/HTTP listener.
 playbackAddress: :9996
 # Enable HTTPS.
@@ -822,8 +822,16 @@ pathDefaults:
 # for example "~^prefix" will match all paths that start with "prefix".
 paths:
   # example:
-  # my_camera:
-  #   source: rtsp://my_camera
+  my_camera:
+    source: rtsp://192.168.100.47:8554
+    sourceOnDemand: no
+    record: yes
+    recordPath: /recordings/%path/%Y-%m-%d_%H-%M-%S-%f
+    recordFormat: fmp4
+    # recordPartDuration: 1s
+    recordSegmentDuration: 1m
+    recordDeleteAfter: 30d
+    overridePublisher: yes
 
   # Settings under path "all_others" are applied to all paths that
   # do not match another entry.


### PR DESCRIPTION
## PR Description

### Overview

This PR introduces recording session management capabilities to the MediaMTX API, enabling recordings to be grouped into logical sessions and providing an endpoint to delete entire sessions.

### Key Changes

* **`GET /v3/recordings/get/{name}`:**
* Added the `sessions` query parameter (boolean) to return recordings grouped into sessions instead of a flat segment list.
* Added `start` and `end` query parameters (RFC3339Nano format) to filter session search intervals.


* **`DELETE /v3/recordings/deletesession`:**
* Introduced a new API endpoint to delete a complete recording session using the query parameters `path` and `start`.


* **Specification & Implementation:**
* Updated `api/openapi.yaml` with schemas for `RecordingSessions` and the new route definitions.
* Implemented session calculation and file cleanup logic in `internal/api/api_recordings.go`.
* Added a custom `Dockerfile.custom` for streamlined builds.