### PR TITLE
fixes #5921 : configurable hlsSessionCloseAfter

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -372,6 +372,8 @@ components:
           type: string
         hlsServerKey:
           type: string
+        hlsSessionCloseAfter:
+          type: string
         hlsTrustedProxies:
           type: array
           items:

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -349,24 +349,25 @@ type Conf struct {
 	RTMPTrustedProxies IPNetworks `json:"rtmpTrustedProxies"`
 
 	// HLS server
-	HLS                bool       `json:"hls"`
-	HLSDisable         *bool      `json:"hlsDisable,omitempty" deprecated:"true"`
-	HLSAddress         string     `json:"hlsAddress"`
-	HLSEncryption      bool       `json:"hlsEncryption"`
-	HLSServerKey       string     `json:"hlsServerKey"`
-	HLSServerCert      string     `json:"hlsServerCert"`
-	HLSAllowOrigin     *string    `json:"hlsAllowOrigin,omitempty" deprecated:"true"`
-	HLSAllowOrigins    []string   `json:"hlsAllowOrigins"`
-	HLSTrustedProxies  IPNetworks `json:"hlsTrustedProxies"`
-	HLSAlwaysRemux     bool       `json:"hlsAlwaysRemux"`
-	HLSVariant         HLSVariant `json:"hlsVariant"`
-	HLSSegmentCount    int        `json:"hlsSegmentCount"`
-	HLSSegmentDuration Duration   `json:"hlsSegmentDuration"`
-	HLSPartDuration    Duration   `json:"hlsPartDuration"`
-	HLSSegmentMaxSize  StringSize `json:"hlsSegmentMaxSize"`
-	HLSDirectory       string     `json:"hlsDirectory"`
-	HLSMuxerCloseAfter Duration   `json:"hlsMuxerCloseAfter"`
-	HLSCDNSecret       string     `json:"hlsCDNSecret"`
+	HLS                  bool       `json:"hls"`
+	HLSDisable           *bool      `json:"hlsDisable,omitempty" deprecated:"true"`
+	HLSAddress           string     `json:"hlsAddress"`
+	HLSEncryption        bool       `json:"hlsEncryption"`
+	HLSServerKey         string     `json:"hlsServerKey"`
+	HLSServerCert        string     `json:"hlsServerCert"`
+	HLSAllowOrigin       *string    `json:"hlsAllowOrigin,omitempty" deprecated:"true"`
+	HLSAllowOrigins      []string   `json:"hlsAllowOrigins"`
+	HLSTrustedProxies    IPNetworks `json:"hlsTrustedProxies"`
+	HLSAlwaysRemux       bool       `json:"hlsAlwaysRemux"`
+	HLSVariant           HLSVariant `json:"hlsVariant"`
+	HLSSegmentCount      int        `json:"hlsSegmentCount"`
+	HLSSegmentDuration   Duration   `json:"hlsSegmentDuration"`
+	HLSPartDuration      Duration   `json:"hlsPartDuration"`
+	HLSSegmentMaxSize    StringSize `json:"hlsSegmentMaxSize"`
+	HLSDirectory         string     `json:"hlsDirectory"`
+	HLSSessionCloseAfter Duration   `json:"hlsSessionCloseAfter"`
+	HLSMuxerCloseAfter   Duration   `json:"hlsMuxerCloseAfter"`
+	HLSCDNSecret         string     `json:"hlsCDNSecret"`
 
 	// WebRTC server
 	WebRTC                      bool              `json:"webrtc"`
@@ -518,6 +519,7 @@ func (conf *Conf) setDefaults() {
 	conf.HLSPartDuration = 200 * Duration(time.Millisecond)
 	conf.HLSSegmentMaxSize = 50 * 1024 * 1024
 	conf.HLSMuxerCloseAfter = 60 * Duration(time.Second)
+	conf.HLSSessionCloseAfter = 10 * Duration(time.Second)
 
 	// WebRTC server
 	conf.WebRTC = true
@@ -957,6 +959,10 @@ func (conf *Conf) Validate(l logger.Writer) error {
 		if conf.HLSAddress == "" {
 			return fmt.Errorf("'hlsAddress' must be set when HLS is enabled")
 		}
+	}
+
+	if conf.HLSSessionCloseAfter <= 0 {
+		return fmt.Errorf("'hlsSessionCloseAfter' must be greater than zero")
 	}
 
 	if conf.HLSCDNSecret != "" {

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -246,6 +246,39 @@ func TestConfFromEnv(t *testing.T) {
 	})
 }
 
+func TestConfHLSSessionCloseAfter(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		conf, _, err := Load("", nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 10*Duration(time.Second), conf.HLSSessionCloseAfter)
+	})
+
+	t.Run("file", func(t *testing.T) {
+		tmpf := createTempFile(t, []byte("hlsSessionCloseAfter: 5s\n"))
+
+		conf, _, err := Load(tmpf, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 5*Duration(time.Second), conf.HLSSessionCloseAfter)
+	})
+
+	t.Run("environment", func(t *testing.T) {
+		t.Setenv("MTX_HLSSESSIONCLOSEAFTER", "5s")
+
+		conf, _, err := Load("", nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 5*Duration(time.Second), conf.HLSSessionCloseAfter)
+	})
+
+	for _, value := range []string{"0s", "-1s"} {
+		t.Run("invalid "+value, func(t *testing.T) {
+			tmpf := createTempFile(t, []byte("hlsSessionCloseAfter: "+value+"\n"))
+
+			_, _, err := Load(tmpf, nil, nil)
+			require.EqualError(t, err, "'hlsSessionCloseAfter' must be greater than zero")
+		})
+	}
+}
+
 func TestConfEncryption(t *testing.T) {
 	key := "testing123testin"
 	plaintext := "paths:\n" +

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -613,28 +613,29 @@ func (p *Core) createResources(initial bool) error {
 	if p.conf.HLS &&
 		p.hlsServer == nil {
 		i := &hls.Server{
-			Address:         p.conf.HLSAddress,
-			DumpPackets:     p.conf.DumpPackets,
-			Encryption:      p.conf.HLSEncryption,
-			ServerKey:       p.conf.HLSServerKey,
-			ServerCert:      p.conf.HLSServerCert,
-			AllowOrigins:    p.conf.HLSAllowOrigins,
-			TrustedProxies:  p.conf.HLSTrustedProxies,
-			AlwaysRemux:     p.conf.HLSAlwaysRemux,
-			Variant:         p.conf.HLSVariant,
-			SegmentCount:    p.conf.HLSSegmentCount,
-			SegmentDuration: p.conf.HLSSegmentDuration,
-			PartDuration:    p.conf.HLSPartDuration,
-			SegmentMaxSize:  p.conf.HLSSegmentMaxSize,
-			Directory:       p.conf.HLSDirectory,
-			CDNSecret:       p.conf.HLSCDNSecret,
-			ReadTimeout:     p.conf.ReadTimeout,
-			WriteTimeout:    p.conf.WriteTimeout,
-			MuxerCloseAfter: p.conf.HLSMuxerCloseAfter,
-			ExternalCmdPool: p.externalCmdPool,
-			Metrics:         p.metrics,
-			PathManager:     p.pathManager,
-			Parent:          p,
+			Address:           p.conf.HLSAddress,
+			DumpPackets:       p.conf.DumpPackets,
+			Encryption:        p.conf.HLSEncryption,
+			ServerKey:         p.conf.HLSServerKey,
+			ServerCert:        p.conf.HLSServerCert,
+			AllowOrigins:      p.conf.HLSAllowOrigins,
+			TrustedProxies:    p.conf.HLSTrustedProxies,
+			AlwaysRemux:       p.conf.HLSAlwaysRemux,
+			Variant:           p.conf.HLSVariant,
+			SegmentCount:      p.conf.HLSSegmentCount,
+			SegmentDuration:   p.conf.HLSSegmentDuration,
+			PartDuration:      p.conf.HLSPartDuration,
+			SegmentMaxSize:    p.conf.HLSSegmentMaxSize,
+			Directory:         p.conf.HLSDirectory,
+			CDNSecret:         p.conf.HLSCDNSecret,
+			ReadTimeout:       p.conf.ReadTimeout,
+			WriteTimeout:      p.conf.WriteTimeout,
+			MuxerCloseAfter:   p.conf.HLSMuxerCloseAfter,
+			SessionCloseAfter: p.conf.HLSSessionCloseAfter,
+			ExternalCmdPool:   p.externalCmdPool,
+			Metrics:           p.metrics,
+			PathManager:       p.pathManager,
+			Parent:            p,
 		}
 		err = i.Initialize()
 		if err != nil {
@@ -963,6 +964,7 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		newConf.ReadTimeout != p.conf.ReadTimeout ||
 		newConf.WriteTimeout != p.conf.WriteTimeout ||
 		newConf.HLSMuxerCloseAfter != p.conf.HLSMuxerCloseAfter ||
+		newConf.HLSSessionCloseAfter != p.conf.HLSSessionCloseAfter ||
 		newConf.HLSCDNSecret != p.conf.HLSCDNSecret ||
 		newConf.DumpPackets != p.conf.DumpPackets ||
 		closePathManager ||

--- a/internal/servers/hls/muxer.go
+++ b/internal/servers/hls/muxer.go
@@ -28,26 +28,31 @@ func emptyTimer() *time.Timer {
 	return t
 }
 
+func getSessionCleanupPeriod(closeAfter conf.Duration) time.Duration {
+	return max(time.Duration(closeAfter)/3, time.Nanosecond)
+}
+
 type muxerCloseInstanceReq struct {
 	instance *muxerInstance
 	err      error
 }
 
 type muxer struct {
-	parentCtx       context.Context
-	remoteAddr      string
-	variant         conf.HLSVariant
-	segmentCount    int
-	segmentDuration conf.Duration
-	partDuration    conf.Duration
-	segmentMaxSize  conf.StringSize
-	directory       string
-	closeAfter      conf.Duration
-	wg              *sync.WaitGroup
-	pathName        string
-	pathManager     serverPathManager
-	parent          *Server
-	query           string
+	parentCtx         context.Context
+	remoteAddr        string
+	variant           conf.HLSVariant
+	segmentCount      int
+	segmentDuration   conf.Duration
+	partDuration      conf.Duration
+	segmentMaxSize    conf.StringSize
+	directory         string
+	closeAfter        conf.Duration
+	sessionCloseAfter conf.Duration
+	wg                *sync.WaitGroup
+	pathName          string
+	pathManager       serverPathManager
+	parent            *Server
+	query             string
 
 	ctx             context.Context
 	ctxCancel       func()
@@ -177,7 +182,7 @@ func (m *muxer) runInner() error {
 		recreateInstanceTimer.Stop()
 	}()
 
-	sessionCleanupTicker := time.NewTicker(sessionCleanupPeriod)
+	sessionCleanupTicker := time.NewTicker(getSessionCleanupPeriod(m.sessionCloseAfter))
 	defer sessionCleanupTicker.Stop()
 
 	var activityCheckTimer *time.Timer
@@ -241,14 +246,14 @@ func (m *muxer) runInner() error {
 			for secret, sx := range m.sessionsBySecret {
 				lastRequest := time.Unix(0, sx.lastRequestTime.Load())
 
-				if now.Sub(lastRequest) >= sessionCloseAfter {
+				if now.Sub(lastRequest) >= time.Duration(m.sessionCloseAfter) {
 					delete(m.sessionsBySecret, secret)
 					sx.close2(fmt.Errorf("inactive"))
 				}
 			}
 			if m.cdnSession != nil {
 				lastRequest := time.Unix(0, m.cdnSession.lastRequestTime.Load())
-				if now.Sub(lastRequest) >= sessionCloseAfter {
+				if now.Sub(lastRequest) >= time.Duration(m.sessionCloseAfter) {
 					m.cdnSession.close2(fmt.Errorf("inactive"))
 					m.cdnSession = nil
 				}

--- a/internal/servers/hls/muxer_instance.go
+++ b/internal/servers/hls/muxer_instance.go
@@ -21,8 +21,6 @@ import (
 const (
 	sessionCookieName     = "hlsSession"
 	sessionQueryParamName = "session"
-	sessionCloseAfter     = 30 * time.Second
-	sessionCleanupPeriod  = sessionCloseAfter / 3
 )
 
 type instanceParent interface {

--- a/internal/servers/hls/server.go
+++ b/internal/servers/hls/server.go
@@ -103,28 +103,29 @@ type serverParent interface {
 
 // Server is a HLS server.
 type Server struct {
-	Address         string
-	DumpPackets     bool
-	Encryption      bool
-	ServerKey       string
-	ServerCert      string
-	AllowOrigins    []string
-	TrustedProxies  conf.IPNetworks
-	AlwaysRemux     bool
-	Variant         conf.HLSVariant
-	SegmentCount    int
-	SegmentDuration conf.Duration
-	PartDuration    conf.Duration
-	SegmentMaxSize  conf.StringSize
-	Directory       string
-	CDNSecret       string
-	ReadTimeout     conf.Duration
-	WriteTimeout    conf.Duration
-	MuxerCloseAfter conf.Duration
-	ExternalCmdPool *externalcmd.Pool
-	Metrics         serverMetrics
-	PathManager     serverPathManager
-	Parent          serverParent
+	Address           string
+	DumpPackets       bool
+	Encryption        bool
+	ServerKey         string
+	SessionCloseAfter conf.Duration
+	ServerCert        string
+	AllowOrigins      []string
+	TrustedProxies    conf.IPNetworks
+	AlwaysRemux       bool
+	Variant           conf.HLSVariant
+	SegmentCount      int
+	SegmentDuration   conf.Duration
+	PartDuration      conf.Duration
+	SegmentMaxSize    conf.StringSize
+	Directory         string
+	CDNSecret         string
+	ReadTimeout       conf.Duration
+	WriteTimeout      conf.Duration
+	MuxerCloseAfter   conf.Duration
+	ExternalCmdPool   *externalcmd.Pool
+	Metrics           serverMetrics
+	PathManager       serverPathManager
+	Parent            serverParent
 
 	ctx        context.Context
 	ctxCancel  func()
@@ -342,20 +343,21 @@ outer:
 
 func (s *Server) createMuxer(pathName string, remoteAddr string, query string) *muxer {
 	r := &muxer{
-		parentCtx:       s.ctx,
-		remoteAddr:      remoteAddr,
-		variant:         s.Variant,
-		segmentCount:    s.SegmentCount,
-		segmentDuration: s.SegmentDuration,
-		partDuration:    s.PartDuration,
-		segmentMaxSize:  s.SegmentMaxSize,
-		directory:       s.Directory,
-		wg:              &s.wg,
-		pathName:        pathName,
-		pathManager:     s.PathManager,
-		parent:          s,
-		query:           query,
-		closeAfter:      s.MuxerCloseAfter,
+		parentCtx:         s.ctx,
+		remoteAddr:        remoteAddr,
+		variant:           s.Variant,
+		segmentCount:      s.SegmentCount,
+		segmentDuration:   s.SegmentDuration,
+		partDuration:      s.PartDuration,
+		segmentMaxSize:    s.SegmentMaxSize,
+		directory:         s.Directory,
+		wg:                &s.wg,
+		pathName:          pathName,
+		pathManager:       s.PathManager,
+		parent:            s,
+		query:             query,
+		closeAfter:        s.MuxerCloseAfter,
+		sessionCloseAfter: s.SessionCloseAfter,
 	}
 	r.initialize()
 	s.muxers[pathName] = r

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -31,6 +31,12 @@ type dummyPathManager struct {
 	addReaderImpl    func(req defs.PathAddReaderReq) (*defs.PathAddReaderRes, error)
 }
 
+func TestSessionCleanupPeriod(t *testing.T) {
+	require.Equal(t, 10*time.Second, getSessionCleanupPeriod(30*conf.Duration(time.Second)))
+	require.Equal(t, 5*time.Second/3, getSessionCleanupPeriod(5*conf.Duration(time.Second)))
+	require.Equal(t, time.Nanosecond, getSessionCleanupPeriod(conf.Duration(time.Nanosecond)))
+}
+
 func (pm *dummyPathManager) SetHLSServer(*Server) []defs.Path {
 	if pm.setHLSServerImpl != nil {
 		return pm.setHLSServerImpl()
@@ -68,12 +74,13 @@ func (pa *dummyPath) RemoveReader(_ defs.PathRemoveReaderReq) {
 
 func TestServerPreflightRequest(t *testing.T) {
 	s := &Server{
-		Address:      "127.0.0.1:8888",
-		AllowOrigins: []string{"*"},
-		ReadTimeout:  conf.Duration(10 * time.Second),
-		WriteTimeout: conf.Duration(10 * time.Second),
-		PathManager:  &dummyPathManager{},
-		Parent:       test.NilLogger,
+		Address:           "127.0.0.1:8888",
+		AllowOrigins:      []string{"*"},
+		SessionCloseAfter: 30 * conf.Duration(time.Second),
+		ReadTimeout:       conf.Duration(10 * time.Second),
+		WriteTimeout:      conf.Duration(10 * time.Second),
+		PathManager:       &dummyPathManager{},
+		Parent:            test.NilLogger,
 	}
 	err := s.Initialize()
 	require.NoError(t, err)
@@ -112,11 +119,12 @@ func TestServerIndexNotConfigured(t *testing.T) {
 	}
 
 	s := &Server{
-		Address:      "127.0.0.1:8888",
-		ReadTimeout:  conf.Duration(10 * time.Second),
-		WriteTimeout: conf.Duration(10 * time.Second),
-		PathManager:  pm,
-		Parent:       test.NilLogger,
+		Address:           "127.0.0.1:8888",
+		SessionCloseAfter: 30 * conf.Duration(time.Second),
+		ReadTimeout:       conf.Duration(10 * time.Second),
+		WriteTimeout:      conf.Duration(10 * time.Second),
+		PathManager:       pm,
+		Parent:            test.NilLogger,
 	}
 	err := s.Initialize()
 	require.NoError(t, err)
@@ -146,11 +154,12 @@ func TestServerIndexNotConfigured(t *testing.T) {
 
 func TestServerIndexRedirect(t *testing.T) {
 	s := &Server{
-		Address:      "127.0.0.1:8888",
-		ReadTimeout:  conf.Duration(10 * time.Second),
-		WriteTimeout: conf.Duration(10 * time.Second),
-		PathManager:  &dummyPathManager{},
-		Parent:       test.NilLogger,
+		Address:           "127.0.0.1:8888",
+		SessionCloseAfter: 30 * conf.Duration(time.Second),
+		ReadTimeout:       conf.Duration(10 * time.Second),
+		WriteTimeout:      conf.Duration(10 * time.Second),
+		PathManager:       &dummyPathManager{},
+		Parent:            test.NilLogger,
 	}
 	err := s.Initialize()
 	require.NoError(t, err)
@@ -188,11 +197,12 @@ func TestServerIndexRedirectNoXSS(t *testing.T) {
 			}
 
 			s := &Server{
-				Address:      "127.0.0.1:8888",
-				ReadTimeout:  conf.Duration(10 * time.Second),
-				WriteTimeout: conf.Duration(10 * time.Second),
-				PathManager:  pm,
-				Parent:       test.NilLogger,
+				Address:           "127.0.0.1:8888",
+				SessionCloseAfter: 30 * conf.Duration(time.Second),
+				ReadTimeout:       conf.Duration(10 * time.Second),
+				WriteTimeout:      conf.Duration(10 * time.Second),
+				PathManager:       pm,
+				Parent:            test.NilLogger,
 			}
 			err := s.Initialize()
 			require.NoError(t, err)
@@ -238,22 +248,23 @@ func TestServerNotFound(t *testing.T) {
 			}
 
 			s := &Server{
-				Address:         "127.0.0.1:8888",
-				Encryption:      false,
-				ServerKey:       "",
-				ServerCert:      "",
-				AlwaysRemux:     ca == "always remux on",
-				Variant:         conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
-				SegmentCount:    7,
-				SegmentDuration: conf.Duration(1 * time.Second),
-				PartDuration:    conf.Duration(200 * time.Millisecond),
-				SegmentMaxSize:  50 * 1024 * 1024,
-				TrustedProxies:  conf.IPNetworks{},
-				Directory:       "",
-				ReadTimeout:     conf.Duration(10 * time.Second),
-				WriteTimeout:    conf.Duration(10 * time.Second),
-				PathManager:     pm,
-				Parent:          test.NilLogger,
+				Address:           "127.0.0.1:8888",
+				SessionCloseAfter: 30 * conf.Duration(time.Second),
+				Encryption:        false,
+				ServerKey:         "",
+				ServerCert:        "",
+				AlwaysRemux:       ca == "always remux on",
+				Variant:           conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
+				SegmentCount:      7,
+				SegmentDuration:   conf.Duration(1 * time.Second),
+				PartDuration:      conf.Duration(200 * time.Millisecond),
+				SegmentMaxSize:    50 * 1024 * 1024,
+				TrustedProxies:    conf.IPNetworks{},
+				Directory:         "",
+				ReadTimeout:       conf.Duration(10 * time.Second),
+				WriteTimeout:      conf.Duration(10 * time.Second),
+				PathManager:       pm,
+				Parent:            test.NilLogger,
 			}
 			err := s.Initialize()
 			require.NoError(t, err)
@@ -363,19 +374,20 @@ func TestServerRead(t *testing.T) {
 				}
 
 				s := &Server{
-					Address:         "127.0.0.1:8888",
-					AlwaysRemux:     ca == "always remux on",
-					Variant:         conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
-					SegmentCount:    7,
-					SegmentDuration: conf.Duration(1 * time.Second),
-					PartDuration:    conf.Duration(200 * time.Millisecond),
-					SegmentMaxSize:  50 * 1024 * 1024,
-					TrustedProxies:  conf.IPNetworks{},
-					CDNSecret:       "myCDNSecret",
-					ReadTimeout:     conf.Duration(10 * time.Second),
-					WriteTimeout:    conf.Duration(10 * time.Second),
-					PathManager:     pm,
-					Parent:          test.NilLogger,
+					Address:           "127.0.0.1:8888",
+					SessionCloseAfter: 30 * conf.Duration(time.Second),
+					AlwaysRemux:       ca == "always remux on",
+					Variant:           conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
+					SegmentCount:      7,
+					SegmentDuration:   conf.Duration(1 * time.Second),
+					PartDuration:      conf.Duration(200 * time.Millisecond),
+					SegmentMaxSize:    50 * 1024 * 1024,
+					TrustedProxies:    conf.IPNetworks{},
+					CDNSecret:         "myCDNSecret",
+					ReadTimeout:       conf.Duration(10 * time.Second),
+					WriteTimeout:      conf.Duration(10 * time.Second),
+					PathManager:       pm,
+					Parent:            test.NilLogger,
 				}
 				err = s.Initialize()
 				require.NoError(t, err)
@@ -509,22 +521,23 @@ func TestServerDirectory(t *testing.T) {
 	}
 
 	s := &Server{
-		Address:         "127.0.0.1:8888",
-		Encryption:      false,
-		ServerKey:       "",
-		ServerCert:      "",
-		AlwaysRemux:     true,
-		Variant:         conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
-		SegmentCount:    7,
-		SegmentDuration: conf.Duration(1 * time.Second),
-		PartDuration:    conf.Duration(200 * time.Millisecond),
-		SegmentMaxSize:  50 * 1024 * 1024,
-		TrustedProxies:  conf.IPNetworks{},
-		Directory:       filepath.Join(dir, "mydir"),
-		ReadTimeout:     conf.Duration(10 * time.Second),
-		WriteTimeout:    conf.Duration(10 * time.Second),
-		PathManager:     pm,
-		Parent:          test.NilLogger,
+		Address:           "127.0.0.1:8888",
+		SessionCloseAfter: 30 * conf.Duration(time.Second),
+		Encryption:        false,
+		ServerKey:         "",
+		ServerCert:        "",
+		AlwaysRemux:       true,
+		Variant:           conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
+		SegmentCount:      7,
+		SegmentDuration:   conf.Duration(1 * time.Second),
+		PartDuration:      conf.Duration(200 * time.Millisecond),
+		SegmentMaxSize:    50 * 1024 * 1024,
+		TrustedProxies:    conf.IPNetworks{},
+		Directory:         filepath.Join(dir, "mydir"),
+		ReadTimeout:       conf.Duration(10 * time.Second),
+		WriteTimeout:      conf.Duration(10 * time.Second),
+		PathManager:       pm,
+		Parent:            test.NilLogger,
 	}
 	err = s.Initialize()
 	require.NoError(t, err)
@@ -570,20 +583,21 @@ func TestServerDynamicAlwaysRemux(t *testing.T) {
 	}
 
 	s := &Server{
-		Address:         "127.0.0.1:8888",
-		Encryption:      false,
-		ServerKey:       "",
-		ServerCert:      "",
-		AlwaysRemux:     true,
-		Variant:         conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
-		SegmentCount:    7,
-		SegmentDuration: conf.Duration(1 * time.Second),
-		PartDuration:    conf.Duration(200 * time.Millisecond),
-		SegmentMaxSize:  50 * 1024 * 1024,
-		ReadTimeout:     conf.Duration(10 * time.Second),
-		WriteTimeout:    conf.Duration(10 * time.Second),
-		PathManager:     pm,
-		Parent:          test.NilLogger,
+		Address:           "127.0.0.1:8888",
+		SessionCloseAfter: 30 * conf.Duration(time.Second),
+		Encryption:        false,
+		ServerKey:         "",
+		ServerCert:        "",
+		AlwaysRemux:       true,
+		Variant:           conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
+		SegmentCount:      7,
+		SegmentDuration:   conf.Duration(1 * time.Second),
+		PartDuration:      conf.Duration(200 * time.Millisecond),
+		SegmentMaxSize:    50 * 1024 * 1024,
+		ReadTimeout:       conf.Duration(10 * time.Second),
+		WriteTimeout:      conf.Duration(10 * time.Second),
+		PathManager:       pm,
+		Parent:            test.NilLogger,
 	}
 	err = s.Initialize()
 	require.NoError(t, err)
@@ -594,18 +608,19 @@ func TestServerDynamicAlwaysRemux(t *testing.T) {
 
 func TestAuthError(t *testing.T) {
 	s := &Server{
-		Address:         "127.0.0.1:8888",
-		Encryption:      false,
-		ServerKey:       "",
-		ServerCert:      "",
-		AlwaysRemux:     true,
-		Variant:         conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
-		SegmentCount:    7,
-		SegmentDuration: conf.Duration(1 * time.Second),
-		PartDuration:    conf.Duration(200 * time.Millisecond),
-		SegmentMaxSize:  50 * 1024 * 1024,
-		ReadTimeout:     conf.Duration(10 * time.Second),
-		WriteTimeout:    conf.Duration(10 * time.Second),
+		Address:           "127.0.0.1:8888",
+		SessionCloseAfter: 30 * conf.Duration(time.Second),
+		Encryption:        false,
+		ServerKey:         "",
+		ServerCert:        "",
+		AlwaysRemux:       true,
+		Variant:           conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
+		SegmentCount:      7,
+		SegmentDuration:   conf.Duration(1 * time.Second),
+		PartDuration:      conf.Duration(200 * time.Millisecond),
+		SegmentMaxSize:    50 * 1024 * 1024,
+		ReadTimeout:       conf.Duration(10 * time.Second),
+		WriteTimeout:      conf.Duration(10 * time.Second),
 		PathManager: &dummyPathManager{
 			addReaderImpl: func(req defs.PathAddReaderReq) (*defs.PathAddReaderRes, error) {
 				if req.AccessRequest.Credentials.User == "" && req.AccessRequest.Credentials.Pass == "" {
@@ -643,18 +658,19 @@ func TestAuthError(t *testing.T) {
 
 func TestAuthQueryPreservedAcrossRedirect(t *testing.T) {
 	s := &Server{
-		Address:         "127.0.0.1:8888",
-		Encryption:      false,
-		ServerKey:       "",
-		ServerCert:      "",
-		AlwaysRemux:     true,
-		Variant:         conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
-		SegmentCount:    7,
-		SegmentDuration: conf.Duration(1 * time.Second),
-		PartDuration:    conf.Duration(200 * time.Millisecond),
-		SegmentMaxSize:  50 * 1024 * 1024,
-		ReadTimeout:     conf.Duration(10 * time.Second),
-		WriteTimeout:    conf.Duration(10 * time.Second),
+		Address:           "127.0.0.1:8888",
+		SessionCloseAfter: 30 * conf.Duration(time.Second),
+		Encryption:        false,
+		ServerKey:         "",
+		ServerCert:        "",
+		AlwaysRemux:       true,
+		Variant:           conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
+		SegmentCount:      7,
+		SegmentDuration:   conf.Duration(1 * time.Second),
+		PartDuration:      conf.Duration(200 * time.Millisecond),
+		SegmentMaxSize:    50 * 1024 * 1024,
+		ReadTimeout:       conf.Duration(10 * time.Second),
+		WriteTimeout:      conf.Duration(10 * time.Second),
 		PathManager: &dummyPathManager{
 			findPathConfImpl: func(_ defs.PathFindPathConfReq) (*defs.PathFindPathConfRes, error) {
 				return nil, &auth.Error{AskCredentials: true, Wrapped: fmt.Errorf("auth error")}
@@ -708,18 +724,19 @@ func TestServerNoSupportedCodecs(t *testing.T) {
 			}
 
 			s := &Server{
-				Address:         "127.0.0.1:8888",
-				AlwaysRemux:     (ca == "always remux on"),
-				Variant:         conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
-				SegmentCount:    7,
-				SegmentDuration: conf.Duration(1 * time.Second),
-				PartDuration:    conf.Duration(200 * time.Millisecond),
-				SegmentMaxSize:  50 * 1024 * 1024,
-				TrustedProxies:  conf.IPNetworks{},
-				ReadTimeout:     conf.Duration(10 * time.Second),
-				WriteTimeout:    conf.Duration(10 * time.Second),
-				PathManager:     pm,
-				Parent:          test.NilLogger,
+				Address:           "127.0.0.1:8888",
+				SessionCloseAfter: 30 * conf.Duration(time.Second),
+				AlwaysRemux:       (ca == "always remux on"),
+				Variant:           conf.HLSVariant(gohlslib.MuxerVariantMPEGTS),
+				SegmentCount:      7,
+				SegmentDuration:   conf.Duration(1 * time.Second),
+				PartDuration:      conf.Duration(200 * time.Millisecond),
+				SegmentMaxSize:    50 * 1024 * 1024,
+				TrustedProxies:    conf.IPNetworks{},
+				ReadTimeout:       conf.Duration(10 * time.Second),
+				WriteTimeout:      conf.Duration(10 * time.Second),
+				PathManager:       pm,
+				Parent:            test.NilLogger,
 			}
 			err = s.Initialize()
 			require.NoError(t, err)

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -368,6 +368,9 @@ hlsDirectory: ""
 # The muxer will be closed when there are no
 # reader requests and this amount of time has passed.
 hlsMuxerCloseAfter: 60s
+# HLS sessions are closed when no requests have been received
+# and this amount of time has passed.
+hlsSessionCloseAfter: 10s
 # Secret to identify requests coming from a CDN.
 # The CDN must insert this secret in every request in the
 # 'Authorization: Bearer' header.


### PR DESCRIPTION
fixes: #5921 

makes the HLS session inactivity timeout configurable through the new
`hlsSessionCloseAfter` option.
The new option defaults to 10 seconds:
any changes are welcome;


https://github.com/user-attachments/assets/c5b6d521-28fd-43d9-8bbf-1d82ddcf56a3
