### PR TITLE
recorder: optionally end fMP4 parts at video random access points

### DIFF
--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -227,14 +227,15 @@ type Path struct {
 	AlwaysAvailableFile   string                 `json:"alwaysAvailableFile"`
 
 	// Record
-	Record                bool         `json:"record"`
-	Playback              *bool        `json:"playback,omitempty" deprecated:"true"`
-	RecordPath            string       `json:"recordPath"`
-	RecordFormat          RecordFormat `json:"recordFormat"`
-	RecordPartDuration    Duration     `json:"recordPartDuration"`
-	RecordMaxPartSize     StringSize   `json:"recordMaxPartSize"`
-	RecordSegmentDuration Duration     `json:"recordSegmentDuration"`
-	RecordDeleteAfter     Duration     `json:"recordDeleteAfter"`
+	Record                    bool         `json:"record"`
+	Playback                  *bool        `json:"playback,omitempty" deprecated:"true"`
+	RecordPath                string       `json:"recordPath"`
+	RecordFormat              RecordFormat `json:"recordFormat"`
+	RecordPartDuration        Duration     `json:"recordPartDuration"`
+	RecordPartAlignToKeyframe bool         `json:"recordPartAlignToKeyframe"`
+	RecordMaxPartSize         StringSize   `json:"recordMaxPartSize"`
+	RecordSegmentDuration     Duration     `json:"recordSegmentDuration"`
+	RecordDeleteAfter         Duration     `json:"recordDeleteAfter"`
 
 	// Authentication (deprecated)
 	PublishUser *Credential `json:"publishUser,omitempty" deprecated:"true"`
@@ -367,6 +368,7 @@ func (pconf *Path) setDefaults() {
 	pconf.RecordPath = "./recordings/%path/%Y-%m-%d_%H-%M-%S-%f"
 	pconf.RecordFormat = RecordFormatFMP4
 	pconf.RecordPartDuration = Duration(1 * time.Second)
+	pconf.RecordPartAlignToKeyframe = false
 	pconf.RecordMaxPartSize = 50 * 1024 * 1024
 	pconf.RecordSegmentDuration = 3600 * Duration(time.Second)
 	pconf.RecordDeleteAfter = 24 * 3600 * Duration(time.Second)

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -403,6 +403,7 @@ func (pa *path) doReloadConf(newConf *conf.Path) {
 			newConf.RecordPath != oldConf.RecordPath ||
 			newConf.RecordFormat != oldConf.RecordFormat ||
 			newConf.RecordPartDuration != oldConf.RecordPartDuration ||
+			newConf.RecordPartAlignToKeyframe != oldConf.RecordPartAlignToKeyframe ||
 			newConf.RecordMaxPartSize != oldConf.RecordMaxPartSize ||
 			newConf.RecordSegmentDuration != oldConf.RecordSegmentDuration ||
 			newConf.RecordDeleteAfter != oldConf.RecordDeleteAfter) {
@@ -943,13 +944,14 @@ func (pa *path) setNotAvailable() {
 
 func (pa *path) startRecording() {
 	pa.recorder = &recorder.Recorder{
-		PathFormat:      pa.conf.RecordPath,
-		Format:          pa.conf.RecordFormat,
-		PartDuration:    time.Duration(pa.conf.RecordPartDuration),
-		MaxPartSize:     pa.conf.RecordMaxPartSize,
-		SegmentDuration: time.Duration(pa.conf.RecordSegmentDuration),
-		PathName:        pa.name,
-		Stream:          pa.stream,
+		PathFormat:          pa.conf.RecordPath,
+		Format:              pa.conf.RecordFormat,
+		PartDuration:        time.Duration(pa.conf.RecordPartDuration),
+		PartAlignToKeyframe: pa.conf.RecordPartAlignToKeyframe,
+		MaxPartSize:         pa.conf.RecordMaxPartSize,
+		SegmentDuration:     time.Duration(pa.conf.RecordSegmentDuration),
+		PathName:            pa.name,
+		Stream:              pa.stream,
 		OnSegmentCreate: func(segmentPath string) {
 			if pa.conf.RunOnRecordSegmentCreate != "" {
 				env := pa.ExternalCmdEnv()

--- a/internal/recorder/format_fmp4_align_test.go
+++ b/internal/recorder/format_fmp4_align_test.go
@@ -1,0 +1,239 @@
+package recorder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bluenviron/mediacommon/v2/pkg/codecs/mpeg4audio"
+	"github.com/bluenviron/mediacommon/v2/pkg/formats/fmp4"
+	mcodecs "github.com/bluenviron/mediacommon/v2/pkg/formats/mp4/codecs"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bluenviron/mediamtx/internal/conf"
+	"github.com/bluenviron/mediamtx/internal/test"
+)
+
+// These tests drive the segment directly rather than a whole stream.
+//
+// What changed is where a part ends, and that decision is made from a sample's
+// flags and the part's duration and size — nothing else. Feeding it a stream
+// would mean synthesising a decodable H.264 bitstream, and the test would then
+// be exercising the codec parsers rather than the boundary rule.
+
+// alignFixture is a segment writing to a real file, which is what
+// closeCurPart needs.
+type alignFixture struct {
+	segment *formatFMP4Segment
+	video   *formatFMP4Track
+	audio   *formatFMP4Track
+	path    string
+}
+
+func newAlignFixture(t *testing.T, align bool, partDuration time.Duration,
+	maxPartSize conf.StringSize, withAudio bool,
+) *alignFixture {
+	t.Helper()
+
+	instance := &recorderInstance{
+		partDuration:        partDuration,
+		partAlignToKeyframe: align,
+		maxPartSize:         maxPartSize,
+		parent:              &Recorder{Parent: test.NilLogger},
+	}
+
+	format := &formatFMP4{ri: instance}
+	video := &formatFMP4Track{
+		f: format, id: 1, clockRate: 90000,
+		initTrack: &fmp4.InitTrack{
+			ID: 1, TimeScale: 90000,
+			Codec: &mcodecs.H264{SPS: test.FormatH264.SPS, PPS: test.FormatH264.PPS},
+		},
+	}
+	format.tracks = []*formatFMP4Track{video}
+	format.hasVideo = true
+
+	var audio *formatFMP4Track
+	if withAudio {
+		audio = &formatFMP4Track{
+			f: format, id: 2, clockRate: 44100,
+			initTrack: &fmp4.InitTrack{
+				ID: 2, TimeScale: 44100,
+				Codec: &mcodecs.MPEG4Audio{Config: mpeg4audio.AudioSpecificConfig{
+					Type: 2, SampleRate: 44100, ChannelCount: 2,
+				}},
+			},
+		}
+		format.tracks = append(format.tracks, audio)
+	}
+
+	path := filepath.Join(t.TempDir(), "segment.mp4")
+	file, err := os.Create(path) //nolint:gosec // a test file in a temp dir.
+	require.NoError(t, err)
+	t.Cleanup(func() { file.Close() })
+
+	segment := &formatFMP4Segment{f: format, startDTS: 0, fi: file}
+	segment.initialize()
+
+	return &alignFixture{segment: segment, video: video, audio: audio, path: path}
+}
+
+// write feeds one sample. payload size is what the size limit is measured in.
+func (f *alignFixture) write(
+	t *testing.T, track *formatFMP4Track, dts time.Duration, keyframe bool, payload int,
+) {
+	t.Helper()
+
+	sample := &formatFMP4Sample{
+		Sample: &fmp4.Sample{
+			Duration:        uint32(40 * int(track.initTrack.TimeScale) / 1000),
+			IsNonSyncSample: !keyframe,
+			Payload:         make([]byte, payload),
+		},
+		dts: int64(dts) * int64(track.initTrack.TimeScale) / int64(time.Second),
+		ntp: time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC).Add(dts),
+	}
+	require.NoError(t, f.segment.write(track, sample, dts))
+}
+
+// parts is how many parts the segment has produced so far, including the open
+// one.
+func (f *alignFixture) parts() uint32 { return f.segment.nextPartNumber }
+
+// videoStream feeds frames at 40 ms with an IDR every gop frames.
+func (f *alignFixture) videoStream(t *testing.T, frames, gop, payload int) {
+	t.Helper()
+
+	for i := range frames {
+		f.write(t, f.video, time.Duration(i)*40*time.Millisecond, i%gop == 0, payload)
+	}
+}
+
+// Without the option a part ends as soon as it has lasted long enough, wherever
+// that falls. This is the behaviour every existing deployment relies on, and the
+// option must not change it.
+func TestPartsAreNotAlignedByDefault(t *testing.T) {
+	f := newAlignFixture(t, false, 200*time.Millisecond, 50*1024*1024, false)
+
+	// 25 frames of 40 ms is one second, with a keyframe only at the start.
+	f.videoStream(t, 25, 25, 100)
+
+	// Five parts of 200 ms, and only the first can start at a keyframe.
+	require.Equal(t, uint32(5), f.parts())
+}
+
+// With the option a part ends only before a sample decoding can start from, so
+// every part is independently decodable. This is the whole purpose.
+func TestPartsEndOnlyAtKeyframesWhenAligned(t *testing.T) {
+	f := newAlignFixture(t, true, 200*time.Millisecond, 50*1024*1024, false)
+
+	// Four seconds at a one-second GOP.
+	f.videoStream(t, 100, 25, 100)
+
+	// One part per GOP: the timer wants a cut every 200 ms and gets one every
+	// second, when the next keyframe arrives.
+	require.Equal(t, uint32(4), f.parts())
+}
+
+// The requested duration becomes a minimum rather than a target. A part runs to
+// the first random access point at or after it, so its length follows the
+// keyframe interval — the cost of alignment, and it has to be visible rather
+// than surprising.
+func TestPartDurationBecomesAMinimumWhenAligned(t *testing.T) {
+	// A GOP of two seconds against a requested part of 200 ms.
+	f := newAlignFixture(t, true, 200*time.Millisecond, 50*1024*1024, false)
+	f.videoStream(t, 200, 50, 100)
+
+	// Eight seconds at a two-second GOP is four parts, not forty.
+	require.Equal(t, uint32(4), f.parts())
+}
+
+// A keyframe arriving before the part has lasted long enough does not end it:
+// alignment narrows where a part may end, it does not make every keyframe a
+// boundary. Otherwise a stream with a short GOP would produce a part per GOP
+// regardless of the configured duration.
+func TestAKeyframeDoesNotEndAShortPart(t *testing.T) {
+	f := newAlignFixture(t, true, 1*time.Second, 50*1024*1024, false)
+
+	// A keyframe every 200 ms against a requested part of one second.
+	f.videoStream(t, 100, 5, 100)
+
+	// Four seconds, so four parts — each ending at the first keyframe at or
+	// after one second, not at every keyframe.
+	require.Equal(t, uint32(4), f.parts())
+}
+
+// A stream with no video has no random access points to align to. Refusing to
+// cut would mean never cutting: the recording would grow into a single part
+// until it hit the size limit.
+func TestAudioOnlyStreamsStillCutParts(t *testing.T) {
+	f := newAlignFixture(t, true, 200*time.Millisecond, 50*1024*1024, true)
+	f.segment.f.hasVideo = false
+
+	for i := range 100 {
+		f.write(t, f.audio, time.Duration(i)*40*time.Millisecond, false, 100)
+	}
+
+	require.Equal(t, uint32(20), f.parts())
+}
+
+// An audio sample must not end a part in a stream that has video. Cutting there
+// would start the next part with a video sample that is not a random access
+// point, which is exactly what alignment exists to prevent.
+func TestAudioSamplesDoNotEndAPartInAVideoStream(t *testing.T) {
+	f := newAlignFixture(t, true, 200*time.Millisecond, 50*1024*1024, true)
+
+	// Audio arriving between video frames, with the video GOP at one second.
+	for i := range 100 {
+		dts := time.Duration(i) * 40 * time.Millisecond
+		f.write(t, f.video, dts, i%25 == 0, 100)
+		f.write(t, f.audio, dts, false, 20)
+	}
+
+	// Still one part per GOP: the audio samples changed nothing.
+	require.Equal(t, uint32(4), f.parts())
+}
+
+// A camera that stops emitting keyframes must keep recording. The part is ended
+// where the size limit falls, which produces one fragment that does not start
+// at a random access point — visible to a reader in the sample flags — and that
+// is far better than the recording stopping, which is what returning an error
+// here would do.
+func TestAStreamWithoutKeyframesKeepsRecording(t *testing.T) {
+	f := newAlignFixture(t, true, 200*time.Millisecond, 4096, false)
+
+	// One keyframe at the start and nothing after it, with payloads big enough
+	// to reach the limit.
+	f.videoStream(t, 100, 1000, 512)
+
+	require.Greater(t, f.parts(), uint32(1),
+		"a stream with no keyframes produced one part; the size limit did not end it")
+}
+
+// And the same stream without alignment must still fail on the size limit,
+// because that is the guard against unbounded memory and this change does not
+// remove it.
+func TestTheSizeLimitStillFailsWithoutAlignment(t *testing.T) {
+	f := newAlignFixture(t, false, 1*time.Hour, 4096, false)
+
+	// A part that can never end on duration, so only the limit can stop it.
+	var err error
+	for i := range 100 {
+		sample := &formatFMP4Sample{
+			Sample: &fmp4.Sample{
+				Duration:        3600,
+				IsNonSyncSample: i != 0,
+				Payload:         make([]byte, 512),
+			},
+			dts: int64(i) * 3600,
+			ntp: time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+		}
+		if err = f.segment.write(f.video, sample, time.Duration(i)*40*time.Millisecond); err != nil {
+			break
+		}
+	}
+
+	require.Error(t, err, "the size limit stopped guarding against an unbounded part")
+	require.Contains(t, err.Error(), "maximum part size")
+}

--- a/internal/recorder/format_fmp4_part.go
+++ b/internal/recorder/format_fmp4_part.go
@@ -56,6 +56,16 @@ func (p *formatFMP4Part) close(w io.Writer) error {
 	return writePart(w, p.number, p.partTracks)
 }
 
+// full reports whether adding this sample would take the part over its size
+// limit.
+//
+// Asked before writing rather than discovered during it, so a caller that has a
+// choice about where to end the part can act on it. write() still refuses an
+// oversized sample, which is what happens when there is no choice.
+func (p *formatFMP4Part) full(sample *formatFMP4Sample) bool {
+	return (p.size + uint64(len(sample.Payload))) > uint64(p.maxPartSize)
+}
+
 func (p *formatFMP4Part) write(track *formatFMP4Track, sample *formatFMP4Sample, dts time.Duration) error {
 	size := uint64(len(sample.Payload))
 	if (p.size + size) > uint64(p.maxPartSize) {

--- a/internal/recorder/format_fmp4_segment.go
+++ b/internal/recorder/format_fmp4_segment.go
@@ -206,16 +206,12 @@ func (s *formatFMP4Segment) write(track *formatFMP4Track, sample *formatFMP4Samp
 		s.endDTS = endDTS
 	}
 
-	if s.curPart == nil {
-		s.curPart = &formatFMP4Part{
-			maxPartSize:     s.f.ri.maxPartSize,
-			segmentStartDTS: s.startDTS,
-			number:          s.nextPartNumber,
-			startDTS:        dts,
-		}
-		s.curPart.initialize()
-		s.nextPartNumber++
-	} else if s.curPart.duration() >= s.f.ri.partDuration {
+	switch {
+	case s.curPart == nil:
+		s.startPart(dts)
+
+	// The part has lasted long enough and may end here.
+	case s.curPart.duration() >= s.f.ri.partDuration && s.partMayEndBefore(track, sample):
 		err := s.closeCurPart()
 		s.curPart = nil
 
@@ -223,15 +219,53 @@ func (s *formatFMP4Segment) write(track *formatFMP4Track, sample *formatFMP4Samp
 			return err
 		}
 
-		s.curPart = &formatFMP4Part{
-			maxPartSize:     s.f.ri.maxPartSize,
-			segmentStartDTS: s.startDTS,
-			number:          s.nextPartNumber,
-			startDTS:        dts,
+		s.startPart(dts)
+
+	// Waiting for a random access point that has not come, and the part cannot
+	// hold another sample. Ending it here produces a part that does not start
+	// at a keyframe, which a reader can detect from the sample flags; not
+	// ending it would fail the write and stop the recording, which is worse by
+	// a long way. Only reachable when alignment is on: without it the part
+	// would already have been closed on duration.
+	case s.f.ri.partAlignToKeyframe && s.curPart.full(sample):
+		err := s.closeCurPart()
+		s.curPart = nil
+
+		if err != nil {
+			return err
 		}
-		s.curPart.initialize()
-		s.nextPartNumber++
+
+		s.startPart(dts)
 	}
 
 	return s.curPart.write(track, sample, dts)
+}
+
+// partMayEndBefore reports whether the current part may end just before this
+// sample.
+//
+// Without alignment, anywhere: the part is a delivery unit and its boundaries
+// carry no meaning for a decoder. With it, only before a sample decoding can
+// start from — which makes every part independently decodable and is the same
+// condition this file's caller already applies when it closes a segment.
+//
+// A stream with no video has no such samples, so every boundary is allowed:
+// audio frames are all random access points, and refusing to cut would mean
+// never cutting at all.
+func (s *formatFMP4Segment) partMayEndBefore(track *formatFMP4Track, sample *formatFMP4Sample) bool {
+	if !s.f.ri.partAlignToKeyframe || !s.f.hasVideo {
+		return true
+	}
+	return track.initTrack.Codec.IsVideo() && !sample.IsNonSyncSample
+}
+
+func (s *formatFMP4Segment) startPart(dts time.Duration) {
+	s.curPart = &formatFMP4Part{
+		maxPartSize:     s.f.ri.maxPartSize,
+		segmentStartDTS: s.startDTS,
+		number:          s.nextPartNumber,
+		startDTS:        dts,
+	}
+	s.curPart.initialize()
+	s.nextPartNumber++
 }

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -21,16 +21,17 @@ type OnSegmentCompleteFunc = func(path string, duration time.Duration)
 
 // Recorder writes recordings to disk.
 type Recorder struct {
-	PathFormat        string
-	Format            conf.RecordFormat
-	PartDuration      time.Duration
-	MaxPartSize       conf.StringSize
-	SegmentDuration   time.Duration
-	PathName          string
-	Stream            *stream.Stream
-	OnSegmentCreate   OnSegmentCreateFunc
-	OnSegmentComplete OnSegmentCompleteFunc
-	Parent            logger.Writer
+	PathFormat          string
+	Format              conf.RecordFormat
+	PartDuration        time.Duration
+	PartAlignToKeyframe bool
+	MaxPartSize         conf.StringSize
+	SegmentDuration     time.Duration
+	PathName            string
+	Stream              *stream.Stream
+	OnSegmentCreate     OnSegmentCreateFunc
+	OnSegmentComplete   OnSegmentCompleteFunc
+	Parent              logger.Writer
 
 	restartPause time.Duration
 
@@ -58,16 +59,17 @@ func (r *Recorder) Initialize() {
 	r.done = make(chan struct{})
 
 	r.currentInstance = &recorderInstance{
-		pathFormat:        r.PathFormat,
-		format:            r.Format,
-		partDuration:      r.PartDuration,
-		maxPartSize:       r.MaxPartSize,
-		segmentDuration:   r.SegmentDuration,
-		pathName:          r.PathName,
-		stream:            r.Stream,
-		onSegmentCreate:   r.OnSegmentCreate,
-		onSegmentComplete: r.OnSegmentComplete,
-		parent:            r,
+		pathFormat:          r.PathFormat,
+		format:              r.Format,
+		partDuration:        r.PartDuration,
+		partAlignToKeyframe: r.PartAlignToKeyframe,
+		maxPartSize:         r.MaxPartSize,
+		segmentDuration:     r.SegmentDuration,
+		pathName:            r.PathName,
+		stream:              r.Stream,
+		onSegmentCreate:     r.OnSegmentCreate,
+		onSegmentComplete:   r.OnSegmentComplete,
+		parent:              r,
 	}
 	r.currentInstance.initialize()
 
@@ -105,16 +107,17 @@ func (r *Recorder) run() {
 		}
 
 		r.currentInstance = &recorderInstance{
-			pathFormat:        r.PathFormat,
-			format:            r.Format,
-			partDuration:      r.PartDuration,
-			maxPartSize:       r.MaxPartSize,
-			segmentDuration:   r.SegmentDuration,
-			pathName:          r.PathName,
-			stream:            r.Stream,
-			onSegmentCreate:   r.OnSegmentCreate,
-			onSegmentComplete: r.OnSegmentComplete,
-			parent:            r,
+			pathFormat:          r.PathFormat,
+			format:              r.Format,
+			partDuration:        r.PartDuration,
+			partAlignToKeyframe: r.PartAlignToKeyframe,
+			maxPartSize:         r.MaxPartSize,
+			segmentDuration:     r.SegmentDuration,
+			pathName:            r.PathName,
+			stream:              r.Stream,
+			onSegmentCreate:     r.OnSegmentCreate,
+			onSegmentComplete:   r.OnSegmentComplete,
+			parent:              r,
 		}
 		r.currentInstance.initialize()
 	}

--- a/internal/recorder/recorder_instance.go
+++ b/internal/recorder/recorder_instance.go
@@ -13,16 +13,17 @@ import (
 )
 
 type recorderInstance struct {
-	pathFormat        string
-	format            conf.RecordFormat
-	partDuration      time.Duration
-	maxPartSize       conf.StringSize
-	segmentDuration   time.Duration
-	pathName          string
-	stream            *stream.Stream
-	onSegmentCreate   OnSegmentCreateFunc
-	onSegmentComplete OnSegmentCompleteFunc
-	parent            logger.Writer
+	pathFormat          string
+	format              conf.RecordFormat
+	partDuration        time.Duration
+	partAlignToKeyframe bool
+	maxPartSize         conf.StringSize
+	segmentDuration     time.Duration
+	pathName            string
+	stream              *stream.Stream
+	onSegmentCreate     OnSegmentCreateFunc
+	onSegmentComplete   OnSegmentCompleteFunc
+	parent              logger.Writer
 
 	streamID    uuid.UUID
 	pathFormat2 string

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -553,6 +553,18 @@ pathDefaults:
   # When a system failure occurs, the last part gets lost.
   # Therefore, the part duration is equal to the RPO (recovery point objective).
   recordPartDuration: 1s
+  # End each fMP4 part at a video random access point, so that every part can be
+  # decoded on its own.
+  # This makes parts usable as independent segments, for instance when serving a
+  # recording as HLS byte ranges, and lets a seek index reference one part per
+  # entry.
+  # recordPartDuration then acts as a minimum: a part lasts until the first
+  # random access point at or after it, so the effective duration follows the
+  # keyframe interval of the stream.
+  # A part that reaches recordMaxPartSize before a random access point arrives is
+  # ended anyway, and does not start at one.
+  # Has no effect on streams without video.
+  recordPartAlignToKeyframe: no
   # This prevents RAM exhaustion.
   recordMaxPartSize: 50M
   # Minimum duration of each segment.


### PR DESCRIPTION
## Problem

An fMP4 part is ended by a timer, with no check on what the next sample is:

```go
} else if s.curPart.duration() >= s.f.ri.partDuration {
```

So a part usually begins in the middle of a GOP and cannot be decoded on its own. Measured on a ten-minute recording of a 2-second-GOP H.265 camera with `recordPartDuration: 4s`: **1 of 105 fragments began at a random access point**. ffprobe reported keyframes every 2 seconds at ticks 92300, 272300, 452300 while fragment boundaries fell at 92300, 355100 — they coincide only at the start of the segment.

That is fine when a part is only a delivery unit and the recording is played back as a whole file. It is a problem when a part has to stand alone: serving a recording as HLS or DASH segments by byte range, or referencing one part per entry in a seek index.

The segment logic one level up already gets this right — `format_fmp4_track.go` will not close a segment unless the next sample is a sync sample. The part logic simply does not apply the same rule.

## Change

`recordPartAlignToKeyframe` (default `no`, so nothing changes unless it is turned on) ends a part only before a sample that decoding can start from:

```go
case s.curPart.duration() >= s.f.ri.partDuration && s.partMayEndBefore(track, sample):
```

`recordPartDuration` then acts as a minimum: a part runs to the first random access point at or after it, so its effective length follows the keyframe interval of the stream. Streams without video are unaffected — they have no such samples, so every boundary stays allowed, or a part would never end at all.

A part that reaches `recordMaxPartSize` before a random access point arrives is ended anyway. Without that, a source that stopped emitting keyframes would grow one part until the size check failed the write, and that error removes the reader and stops the recording. Ending the part instead produces a single fragment that does not begin at a random access point, which a reader can detect from the sample flags. The failure stays in place when alignment is off, where it is still the only guard against an unbounded part.

## Tests

`internal/recorder/format_fmp4_align_test.go` drives the segment directly, since what changed is a boundary rule decided from sample flags and the part's duration and size:

- both modes, so the default is pinned as unchanged
- the duration becoming a minimum
- a keyframe arriving before the part has lasted long enough does not end it
- audio-only streams still cut parts
- audio samples do not end a part in a stream that has video
- a stream with no keyframes keeps recording
- the size limit still fails when alignment is off

Also verified on live recordings rather than only synthetically: with the option on, two segments of an H.265 camera indexed 80 and 60 fragments, none of which began outside a random access point, against 39 of 40 before.

## Config

```yaml
  # End each fMP4 part at a video random access point, so that every part can be
  # decoded on its own.
  recordPartAlignToKeyframe: no
```