### PR TITLE
feat: add global recordDeleteMaxSize for recording storage limits

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -525,6 +525,8 @@ components:
           type: string
           nullable: true
           deprecated: true
+        recordDeleteMaxSize:
+          type: string
         recordFormat:
           type: string
           allOf:

--- a/docs/2-features/09-record.md
+++ b/docs/2-features/09-record.md
@@ -49,7 +49,7 @@ To cap total disk usage across all paths, set the global `recordDeleteMaxSize` p
 
 ```yml
 # Maximum total size of all recording segments across all paths.
-# Set to 0 to disable size-based deletion.
+# Set to 0B (or "0") to disable size-based deletion.
 recordDeleteMaxSize: 100G
 ```
 

--- a/docs/2-features/09-record.md
+++ b/docs/2-features/09-record.md
@@ -45,6 +45,14 @@ pathDefaults:
   recordDeleteAfter: 1d
 ```
 
+To cap total disk usage across all paths, set the global `recordDeleteMaxSize` parameter. When the limit is exceeded, the oldest completed segments are deleted first, even if they have not yet reached `recordDeleteAfter`:
+
+```yml
+# Maximum total size of all recording segments across all paths.
+# Set to 0 to disable size-based deletion.
+recordDeleteMaxSize: 100G
+```
+
 All available recording parameters are listed in the [configuration file](../5-references/1-configuration-file.md).
 
 ## Remote upload

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -311,6 +311,9 @@ type Conf struct {
 	PlaybackAllowOrigins   []string   `json:"playbackAllowOrigins"`
 	PlaybackTrustedProxies IPNetworks `json:"playbackTrustedProxies"`
 
+	// Recording cleanup
+	RecordDeleteMaxSize StringSize `json:"recordDeleteMaxSize"`
+
 	// RTSP server
 	RTSP                  bool             `json:"rtsp"`
 	RTSPDisable           *bool            `json:"rtspDisable,omitempty" deprecated:"true"`
@@ -474,6 +477,9 @@ func (conf *Conf) setDefaults() {
 	conf.PlaybackServerKey = "server.key"
 	conf.PlaybackServerCert = "server.crt"
 	conf.PlaybackAllowOrigins = []string{"*"}
+
+	// Recording cleanup
+	conf.RecordDeleteMaxSize = 0
 
 	// RTSP server
 	conf.RTSP = true

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -77,7 +77,10 @@ func getArch() string {
 	return arch
 }
 
-func atLeastOneRecordDeleteAfter(pathConfs map[string]*conf.Path) bool {
+func recordCleanerNeeded(pathConfs map[string]*conf.Path, recordDeleteMaxSize conf.StringSize) bool {
+	if recordDeleteMaxSize != 0 {
+		return true
+	}
 	for _, e := range pathConfs {
 		if e.RecordDeleteAfter != 0 {
 			return true
@@ -412,10 +415,11 @@ func (p *Core) createResources(initial bool) error {
 	}
 
 	if p.recordCleaner == nil &&
-		atLeastOneRecordDeleteAfter(p.conf.Paths) {
+		recordCleanerNeeded(p.conf.Paths, p.conf.RecordDeleteMaxSize) {
 		p.recordCleaner = &recordcleaner.Cleaner{
-			PathConfs: p.conf.Paths,
-			Parent:    p,
+			PathConfs:           p.conf.Paths,
+			RecordDeleteMaxSize: p.conf.RecordDeleteMaxSize,
+			Parent:              p,
 		}
 		p.recordCleaner.Initialize()
 	}
@@ -823,10 +827,13 @@ func (p *Core) closeResources(newConf *conf.Conf, calledByAPI bool) {
 		closeLogger
 
 	closeRecorderCleaner := newConf == nil ||
-		atLeastOneRecordDeleteAfter(newConf.Paths) != atLeastOneRecordDeleteAfter(p.conf.Paths) ||
+		recordCleanerNeeded(newConf.Paths, newConf.RecordDeleteMaxSize) !=
+			recordCleanerNeeded(p.conf.Paths, p.conf.RecordDeleteMaxSize) ||
 		closeLogger
-	if !closeRecorderCleaner && p.recordCleaner != nil && !reflect.DeepEqual(newConf.Paths, p.conf.Paths) {
-		p.recordCleaner.ReloadPathConfs(newConf.Paths)
+	if !closeRecorderCleaner && p.recordCleaner != nil &&
+		(!reflect.DeepEqual(newConf.Paths, p.conf.Paths) ||
+			newConf.RecordDeleteMaxSize != p.conf.RecordDeleteMaxSize) {
+		p.recordCleaner.ReloadPathConfs(newConf.Paths, newConf.RecordDeleteMaxSize)
 	}
 
 	closePlaybackServer := newConf == nil ||

--- a/internal/recordcleaner/cleaner.go
+++ b/internal/recordcleaner/cleaner.go
@@ -165,6 +165,7 @@ func (c *Cleaner) deleteOverflowSegments() {
 
 	entries, err := c.gatherSegmentEntries()
 	if err != nil {
+		c.Log(logger.Warn, "failed to gather recording segments: %v", err)
 		return
 	}
 

--- a/internal/recordcleaner/cleaner.go
+++ b/internal/recordcleaner/cleaner.go
@@ -52,7 +52,7 @@ func (c *Cleaner) Initialize() {
 	go c.run()
 }
 
-// Close closes the Cleaner.
+// Close closes a Cleaner.
 func (c *Cleaner) Close() {
 	c.ctxCancel()
 	<-c.done
@@ -201,15 +201,15 @@ func (c *Cleaner) deleteOverflowSegments() {
 		}
 
 		c.Log(logger.Debug, "removing %s (storage limit)", e.fpath)
-		err := os.Remove(e.fpath)
+		err = os.Remove(e.fpath)
 		if err != nil {
 			continue
 		}
 
 		totalSize -= uint64(e.size)
 
-		pathConf, _, err := conf.FindPathConf(c.PathConfs, e.pathName)
-		if err == nil {
+		pathConf, _, findErr := conf.FindPathConf(c.PathConfs, e.pathName)
+		if findErr == nil {
 			touchedPathConfs[pathConf] = struct{}{}
 		}
 	}
@@ -238,8 +238,8 @@ func (c *Cleaner) gatherSegmentEntries() ([]segmentEntry, error) {
 		}
 
 		for _, seg := range segments {
-			fi, err := os.Stat(seg.Fpath)
-			if err != nil {
+			fi, err2 := os.Stat(seg.Fpath)
+			if err2 != nil {
 				continue
 			}
 

--- a/internal/recordcleaner/cleaner.go
+++ b/internal/recordcleaner/cleaner.go
@@ -3,9 +3,11 @@ package recordcleaner
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,22 +18,35 @@ import (
 
 var timeNow = time.Now
 
+type segmentEntry struct {
+	fpath    string
+	start    time.Time
+	size     int64
+	pathName string
+}
+
 // Cleaner removes expired recording segments from disk.
 type Cleaner struct {
-	PathConfs map[string]*conf.Path
-	Parent    logger.Writer
+	PathConfs           map[string]*conf.Path
+	RecordDeleteMaxSize conf.StringSize
+	Parent              logger.Writer
 
 	ctx       context.Context
 	ctxCancel func()
 
-	chReloadConf chan map[string]*conf.Path
+	chReloadConf chan reloadConf
 	done         chan struct{}
+}
+
+type reloadConf struct {
+	pathConfs           map[string]*conf.Path
+	recordDeleteMaxSize conf.StringSize
 }
 
 // Initialize initializes a Cleaner.
 func (c *Cleaner) Initialize() {
 	c.ctx, c.ctxCancel = context.WithCancel(context.Background())
-	c.chReloadConf = make(chan map[string]*conf.Path)
+	c.chReloadConf = make(chan reloadConf)
 	c.done = make(chan struct{})
 
 	go c.run()
@@ -49,9 +64,12 @@ func (c *Cleaner) Log(level logger.Level, format string, args ...any) {
 }
 
 // ReloadPathConfs is called by core.Core.
-func (c *Cleaner) ReloadPathConfs(pathConfs map[string]*conf.Path) {
+func (c *Cleaner) ReloadPathConfs(pathConfs map[string]*conf.Path, recordDeleteMaxSize conf.StringSize) {
 	select {
-	case c.chReloadConf <- pathConfs:
+	case c.chReloadConf <- reloadConf{
+		pathConfs:           pathConfs,
+		recordDeleteMaxSize: recordDeleteMaxSize,
+	}:
 	case <-c.ctx.Done():
 	}
 }
@@ -67,7 +85,8 @@ func (c *Cleaner) run() {
 			c.doRun()
 
 		case cnf := <-c.chReloadConf:
-			c.PathConfs = cnf
+			c.PathConfs = cnf.pathConfs
+			c.RecordDeleteMaxSize = cnf.recordDeleteMaxSize
 
 		case <-c.ctx.Done():
 			return
@@ -77,6 +96,10 @@ func (c *Cleaner) run() {
 
 func (c *Cleaner) cleanInterval() time.Duration {
 	interval := 30 * 60 * time.Second
+
+	if c.RecordDeleteMaxSize != 0 {
+		interval = 60 * time.Second
+	}
 
 	for _, e := range c.PathConfs {
 		if e.RecordDeleteAfter != 0 &&
@@ -96,6 +119,8 @@ func (c *Cleaner) doRun() {
 	for _, pathName := range pathNames {
 		c.processPath(now, pathName) //nolint:errcheck
 	}
+
+	c.deleteOverflowSegments()
 }
 
 func (c *Cleaner) processPath(now time.Time, pathName string) error {
@@ -131,6 +156,103 @@ func (c *Cleaner) deleteExpiredSegments(now time.Time, pathName string, pathConf
 	}
 
 	return nil
+}
+
+func (c *Cleaner) deleteOverflowSegments() {
+	if c.RecordDeleteMaxSize == 0 {
+		return
+	}
+
+	entries, err := c.gatherSegmentEntries()
+	if err != nil {
+		return
+	}
+
+	var totalSize uint64
+	for _, e := range entries {
+		totalSize += uint64(e.size)
+	}
+
+	limit := uint64(c.RecordDeleteMaxSize)
+	if totalSize <= limit {
+		return
+	}
+
+	newestByPath := make(map[string]time.Time)
+	for _, e := range entries {
+		if t, ok := newestByPath[e.pathName]; !ok || e.start.After(t) {
+			newestByPath[e.pathName] = e.start
+		}
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].start.Before(entries[j].start)
+	})
+
+	touchedPathConfs := make(map[*conf.Path]struct{})
+
+	for _, e := range entries {
+		if totalSize <= limit {
+			break
+		}
+
+		if e.start.Equal(newestByPath[e.pathName]) {
+			continue
+		}
+
+		c.Log(logger.Debug, "removing %s (storage limit)", e.fpath)
+		err := os.Remove(e.fpath)
+		if err != nil {
+			continue
+		}
+
+		totalSize -= uint64(e.size)
+
+		pathConf, _, err := conf.FindPathConf(c.PathConfs, e.pathName)
+		if err == nil {
+			touchedPathConfs[pathConf] = struct{}{}
+		}
+	}
+
+	for pathConf := range touchedPathConfs {
+		c.deleteEmptyDirs(pathConf)
+	}
+}
+
+func (c *Cleaner) gatherSegmentEntries() ([]segmentEntry, error) {
+	pathNames := recordstore.FindAllPathsWithSegments(c.PathConfs)
+	var entries []segmentEntry
+
+	for _, pathName := range pathNames {
+		pathConf, _, err := conf.FindPathConf(c.PathConfs, pathName)
+		if err != nil {
+			continue
+		}
+
+		segments, err := recordstore.FindSegments(pathConf, pathName, nil, nil)
+		if err != nil {
+			if errors.Is(err, recordstore.ErrNoSegmentsFound) {
+				continue
+			}
+			return nil, err
+		}
+
+		for _, seg := range segments {
+			fi, err := os.Stat(seg.Fpath)
+			if err != nil {
+				continue
+			}
+
+			entries = append(entries, segmentEntry{
+				fpath:    seg.Fpath,
+				start:    seg.Start,
+				size:     fi.Size(),
+				pathName: pathName,
+			})
+		}
+	}
+
+	return entries, nil
 }
 
 func (c *Cleaner) deleteEmptyDirs(pathConf *conf.Path) {

--- a/internal/recordcleaner/cleaner_test.go
+++ b/internal/recordcleaner/cleaner_test.go
@@ -145,10 +145,7 @@ func TestCleanerMaxSize(t *testing.T) {
 		RecordDeleteMaxSize: 8,
 		Parent:              test.NilLogger,
 	}
-	c.Initialize()
-	defer c.Close()
-
-	time.Sleep(500 * time.Millisecond)
+	c.doRun()
 
 	_, err = os.Stat(filepath.Join(dir, "path2", "2009-05-18_22-15-25-000001.mp4"))
 	require.Error(t, err)
@@ -184,10 +181,7 @@ func TestCleanerMaxSizeUnderQuota(t *testing.T) {
 		RecordDeleteMaxSize: 100,
 		Parent:              test.NilLogger,
 	}
-	c.Initialize()
-	defer c.Close()
-
-	time.Sleep(500 * time.Millisecond)
+	c.doRun()
 
 	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"))
 	require.NoError(t, err)
@@ -228,10 +222,7 @@ func TestCleanerMaxSizeAndAge(t *testing.T) {
 		RecordDeleteMaxSize: 4,
 		Parent:              test.NilLogger,
 	}
-	c.Initialize()
-	defer c.Close()
-
-	time.Sleep(500 * time.Millisecond)
+	c.doRun()
 
 	_, err = os.Stat(filepath.Join(dir, "path1", "2008-05-20_22-15-25-000001.mp4"))
 	require.Error(t, err)
@@ -266,10 +257,7 @@ func TestCleanerMaxSizeOnly(t *testing.T) {
 		RecordDeleteMaxSize: 4,
 		Parent:              test.NilLogger,
 	}
-	c.Initialize()
-	defer c.Close()
-
-	time.Sleep(500 * time.Millisecond)
+	c.doRun()
 
 	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"))
 	require.Error(t, err)
@@ -306,10 +294,7 @@ func TestCleanerMaxSizeProtectsNewest(t *testing.T) {
 		RecordDeleteMaxSize: 1,
 		Parent:              test.NilLogger,
 	}
-	c.Initialize()
-	defer c.Close()
-
-	time.Sleep(500 * time.Millisecond)
+	c.doRun()
 
 	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"))
 	require.Error(t, err)

--- a/internal/recordcleaner/cleaner_test.go
+++ b/internal/recordcleaner/cleaner_test.go
@@ -288,7 +288,11 @@ func TestCleanerMaxSizeProtectsNewest(t *testing.T) {
 	// Single path with one large newest segment that alone exceeds the limit.
 	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"), []byte{1, 2}, 0o644)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"), []byte{1, 2, 3, 4, 5, 6, 7, 8}, 0o644)
+	err = os.WriteFile(
+		filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"),
+		[]byte{1, 2, 3, 4, 5, 6, 7, 8},
+		0o644,
+	)
 	require.NoError(t, err)
 
 	c := &Cleaner{

--- a/internal/recordcleaner/cleaner_test.go
+++ b/internal/recordcleaner/cleaner_test.go
@@ -17,11 +17,13 @@ func TestCleaner(t *testing.T) {
 		return time.Date(2009, 5, 20, 22, 15, 25, 427000, time.Local)
 	}
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "mediamtx-cleaner")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
 
 	const specialChars = "_-+*?^$()[]{}|"
 
-	err := os.Mkdir(filepath.Join(dir, specialChars+"_mypath"), 0o755)
+	err = os.Mkdir(filepath.Join(dir, specialChars+"_mypath"), 0o755)
 	require.NoError(t, err)
 
 	err = os.WriteFile(filepath.Join(dir, specialChars+"_mypath", "2008-05-20_22-15-25-000125.mp4"), []byte{1}, 0o644)
@@ -59,9 +61,11 @@ func TestCleanerMultipleEntriesSamePath(t *testing.T) {
 		return time.Date(2009, 5, 20, 22, 15, 25, 427000, time.Local)
 	}
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "mediamtx-cleaner")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
 
-	err := os.Mkdir(filepath.Join(dir, "path1"), 0o755)
+	err = os.Mkdir(filepath.Join(dir, "path1"), 0o755)
 	require.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(dir, "path2"), 0o755)
@@ -102,5 +106,209 @@ func TestCleanerMultipleEntriesSamePath(t *testing.T) {
 	require.Error(t, err, "testing")
 
 	_, err = os.Stat(filepath.Join(dir, "path2", "2009-05-19_22-15-25-000427.mp4"))
+	require.NoError(t, err)
+}
+
+func TestCleanerMaxSize(t *testing.T) {
+	dir, err := os.MkdirTemp("", "mediamtx-cleaner")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	err = os.Mkdir(filepath.Join(dir, "path1"), 0o755)
+	require.NoError(t, err)
+	err = os.Mkdir(filepath.Join(dir, "path2"), 0o755)
+	require.NoError(t, err)
+
+	// 4 bytes each; total 16. Limit 8 keeps two newest across paths.
+	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "path2", "2009-05-18_22-15-25-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "path2", "2009-05-21_22-15-25-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+
+	c := &Cleaner{
+		PathConfs: map[string]*conf.Path{
+			"path1": {
+				Name:         "path1",
+				RecordPath:   filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
+				RecordFormat: conf.RecordFormatFMP4,
+			},
+			"path2": {
+				Name:         "path2",
+				RecordPath:   filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
+				RecordFormat: conf.RecordFormatFMP4,
+			},
+		},
+		RecordDeleteMaxSize: 8,
+		Parent:              test.NilLogger,
+	}
+	c.Initialize()
+	defer c.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	_, err = os.Stat(filepath.Join(dir, "path2", "2009-05-18_22-15-25-000001.mp4"))
+	require.Error(t, err)
+	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"))
+	require.Error(t, err)
+	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, "path2", "2009-05-21_22-15-25-000001.mp4"))
+	require.NoError(t, err)
+}
+
+func TestCleanerMaxSizeUnderQuota(t *testing.T) {
+	dir, err := os.MkdirTemp("", "mediamtx-cleaner")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	err = os.Mkdir(filepath.Join(dir, "path1"), 0o755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+
+	c := &Cleaner{
+		PathConfs: map[string]*conf.Path{
+			"path1": {
+				Name:         "path1",
+				RecordPath:   filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
+				RecordFormat: conf.RecordFormatFMP4,
+			},
+		},
+		RecordDeleteMaxSize: 100,
+		Parent:              test.NilLogger,
+	}
+	c.Initialize()
+	defer c.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"))
+	require.NoError(t, err)
+}
+
+func TestCleanerMaxSizeAndAge(t *testing.T) {
+	timeNow = func() time.Time {
+		return time.Date(2009, 5, 20, 22, 15, 25, 427000, time.Local)
+	}
+	defer func() { timeNow = time.Now }()
+
+	dir, err := os.MkdirTemp("", "mediamtx-cleaner")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	err = os.Mkdir(filepath.Join(dir, "path1"), 0o755)
+	require.NoError(t, err)
+
+	// Age-expired (start before now-10s), then two recent ones totaling 8 bytes.
+	err = os.WriteFile(filepath.Join(dir, "path1", "2008-05-20_22-15-25-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-20_22-15-20-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+
+	c := &Cleaner{
+		PathConfs: map[string]*conf.Path{
+			"path1": {
+				Name:              "path1",
+				RecordPath:        filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
+				RecordFormat:      conf.RecordFormatFMP4,
+				RecordDeleteAfter: conf.Duration(10 * time.Second),
+			},
+		},
+		RecordDeleteMaxSize: 4,
+		Parent:              test.NilLogger,
+	}
+	c.Initialize()
+	defer c.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	_, err = os.Stat(filepath.Join(dir, "path1", "2008-05-20_22-15-25-000001.mp4"))
+	require.Error(t, err)
+	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-20_22-15-20-000001.mp4"))
+	require.Error(t, err)
+	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"))
+	require.NoError(t, err)
+}
+
+func TestCleanerMaxSizeOnly(t *testing.T) {
+	dir, err := os.MkdirTemp("", "mediamtx-cleaner")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	err = os.Mkdir(filepath.Join(dir, "path1"), 0o755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"), []byte{1, 2, 3, 4}, 0o644)
+	require.NoError(t, err)
+
+	c := &Cleaner{
+		PathConfs: map[string]*conf.Path{
+			"path1": {
+				Name:              "path1",
+				RecordPath:        filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
+				RecordFormat:      conf.RecordFormatFMP4,
+				RecordDeleteAfter: 0,
+			},
+		},
+		RecordDeleteMaxSize: 4,
+		Parent:              test.NilLogger,
+	}
+	c.Initialize()
+	defer c.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"))
+	require.Error(t, err)
+	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"))
+	require.NoError(t, err)
+}
+
+func TestCleanerMaxSizeProtectsNewest(t *testing.T) {
+	dir, err := os.MkdirTemp("", "mediamtx-cleaner")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	err = os.Mkdir(filepath.Join(dir, "path1"), 0o755)
+	require.NoError(t, err)
+
+	// Single path with one large newest segment that alone exceeds the limit.
+	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"), []byte{1, 2}, 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"), []byte{1, 2, 3, 4, 5, 6, 7, 8}, 0o644)
+	require.NoError(t, err)
+
+	c := &Cleaner{
+		PathConfs: map[string]*conf.Path{
+			"path1": {
+				Name:         "path1",
+				RecordPath:   filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
+				RecordFormat: conf.RecordFormatFMP4,
+			},
+		},
+		RecordDeleteMaxSize: 1,
+		Parent:              test.NilLogger,
+	}
+	c.Initialize()
+	defer c.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-19_22-15-25-000001.mp4"))
+	require.Error(t, err)
+	_, err = os.Stat(filepath.Join(dir, "path1", "2009-05-20_22-15-25-000001.mp4"))
 	require.NoError(t, err)
 }

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -240,6 +240,15 @@ playbackAllowOrigins: ["*"]
 playbackTrustedProxies: []
 
 ###############################################
+# Global settings -> Recording cleanup
+
+# Maximum total size of all recording segments across all paths.
+# When exceeded, the oldest completed segments are deleted until under the limit,
+# even if they have not yet reached recordDeleteAfter.
+# Set to 0 to disable size-based deletion.
+recordDeleteMaxSize: 0B
+
+###############################################
 # Global settings -> RTSP server
 
 # Enable the RTSP server, which allows to publish and read streams with the RTSP protocol.

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -245,7 +245,7 @@ playbackTrustedProxies: []
 # Maximum total size of all recording segments across all paths.
 # When exceeded, the oldest completed segments are deleted until under the limit,
 # even if they have not yet reached recordDeleteAfter.
-# Set to 0 to disable size-based deletion.
+# Set to 0B (or "0") to disable size-based deletion.
 recordDeleteMaxSize: 0B
 
 ###############################################


### PR DESCRIPTION
## Description

Adds a global `recordDeleteMaxSize` setting that caps total recording storage across all paths. When the limit is exceeded, the record cleaner deletes the oldest completed segments first, even if they have not yet reached `recordDeleteAfter`.

The newest segment of each path is never deleted (it may still be in progress). Age-based retention continues to run first; size eviction is a second pass. Set `recordDeleteMaxSize` to `0` / `0B` to disable.

## Testing

- `go test ./internal/recordcleaner/ ./internal/conf/`
- Unit coverage for over-quota eviction across paths, under-quota no-op, age+size, size-only mode, and newest-segment protection
