### PR TITLE
fix inability to read some AV1 streams with RTSP (#6001)

### DIFF
--- a/internal/servers/moq/server_test.go
+++ b/internal/servers/moq/server_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
-	mch264 "github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
 	"github.com/bluenviron/mediamtx/internal/auth"
 	"github.com/bluenviron/mediamtx/internal/conf"
 	"github.com/bluenviron/mediamtx/internal/defs"
@@ -449,7 +449,7 @@ func TestServer(t *testing.T) {
 			err = frameSG2.Read(frameStream2)
 			require.NoError(t, err)
 
-			expectedPayload, err2 := mch264.AVCC([][]byte{test.FormatH264.SPS, test.FormatH264.PPS, {5, 1}}).Marshal()
+			expectedPayload, err2 := h264.AVCC([][]byte{test.FormatH264.SPS, test.FormatH264.PPS, {5, 1}}).Marshal()
 			require.NoError(t, err2)
 			require.Equal(t, expectedPayload, frameSG.Objects[0].Payload)
 			require.Equal(t, expectedPayload, frameSG2.Objects[0].Payload)
@@ -473,7 +473,7 @@ func TestServer(t *testing.T) {
 			err = frameSG3.Read(frameStream3)
 			require.NoError(t, err)
 
-			expectedPayload2, err2 := mch264.AVCC([][]byte{test.FormatH264.SPS, test.FormatH264.PPS, {5, 2}}).Marshal()
+			expectedPayload2, err2 := h264.AVCC([][]byte{test.FormatH264.SPS, test.FormatH264.PPS, {5, 2}}).Marshal()
 			require.NoError(t, err2)
 			require.Equal(t, expectedPayload2, frameSG3.Objects[0].Payload)
 			require.Equal(t, uint64(3), frameSG3.Header.TrackAlias)

--- a/internal/stream/format_updater.go
+++ b/internal/stream/format_updater.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/format"
-	mch264 "github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
-	mch265 "github.com/bluenviron/mediacommon/v2/pkg/codecs/h265"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h265"
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/mpeg4video"
 	"github.com/bluenviron/mediamtx/internal/unit"
 )
@@ -20,22 +20,22 @@ func formatUpdaterH265(outFormat format.Format, payload unit.Payload, updateOutD
 	update := false
 
 	for _, nalu := range au {
-		typ := mch265.NALUType((nalu[0] >> 1) & 0b111111)
+		typ := h265.NALUType((nalu[0] >> 1) & 0b111111)
 
 		switch typ {
-		case mch265.NALUType_VPS_NUT:
+		case h265.NALUType_VPS_NUT:
 			if !bytes.Equal(nalu, formatH265.VPS) {
 				vps = nalu
 				update = true
 			}
 
-		case mch265.NALUType_SPS_NUT:
+		case h265.NALUType_SPS_NUT:
 			if !bytes.Equal(nalu, formatH265.SPS) {
 				sps = nalu
 				update = true
 			}
 
-		case mch265.NALUType_PPS_NUT:
+		case h265.NALUType_PPS_NUT:
 			if !bytes.Equal(nalu, formatH265.PPS) {
 				pps = nalu
 				update = true
@@ -60,16 +60,16 @@ func formatUpdaterH264(outFormat format.Format, payload unit.Payload, updateOutD
 	update := false
 
 	for _, nalu := range au {
-		typ := mch264.NALUType(nalu[0] & 0x1F)
+		typ := h264.NALUType(nalu[0] & 0x1F)
 
 		switch typ {
-		case mch264.NALUTypeSPS:
+		case h264.NALUTypeSPS:
 			if !bytes.Equal(nalu, sps) {
 				sps = nalu
 				update = true
 			}
 
-		case mch264.NALUTypePPS:
+		case h264.NALUTypePPS:
 			if !bytes.Equal(nalu, pps) {
 				pps = nalu
 				update = true

--- a/internal/stream/format_updater_test.go
+++ b/internal/stream/format_updater_test.go
@@ -1,0 +1,155 @@
+package stream_test
+
+import (
+	"testing"
+
+	"github.com/bluenviron/gortsplib/v5/pkg/description"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/bluenviron/mediamtx/internal/stream"
+	"github.com/bluenviron/mediamtx/internal/unit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatUpdater(t *testing.T) {
+	for _, ca := range []string{"h265", "h264", "mpeg4video"} {
+		t.Run(ca, func(t *testing.T) {
+			var forma format.Format
+			var u *unit.Unit
+
+			switch ca {
+			case "h265":
+				vps := []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xfe}
+				sps := []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x04}
+				pps := []byte{0x44, 0x01, 0xc1, 0x73, 0xd1, 0x8a}
+
+				forma = &format.H265{
+					VPS: []byte{0x40, 0x01, 0x0c},
+					SPS: []byte{0x42, 0x01, 0x01},
+					PPS: []byte{0x44, 0x01, 0xc1},
+				}
+
+				u = &unit.Unit{
+					PTS: 90000,
+					Payload: unit.PayloadH265{
+						vps,                      // New VPS
+						sps,                      // New SPS
+						pps,                      // New PPS
+						{0x26, 0x01, 0x01, 0x02}, // IDR
+					},
+				}
+
+			case "h264":
+				sps := []byte{
+					0x67, 0x64, 0x00, 0x20, 0xac, 0xd9, 0x40, 0x78,
+					0x02, 0x27, 0xe5, 0x9a, 0x80, 0x80, 0x80, 0xa0,
+				}
+				pps := []byte{0x08, 0x07, 0x08, 0x09}
+
+				forma = &format.H264{
+					PacketizationMode: 1,
+					SPS:               []byte{0x67, 0x42, 0xc0, 0x28},
+					PPS:               []byte{0x08, 0x06},
+				}
+
+				u = &unit.Unit{
+					PTS: 90000,
+					Payload: unit.PayloadH264{
+						sps,    // New SPS
+						pps,    // New PPS
+						{5, 1}, // IDR
+					},
+				}
+
+			case "mpeg4video":
+				config := []byte{
+					0x00, 0x00, 0x01, 0xb0, // Visual Object Sequence Start
+					0x02, 0x00, 0x00, 0x01, 0xb5, 0x8a,
+					0x14, 0x00, 0x00, 0x01, 0x00,
+				}
+
+				forma = &format.MPEG4Video{
+					Config: []byte{0x00, 0x00, 0x01, 0xb0, 0x01},
+				}
+
+				frame := make([]byte, 0, len(config)+20)
+				frame = append(frame, config...)
+				frame = append(frame, []byte{0x00, 0x00, 0x01, 0xb3}...) // Group of VOP
+				frame = append(frame, []byte{0x01, 0x02, 0x03, 0x04}...)
+
+				u = &unit.Unit{
+					PTS:     90000,
+					Payload: unit.PayloadMPEG4Video(frame),
+				}
+			}
+
+			media := &description.Media{
+				Type:    description.MediaTypeVideo,
+				Formats: []format.Format{forma},
+			}
+
+			desc := &description.Session{Medias: []*description.Media{media}}
+
+			strm := &stream.Stream{
+				OrigDesc:          desc,
+				WriteQueueSize:    512,
+				RTPMaxPayloadSize: 1450,
+			}
+			err := strm.Initialize()
+			require.NoError(t, err)
+			defer strm.Close()
+
+			subStream := &stream.SubStream{
+				Stream:        strm,
+				UseRTPPackets: false,
+			}
+			err = subStream.Initialize()
+			require.NoError(t, err)
+
+			r := &stream.Reader{}
+			recv := make(chan struct{})
+
+			r.OnData(media, forma, func(_ *unit.Unit) error {
+				close(recv)
+				return nil
+			})
+
+			strm.AddReader(r)
+			defer strm.RemoveReader(r)
+
+			subStream.WriteUnit(media, forma, u)
+
+			<-recv
+
+			outDesc := strm.OutDescCopy()
+
+			// Verify that format parameters were updated
+			switch ca {
+			case "h265":
+				require.Equal(t, &format.H265{
+					VPS: []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xfe},
+					SPS: []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x04},
+					PPS: []byte{0x44, 0x01, 0xc1, 0x73, 0xd1, 0x8a},
+				}, outDesc.Medias[0].Formats[0])
+
+			case "h264":
+				require.Equal(t, &format.H264{
+					SPS: []byte{
+						0x67, 0x64, 0x00, 0x20, 0xac, 0xd9, 0x40, 0x78,
+						0x02, 0x27, 0xe5, 0x9a, 0x80, 0x80, 0x80, 0xa0,
+					},
+					PPS:               []byte{0x08, 0x07, 0x08, 0x09},
+					PacketizationMode: 1,
+				}, outDesc.Medias[0].Formats[0])
+
+			case "mpeg4video":
+				require.Equal(t, &format.MPEG4Video{
+					Config: []byte{
+						0x00, 0x00, 0x01, 0xb0,
+						0x02, 0x00, 0x00, 0x01, 0xb5, 0x8a,
+						0x14, 0x00, 0x00, 0x01, 0x00,
+					},
+				}, outDesc.Medias[0].Formats[0])
+			}
+		})
+	}
+}

--- a/internal/stream/rtp_decoder_test.go
+++ b/internal/stream/rtp_decoder_test.go
@@ -1,382 +1,16 @@
-package stream
+package stream_test
 
 import (
 	"testing"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	"github.com/bluenviron/gortsplib/v5/pkg/format"
-	"github.com/bluenviron/mediamtx/internal/logger"
+	"github.com/bluenviron/mediamtx/internal/stream"
+	"github.com/bluenviron/mediamtx/internal/test"
 	"github.com/bluenviron/mediamtx/internal/unit"
 	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
 )
-
-type nilLogger struct{}
-
-func (nilLogger) Log(logger.Level, string, ...any) {
-}
-
-func TestStream(t *testing.T) {
-	desc := &description.Session{Medias: []*description.Media{
-		{
-			Type:    description.MediaTypeVideo,
-			Formats: []format.Format{&format.H264{PacketizationMode: 1}},
-		},
-		{
-			Type:    description.MediaTypeVideo,
-			Formats: []format.Format{&format.VP8{}},
-		},
-	}}
-
-	strm := &Stream{
-		OrigDesc:          desc,
-		WriteQueueSize:    512,
-		RTPMaxPayloadSize: 1450,
-	}
-	err := strm.Initialize()
-	require.NoError(t, err)
-	defer strm.Close()
-
-	subStream := &SubStream{
-		Stream:        strm,
-		UseRTPPackets: false,
-	}
-	err = subStream.Initialize()
-	require.NoError(t, err)
-
-	r := &Reader{}
-
-	recv := make(chan struct{})
-
-	r.OnData(desc.Medias[0], desc.Medias[0].Formats[0], func(_ *unit.Unit) error {
-		close(recv)
-		return nil
-	})
-
-	strm.AddReader(r)
-	defer strm.RemoveReader(r)
-
-	subStream.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], &unit.Unit{
-		PTS: 30000 * 2,
-		Payload: unit.PayloadH264{
-			{5, 2}, // IDR
-		},
-	})
-
-	<-recv
-
-	require.Equal(t, uint64(14), strm.InboundBytes())
-	require.Equal(t, uint64(14), strm.OutboundBytes())
-}
-
-func TestStreamSkipOutboundBytes(t *testing.T) {
-	desc := &description.Session{Medias: []*description.Media{
-		{
-			Type:    description.MediaTypeVideo,
-			Formats: []format.Format{&format.H264{PacketizationMode: 1}},
-		},
-		{
-			Type:    description.MediaTypeVideo,
-			Formats: []format.Format{&format.VP8{}},
-		},
-	}}
-
-	strm := &Stream{
-		OrigDesc:          desc,
-		WriteQueueSize:    512,
-		RTPMaxPayloadSize: 1450,
-	}
-	err := strm.Initialize()
-	require.NoError(t, err)
-	defer strm.Close()
-
-	subStream := &SubStream{
-		Stream:        strm,
-		UseRTPPackets: false,
-	}
-	err = subStream.Initialize()
-	require.NoError(t, err)
-
-	r := &Reader{
-		SkipOutboundBytes: true,
-	}
-
-	recv := make(chan struct{})
-
-	r.OnData(desc.Medias[0], desc.Medias[0].Formats[0], func(_ *unit.Unit) error {
-		close(recv)
-		return nil
-	})
-
-	strm.AddReader(r)
-	defer strm.RemoveReader(r)
-
-	subStream.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], &unit.Unit{
-		PTS: 30000 * 2,
-		Payload: unit.PayloadH264{
-			{5, 2}, // IDR
-		},
-	})
-
-	<-recv
-
-	require.Equal(t, uint64(14), strm.InboundBytes())
-	require.Equal(t, uint64(0), strm.OutboundBytes())
-}
-
-func TestStreamResizeOversizedRTPPackets(t *testing.T) {
-	desc := &description.Session{Medias: []*description.Media{
-		{
-			Type: description.MediaTypeVideo,
-			Formats: []format.Format{&format.H264{
-				PacketizationMode: 1,
-				SPS: []byte{ // 1920x1080 baseline
-					0x67, 0x42, 0xc0, 0x28, 0xd9, 0x00, 0x78, 0x02,
-					0x27, 0xe5, 0x84, 0x00, 0x00, 0x03, 0x00, 0x04,
-					0x00, 0x00, 0x03, 0x00, 0xf0, 0x3c, 0x60, 0xc9, 0x20,
-				},
-				PPS: []byte{0x08, 0x06, 0x07, 0x08},
-			}},
-		},
-	}}
-
-	strm := &Stream{
-		OrigDesc:          desc,
-		WriteQueueSize:    512,
-		RTPMaxPayloadSize: 400,
-		Parent:            &nilLogger{},
-	}
-	err := strm.Initialize()
-	require.NoError(t, err)
-	defer strm.Close()
-
-	subStream := &SubStream{
-		Stream:        strm,
-		UseRTPPackets: true,
-	}
-	err = subStream.Initialize()
-	require.NoError(t, err)
-
-	r := &Reader{}
-
-	recv := make(chan *unit.Unit)
-	n := 0
-
-	r.OnData(desc.Medias[0], desc.Medias[0].Formats[0], func(u *unit.Unit) error {
-		switch n {
-		case 0:
-		case 1:
-			recv <- u
-		default:
-			t.Error("should not happen")
-		}
-		n++
-		return nil
-	})
-
-	strm.AddReader(r)
-	defer strm.RemoveReader(r)
-
-	subStream.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], &unit.Unit{
-		PTS: 90000,
-		RTPPackets: []*rtp.Packet{
-			{
-				Header: rtp.Header{
-					Version:        2,
-					Marker:         true,
-					PayloadType:    96,
-					SequenceNumber: 122,
-					Timestamp:      45343,
-					SSRC:           563423,
-				},
-				Payload: []byte{1, 2, 3, 4},
-			},
-		},
-	})
-
-	oversizedPayload := make([]byte, 1000)
-	for i := range oversizedPayload {
-		oversizedPayload[i] = byte(i % 256)
-	}
-
-	subStream.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], &unit.Unit{
-		PTS: 90000,
-		RTPPackets: []*rtp.Packet{
-			{
-				Header: rtp.Header{
-					Version:        2,
-					Marker:         true,
-					PayloadType:    96,
-					SequenceNumber: 123,
-					Timestamp:      45343,
-					SSRC:           563423,
-				},
-				Payload: oversizedPayload,
-			},
-		},
-	})
-
-	received := <-recv
-
-	require.Equal(t, 3, len(received.RTPPackets))
-
-	for i, pkt := range received.RTPPackets {
-		require.Equal(t, 123+uint16(i), pkt.SequenceNumber)
-		require.Equal(t, uint32(45343), pkt.Timestamp)
-	}
-
-	totalPayloadSize := 0
-	for _, pkt := range received.RTPPackets {
-		require.LessOrEqual(t, len(pkt.Payload), 400)
-		totalPayloadSize += len(pkt.Payload)
-	}
-
-	require.Equal(t, 1005, totalPayloadSize)
-}
-
-func TestStreamUpdateFormatParams(t *testing.T) {
-	for _, ca := range []string{"h264", "h265", "mpeg4video"} {
-		t.Run(ca, func(t *testing.T) {
-			var forma format.Format
-			var u *unit.Unit
-
-			switch ca {
-			case "h264":
-				sps := []byte{
-					0x67, 0x64, 0x00, 0x20, 0xac, 0xd9, 0x40, 0x78,
-					0x02, 0x27, 0xe5, 0x9a, 0x80, 0x80, 0x80, 0xa0,
-				}
-				pps := []byte{0x08, 0x07, 0x08, 0x09}
-
-				forma = &format.H264{
-					PacketizationMode: 1,
-					SPS:               []byte{0x67, 0x42, 0xc0, 0x28},
-					PPS:               []byte{0x08, 0x06},
-				}
-
-				u = &unit.Unit{
-					PTS: 90000,
-					Payload: unit.PayloadH264{
-						sps,    // New SPS
-						pps,    // New PPS
-						{5, 1}, // IDR
-					},
-				}
-
-			case "h265":
-				vps := []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xfe}
-				sps := []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x04}
-				pps := []byte{0x44, 0x01, 0xc1, 0x73, 0xd1, 0x8a}
-
-				forma = &format.H265{
-					VPS: []byte{0x40, 0x01, 0x0c},
-					SPS: []byte{0x42, 0x01, 0x01},
-					PPS: []byte{0x44, 0x01, 0xc1},
-				}
-
-				u = &unit.Unit{
-					PTS: 90000,
-					Payload: unit.PayloadH265{
-						vps,                      // New VPS
-						sps,                      // New SPS
-						pps,                      // New PPS
-						{0x26, 0x01, 0x01, 0x02}, // IDR
-					},
-				}
-
-			case "mpeg4video":
-				config := []byte{
-					0x00, 0x00, 0x01, 0xb0, // Visual Object Sequence Start
-					0x02, 0x00, 0x00, 0x01, 0xb5, 0x8a,
-					0x14, 0x00, 0x00, 0x01, 0x00,
-				}
-
-				forma = &format.MPEG4Video{
-					Config: []byte{0x00, 0x00, 0x01, 0xb0, 0x01},
-				}
-
-				frame := make([]byte, 0, len(config)+20)
-				frame = append(frame, config...)
-				frame = append(frame, []byte{0x00, 0x00, 0x01, 0xb3}...) // Group of VOP
-				frame = append(frame, []byte{0x01, 0x02, 0x03, 0x04}...)
-
-				u = &unit.Unit{
-					PTS:     90000,
-					Payload: unit.PayloadMPEG4Video(frame),
-				}
-			}
-
-			media := &description.Media{
-				Type:    description.MediaTypeVideo,
-				Formats: []format.Format{forma},
-			}
-
-			desc := &description.Session{Medias: []*description.Media{media}}
-
-			strm := &Stream{
-				OrigDesc:          desc,
-				WriteQueueSize:    512,
-				RTPMaxPayloadSize: 1450,
-			}
-			err := strm.Initialize()
-			require.NoError(t, err)
-			defer strm.Close()
-
-			subStream := &SubStream{
-				Stream:        strm,
-				UseRTPPackets: false,
-			}
-			err = subStream.Initialize()
-			require.NoError(t, err)
-
-			r := &Reader{}
-			recv := make(chan struct{})
-
-			r.OnData(media, forma, func(_ *unit.Unit) error {
-				close(recv)
-				return nil
-			})
-
-			strm.AddReader(r)
-			defer strm.RemoveReader(r)
-
-			subStream.WriteUnit(media, forma, u)
-
-			<-recv
-
-			outDesc := strm.OutDescCopy()
-
-			// Verify that format parameters were updated
-			switch ca {
-			case "h264":
-				require.Equal(t, &format.H264{
-					SPS: []byte{
-						0x67, 0x64, 0x00, 0x20, 0xac, 0xd9, 0x40, 0x78,
-						0x02, 0x27, 0xe5, 0x9a, 0x80, 0x80, 0x80, 0xa0,
-					},
-					PPS:               []byte{0x08, 0x07, 0x08, 0x09},
-					PacketizationMode: 1,
-				}, outDesc.Medias[0].Formats[0])
-
-			case "h265":
-				require.Equal(t, &format.H265{
-					VPS: []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xfe},
-					SPS: []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x04},
-					PPS: []byte{0x44, 0x01, 0xc1, 0x73, 0xd1, 0x8a},
-				}, outDesc.Medias[0].Formats[0])
-
-			case "mpeg4video":
-				require.Equal(t, &format.MPEG4Video{
-					Config: []byte{
-						0x00, 0x00, 0x01, 0xb0,
-						0x02, 0x00, 0x00, 0x01, 0xb5, 0x8a,
-						0x14, 0x00, 0x00, 0x01, 0x00,
-					},
-				}, outDesc.Medias[0].Formats[0])
-			}
-		})
-	}
-}
 
 var casesDecodeEncode = []struct {
 	name    string
@@ -1208,31 +842,31 @@ var casesDecodeEncode = []struct {
 	},
 }
 
-func TestStreamDecode(t *testing.T) {
+func TestRTPDecoder(t *testing.T) {
 	for _, ca := range casesDecodeEncode {
 		t.Run(ca.name, func(t *testing.T) {
 			desc := &description.Session{Medias: []*description.Media{{
 				Formats: []format.Format{ca.format},
 			}}}
 
-			strm := &Stream{
+			strm := &stream.Stream{
 				OrigDesc:          desc,
 				WriteQueueSize:    512,
 				RTPMaxPayloadSize: 1450,
-				Parent:            &nilLogger{},
+				Parent:            test.NilLogger,
 			}
 			err := strm.Initialize()
 			require.NoError(t, err)
 			defer strm.Close()
 
-			subStream := &SubStream{
+			subStream := &stream.SubStream{
 				Stream:        strm,
 				UseRTPPackets: true,
 			}
 			err = subStream.Initialize()
 			require.NoError(t, err)
 
-			r := &Reader{}
+			r := &stream.Reader{}
 			recv := make(chan *unit.Unit)
 
 			r.OnData(desc.Medias[0], ca.format, func(u *unit.Unit) error {
@@ -1256,80 +890,4 @@ func TestStreamDecode(t *testing.T) {
 			require.Equal(t, ca.decoded, received.Payload)
 		})
 	}
-}
-
-func TestStreamEncode(t *testing.T) {
-	for _, ca := range casesDecodeEncode {
-		t.Run(ca.name, func(t *testing.T) {
-			desc := &description.Session{Medias: []*description.Media{{
-				Formats: []format.Format{ca.format},
-			}}}
-
-			strm := &Stream{
-				OrigDesc:          desc,
-				WriteQueueSize:    512,
-				RTPMaxPayloadSize: 1450,
-				Parent:            &nilLogger{},
-			}
-			err := strm.Initialize()
-			require.NoError(t, err)
-			defer strm.Close()
-
-			subStream := &SubStream{
-				Stream:        strm,
-				UseRTPPackets: false,
-			}
-			err = subStream.Initialize()
-			require.NoError(t, err)
-
-			r := &Reader{}
-			recv := make(chan struct{})
-
-			r.OnData(desc.Medias[0], ca.format, func(u *unit.Unit) error {
-				for i := range min(len(u.RTPPackets), len(ca.encoded)) {
-					u.RTPPackets[i].Timestamp = ca.encoded[i].Timestamp
-					u.RTPPackets[i].SequenceNumber = ca.encoded[i].SequenceNumber
-					u.RTPPackets[i].SSRC = ca.encoded[i].SSRC
-				}
-				require.Equal(t, ca.encoded, u.RTPPackets)
-				close(recv)
-				return nil
-			})
-
-			strm.AddReader(r)
-			defer strm.RemoveReader(r)
-
-			subStream.WriteUnit(desc.Medias[0], ca.format, &unit.Unit{
-				Payload: ca.decoded,
-			})
-
-			<-recv
-		})
-	}
-}
-
-func TestStreamUpgradeH264PacketizationMode(t *testing.T) {
-	forma := &format.H264{
-		PacketizationMode: 0,
-		SPS:               []byte{0x67, 0x42, 0xc0, 0x28},
-		PPS:               []byte{0x08, 0x06},
-	}
-
-	strm := &Stream{
-		OrigDesc:          &description.Session{Medias: []*description.Media{{Formats: []format.Format{forma}}}},
-		WriteQueueSize:    512,
-		RTPMaxPayloadSize: 1450,
-		Parent:            &nilLogger{},
-	}
-	err := strm.Initialize()
-	require.NoError(t, err)
-	defer strm.Close()
-
-	outDesc := strm.OutDescCopy()
-
-	require.Equal(t, &format.H264{
-		PacketizationMode: 1,
-		SPS:               []byte{0x67, 0x42, 0xc0, 0x28},
-		PPS:               []byte{0x08, 0x06},
-	}, outDesc.Medias[0].Formats[0])
 }

--- a/internal/stream/rtp_encoder_test.go
+++ b/internal/stream/rtp_encoder_test.go
@@ -1,0 +1,62 @@
+package stream_test
+
+import (
+	"testing"
+
+	"github.com/bluenviron/gortsplib/v5/pkg/description"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/bluenviron/mediamtx/internal/stream"
+	"github.com/bluenviron/mediamtx/internal/test"
+	"github.com/bluenviron/mediamtx/internal/unit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRTPEncoder(t *testing.T) {
+	for _, ca := range casesDecodeEncode {
+		t.Run(ca.name, func(t *testing.T) {
+			desc := &description.Session{Medias: []*description.Media{{
+				Formats: []format.Format{ca.format},
+			}}}
+
+			strm := &stream.Stream{
+				OrigDesc:          desc,
+				WriteQueueSize:    512,
+				RTPMaxPayloadSize: 1450,
+				Parent:            test.NilLogger,
+			}
+			err := strm.Initialize()
+			require.NoError(t, err)
+			defer strm.Close()
+
+			subStream := &stream.SubStream{
+				Stream:        strm,
+				UseRTPPackets: false,
+			}
+			err = subStream.Initialize()
+			require.NoError(t, err)
+
+			r := &stream.Reader{}
+			recv := make(chan struct{})
+
+			r.OnData(desc.Medias[0], ca.format, func(u *unit.Unit) error {
+				for i := range min(len(u.RTPPackets), len(ca.encoded)) {
+					u.RTPPackets[i].Timestamp = ca.encoded[i].Timestamp
+					u.RTPPackets[i].SequenceNumber = ca.encoded[i].SequenceNumber
+					u.RTPPackets[i].SSRC = ca.encoded[i].SSRC
+				}
+				require.Equal(t, ca.encoded, u.RTPPackets)
+				close(recv)
+				return nil
+			})
+
+			strm.AddReader(r)
+			defer strm.RemoveReader(r)
+
+			subStream.WriteUnit(desc.Medias[0], ca.format, &unit.Unit{
+				Payload: ca.decoded,
+			})
+
+			<-recv
+		})
+	}
+}

--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -12,9 +12,260 @@ import (
 	"github.com/bluenviron/mediacommon/v2/pkg/formats/mp4/codecs"
 	"github.com/bluenviron/mediacommon/v2/pkg/formats/pmp4"
 	"github.com/bluenviron/mediamtx/internal/conf"
+	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/unit"
+	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
 )
+
+type nilLogger struct{}
+
+func (nilLogger) Log(logger.Level, string, ...any) {
+}
+
+func TestStream(t *testing.T) {
+	desc := &description.Session{Medias: []*description.Media{
+		{
+			Type:    description.MediaTypeVideo,
+			Formats: []format.Format{&format.H264{PacketizationMode: 1}},
+		},
+		{
+			Type:    description.MediaTypeVideo,
+			Formats: []format.Format{&format.VP8{}},
+		},
+	}}
+
+	strm := &Stream{
+		OrigDesc:          desc,
+		WriteQueueSize:    512,
+		RTPMaxPayloadSize: 1450,
+	}
+	err := strm.Initialize()
+	require.NoError(t, err)
+	defer strm.Close()
+
+	subStream := &SubStream{
+		Stream:        strm,
+		UseRTPPackets: false,
+	}
+	err = subStream.Initialize()
+	require.NoError(t, err)
+
+	r := &Reader{}
+
+	recv := make(chan struct{})
+
+	r.OnData(desc.Medias[0], desc.Medias[0].Formats[0], func(_ *unit.Unit) error {
+		close(recv)
+		return nil
+	})
+
+	strm.AddReader(r)
+	defer strm.RemoveReader(r)
+
+	subStream.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], &unit.Unit{
+		PTS: 30000 * 2,
+		Payload: unit.PayloadH264{
+			{5, 2}, // IDR
+		},
+	})
+
+	<-recv
+
+	require.Equal(t, uint64(14), strm.InboundBytes())
+	require.Equal(t, uint64(14), strm.OutboundBytes())
+}
+
+func TestStreamSkipOutboundBytes(t *testing.T) {
+	desc := &description.Session{Medias: []*description.Media{
+		{
+			Type:    description.MediaTypeVideo,
+			Formats: []format.Format{&format.H264{PacketizationMode: 1}},
+		},
+		{
+			Type:    description.MediaTypeVideo,
+			Formats: []format.Format{&format.VP8{}},
+		},
+	}}
+
+	strm := &Stream{
+		OrigDesc:          desc,
+		WriteQueueSize:    512,
+		RTPMaxPayloadSize: 1450,
+	}
+	err := strm.Initialize()
+	require.NoError(t, err)
+	defer strm.Close()
+
+	subStream := &SubStream{
+		Stream:        strm,
+		UseRTPPackets: false,
+	}
+	err = subStream.Initialize()
+	require.NoError(t, err)
+
+	r := &Reader{
+		SkipOutboundBytes: true,
+	}
+
+	recv := make(chan struct{})
+
+	r.OnData(desc.Medias[0], desc.Medias[0].Formats[0], func(_ *unit.Unit) error {
+		close(recv)
+		return nil
+	})
+
+	strm.AddReader(r)
+	defer strm.RemoveReader(r)
+
+	subStream.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], &unit.Unit{
+		PTS: 30000 * 2,
+		Payload: unit.PayloadH264{
+			{5, 2}, // IDR
+		},
+	})
+
+	<-recv
+
+	require.Equal(t, uint64(14), strm.InboundBytes())
+	require.Equal(t, uint64(0), strm.OutboundBytes())
+}
+
+func TestStreamResizeOversizedRTPPackets(t *testing.T) {
+	desc := &description.Session{Medias: []*description.Media{
+		{
+			Type: description.MediaTypeVideo,
+			Formats: []format.Format{&format.H264{
+				PacketizationMode: 1,
+				SPS: []byte{ // 1920x1080 baseline
+					0x67, 0x42, 0xc0, 0x28, 0xd9, 0x00, 0x78, 0x02,
+					0x27, 0xe5, 0x84, 0x00, 0x00, 0x03, 0x00, 0x04,
+					0x00, 0x00, 0x03, 0x00, 0xf0, 0x3c, 0x60, 0xc9, 0x20,
+				},
+				PPS: []byte{0x08, 0x06, 0x07, 0x08},
+			}},
+		},
+	}}
+
+	strm := &Stream{
+		OrigDesc:          desc,
+		WriteQueueSize:    512,
+		RTPMaxPayloadSize: 400,
+		Parent:            &nilLogger{},
+	}
+	err := strm.Initialize()
+	require.NoError(t, err)
+	defer strm.Close()
+
+	subStream := &SubStream{
+		Stream:        strm,
+		UseRTPPackets: true,
+	}
+	err = subStream.Initialize()
+	require.NoError(t, err)
+
+	r := &Reader{}
+
+	recv := make(chan *unit.Unit)
+	n := 0
+
+	r.OnData(desc.Medias[0], desc.Medias[0].Formats[0], func(u *unit.Unit) error {
+		switch n {
+		case 0:
+		case 1:
+			recv <- u
+		default:
+			t.Error("should not happen")
+		}
+		n++
+		return nil
+	})
+
+	strm.AddReader(r)
+	defer strm.RemoveReader(r)
+
+	subStream.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], &unit.Unit{
+		PTS: 90000,
+		RTPPackets: []*rtp.Packet{
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    96,
+					SequenceNumber: 122,
+					Timestamp:      45343,
+					SSRC:           563423,
+				},
+				Payload: []byte{1, 2, 3, 4},
+			},
+		},
+	})
+
+	oversizedPayload := make([]byte, 1000)
+	for i := range oversizedPayload {
+		oversizedPayload[i] = byte(i % 256)
+	}
+
+	subStream.WriteUnit(desc.Medias[0], desc.Medias[0].Formats[0], &unit.Unit{
+		PTS: 90000,
+		RTPPackets: []*rtp.Packet{
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    96,
+					SequenceNumber: 123,
+					Timestamp:      45343,
+					SSRC:           563423,
+				},
+				Payload: oversizedPayload,
+			},
+		},
+	})
+
+	received := <-recv
+
+	require.Equal(t, 3, len(received.RTPPackets))
+
+	for i, pkt := range received.RTPPackets {
+		require.Equal(t, 123+uint16(i), pkt.SequenceNumber)
+		require.Equal(t, uint32(45343), pkt.Timestamp)
+	}
+
+	totalPayloadSize := 0
+	for _, pkt := range received.RTPPackets {
+		require.LessOrEqual(t, len(pkt.Payload), 400)
+		totalPayloadSize += len(pkt.Payload)
+	}
+
+	require.Equal(t, 1005, totalPayloadSize)
+}
+
+func TestStreamUpgradeH264PacketizationMode(t *testing.T) {
+	forma := &format.H264{
+		PacketizationMode: 0,
+		SPS:               []byte{0x67, 0x42, 0xc0, 0x28},
+		PPS:               []byte{0x08, 0x06},
+	}
+
+	strm := &Stream{
+		OrigDesc:          &description.Session{Medias: []*description.Media{{Formats: []format.Format{forma}}}},
+		WriteQueueSize:    512,
+		RTPMaxPayloadSize: 1450,
+		Parent:            &nilLogger{},
+	}
+	err := strm.Initialize()
+	require.NoError(t, err)
+	defer strm.Close()
+
+	outDesc := strm.OutDescCopy()
+
+	require.Equal(t, &format.H264{
+		PacketizationMode: 1,
+		SPS:               []byte{0x67, 0x42, 0xc0, 0x28},
+		PPS:               []byte{0x08, 0x06},
+	}, outDesc.Medias[0].Formats[0])
+}
 
 func TestStreamAlwaysAvailableErrors(t *testing.T) {
 	for _, ca := range []struct {

--- a/internal/stream/unit_remuxer.go
+++ b/internal/stream/unit_remuxer.go
@@ -4,13 +4,51 @@ import (
 	"bytes"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/format"
-	mch264 "github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
-	mch265 "github.com/bluenviron/mediacommon/v2/pkg/codecs/h265"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/av1"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h264"
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/h265"
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/mpeg4video"
 	"github.com/bluenviron/mediamtx/internal/unit"
 )
 
+// prototype of a function that remuxes a unit payload.
+// payload is assumed to be non-nil and to be of the same type as the format.
 type unitRemuxer func(format.Format, unit.Payload) unit.Payload
+
+func unitRemuxerAV1(_ format.Format, payload unit.Payload) unit.Payload {
+	tu := payload.(unit.PayloadAV1)
+
+	n := 0
+
+	for _, obu := range tu {
+		typ := av1.OBUType((obu[0] >> 3) & 0b1111)
+
+		if typ == av1.OBUTypeTemporalDelimiter {
+			continue
+		}
+		n++
+	}
+
+	if n == 0 {
+		return nil
+	}
+
+	filteredTU := make([][]byte, n)
+	i := 0
+
+	for _, obu := range tu {
+		typ := av1.OBUType((obu[0] >> 3) & 0b1111)
+
+		if typ == av1.OBUTypeTemporalDelimiter {
+			continue
+		}
+
+		filteredTU[i] = obu
+		i++
+	}
+
+	return unit.PayloadAV1(filteredTU)
+}
 
 func unitRemuxerH265(forma format.Format, payload unit.Payload) unit.Payload {
 	formatH265 := forma.(*format.H265)
@@ -20,16 +58,16 @@ func unitRemuxerH265(forma format.Format, payload unit.Payload) unit.Payload {
 	n := 0
 
 	for _, nalu := range au {
-		typ := mch265.NALUType((nalu[0] >> 1) & 0b111111)
+		typ := h265.NALUType((nalu[0] >> 1) & 0b111111)
 
 		switch typ {
-		case mch265.NALUType_VPS_NUT, mch265.NALUType_SPS_NUT, mch265.NALUType_PPS_NUT:
+		case h265.NALUType_VPS_NUT, h265.NALUType_SPS_NUT, h265.NALUType_PPS_NUT:
 			continue
 
-		case mch265.NALUType_AUD_NUT:
+		case h265.NALUType_AUD_NUT:
 			continue
 
-		case mch265.NALUType_IDR_W_RADL, mch265.NALUType_IDR_N_LP, mch265.NALUType_CRA_NUT:
+		case h265.NALUType_IDR_W_RADL, h265.NALUType_IDR_N_LP, h265.NALUType_CRA_NUT:
 			if !isKeyFrame {
 				isKeyFrame = true
 
@@ -57,13 +95,13 @@ func unitRemuxerH265(forma format.Format, payload unit.Payload) unit.Payload {
 	}
 
 	for _, nalu := range au {
-		typ := mch265.NALUType((nalu[0] >> 1) & 0b111111)
+		typ := h265.NALUType((nalu[0] >> 1) & 0b111111)
 
 		switch typ {
-		case mch265.NALUType_VPS_NUT, mch265.NALUType_SPS_NUT, mch265.NALUType_PPS_NUT:
+		case h265.NALUType_VPS_NUT, h265.NALUType_SPS_NUT, h265.NALUType_PPS_NUT:
 			continue
 
-		case mch265.NALUType_AUD_NUT:
+		case h265.NALUType_AUD_NUT:
 			continue
 		}
 
@@ -82,16 +120,16 @@ func unitRemuxerH264(forma format.Format, payload unit.Payload) unit.Payload {
 	n := 0
 
 	for _, nalu := range au {
-		typ := mch264.NALUType(nalu[0] & 0x1F)
+		typ := h264.NALUType(nalu[0] & 0x1F)
 
 		switch typ {
-		case mch264.NALUTypeSPS, mch264.NALUTypePPS:
+		case h264.NALUTypeSPS, h264.NALUTypePPS:
 			continue
 
-		case mch264.NALUTypeAccessUnitDelimiter:
+		case h264.NALUTypeAccessUnitDelimiter:
 			continue
 
-		case mch264.NALUTypeIDR:
+		case h264.NALUTypeIDR:
 			if !isKeyFrame {
 				isKeyFrame = true
 
@@ -118,13 +156,13 @@ func unitRemuxerH264(forma format.Format, payload unit.Payload) unit.Payload {
 	}
 
 	for _, nalu := range au {
-		typ := mch264.NALUType(nalu[0] & 0x1F)
+		typ := h264.NALUType(nalu[0] & 0x1F)
 
 		switch typ {
-		case mch264.NALUTypeSPS, mch264.NALUTypePPS:
+		case h264.NALUTypeSPS, h264.NALUTypePPS:
 			continue
 
-		case mch264.NALUTypeAccessUnitDelimiter:
+		case h264.NALUTypeAccessUnitDelimiter:
 			continue
 		}
 
@@ -164,6 +202,9 @@ func unitRemuxerMPEG4Video(forma format.Format, payload unit.Payload) unit.Paylo
 
 func newUnitRemuxer(forma format.Format) unitRemuxer {
 	switch forma.(type) {
+	case *format.AV1:
+		return unitRemuxerAV1
+
 	case *format.H265:
 		return unitRemuxerH265
 

--- a/internal/stream/unit_remuxer_test.go
+++ b/internal/stream/unit_remuxer_test.go
@@ -1,0 +1,132 @@
+package stream_test
+
+import (
+	"testing"
+
+	"github.com/bluenviron/gortsplib/v5/pkg/description"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/bluenviron/mediamtx/internal/stream"
+	"github.com/bluenviron/mediamtx/internal/unit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitRemuxer(t *testing.T) {
+	for _, ca := range []string{
+		"av1",
+		"h265",
+		"h264",
+		"mpeg4video",
+	} {
+		t.Run(ca, func(t *testing.T) {
+			var forma format.Format
+			var inputPayload unit.Payload
+			var expectedPayload unit.Payload
+
+			switch ca {
+			case "av1":
+				forma = &format.AV1{}
+				inputPayload = unit.PayloadAV1{
+					{0x10},       // Temporal Delimiter
+					{0x08, 0x01}, // Sequence Header
+					{0x10},       // Temporal Delimiter
+				}
+				expectedPayload = unit.PayloadAV1{{0x08, 0x01}}
+
+			case "h265":
+				vps := []byte{0x40, 0x01, 0x0c}
+				sps := []byte{0x42, 0x01, 0x01}
+				pps := []byte{0x44, 0x01, 0xc1}
+
+				forma = &format.H265{
+					VPS: vps,
+					SPS: sps,
+					PPS: pps,
+				}
+				inputPayload = unit.PayloadH265{
+					vps,
+					sps,
+					pps,
+					{0x46, 0x01}, // AUD
+					{0x26, 0x01}, // IDR
+				}
+				expectedPayload = unit.PayloadH265{
+					vps,
+					sps,
+					pps,
+					{0x26, 0x01},
+				}
+
+			case "h264":
+				sps := []byte{0x67, 0x64, 0x00, 0x20}
+				pps := []byte{0x68, 0xee, 0x3c, 0x80}
+
+				forma = &format.H264{
+					PacketizationMode: 1,
+					SPS:               sps,
+					PPS:               pps,
+				}
+				inputPayload = unit.PayloadH264{
+					sps,
+					pps,
+					{0x09, 0xf0}, // AUD
+					{0x65, 0x01}, // IDR
+				}
+				expectedPayload = unit.PayloadH264{
+					sps,
+					pps,
+					{0x65, 0x01},
+				}
+
+			case "mpeg4video":
+				config := []byte{0x00, 0x00, 0x01, 0xb0, 0x01}
+				frame := []byte{0x00, 0x00, 0x01, 0xb3, 0x11, 0x22}
+
+				forma = &format.MPEG4Video{Config: config}
+				inputPayload = unit.PayloadMPEG4Video(frame)
+				expectedPayload = unit.PayloadMPEG4Video(append(append([]byte{}, config...), frame...))
+			}
+
+			media := &description.Media{
+				Type:    description.MediaTypeVideo,
+				Formats: []format.Format{forma},
+			}
+
+			desc := &description.Session{Medias: []*description.Media{media}}
+
+			strm := &stream.Stream{
+				OrigDesc:          desc,
+				WriteQueueSize:    512,
+				RTPMaxPayloadSize: 1450,
+			}
+			err := strm.Initialize()
+			require.NoError(t, err)
+			defer strm.Close()
+
+			subStream := &stream.SubStream{
+				Stream:        strm,
+				UseRTPPackets: false,
+			}
+			err = subStream.Initialize()
+			require.NoError(t, err)
+
+			r := &stream.Reader{}
+			recv := make(chan *unit.Unit, 1)
+
+			r.OnData(media, forma, func(u *unit.Unit) error {
+				recv <- u
+				return nil
+			})
+
+			strm.AddReader(r)
+			defer strm.RemoveReader(r)
+
+			subStream.WriteUnit(media, forma, &unit.Unit{
+				PTS:     90000,
+				Payload: inputPayload,
+			})
+
+			received := <-recv
+			require.Equal(t, expectedPayload, received.Payload)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #6001

Since v1.16.0, temporal unit delimiters were not stripped anymore from AV1 streams. This has been restored, healing AV1 streams read with RTSP.