### PR TITLE
playback: optionally number the output timeline from a given origin

### DIFF
--- a/docs/2-features/10-playback.md
+++ b/docs/2-features/10-playback.md
@@ -39,7 +39,7 @@ The server will return a list of timespans in JSON format:
 The server provides an endpoint to download recordings:
 
 ```
-http://localhost:9996/get?path=[mypath]&start=[start]&duration=[duration]&format=[format]
+http://localhost:9996/get?path=[mypath]&start=[start]&duration=[duration]&format=[format]&origin=[origin]
 ```
 
 Where:
@@ -48,6 +48,7 @@ Where:
 - [start] is the start date in [RFC3339 format](https://www.utctime.net/)
 - [duration] is the maximum duration of the recording in seconds
 - [format] (optional) is the output format of the stream. Available values are "fmp4" (default) and "mp4"
+- [origin] (optional) is the date the output timeline is numbered from, in [RFC3339 format](https://www.utctime.net/). It must not be after [start]. By default each response is numbered from zero, which is what a player expects of a standalone file; set it when serving several consecutive requests as segments of one stream, so that they follow one another instead of overlapping. It shifts the timeline only: which samples are returned still follows [start]. Applies to the "fmp4" format.
 
 All parameters must be [url-encoded](https://www.urlencoder.org/). For instance:
 

--- a/internal/playback/muxer_fmp4.go
+++ b/internal/playback/muxer_fmp4.go
@@ -33,6 +33,13 @@ func findTrack(tracks []*muxerFMP4Track, id int) *muxerFMP4Track {
 type muxerFMP4 struct {
 	w io.Writer
 
+	// baseOffset shifts the timeline of the output. It is zero unless the
+	// caller asked for a specific origin, in which case it holds the distance
+	// from that origin to the start of this request, so that consecutive
+	// requests over one recording produce one continuous timeline instead of
+	// each starting from zero.
+	baseOffset time.Duration
+
 	init               *fmp4.Init
 	nextSequenceNumber uint32
 	tracks             []*muxerFMP4Track
@@ -146,7 +153,7 @@ func (w *muxerFMP4) innerFlush(final bool) error {
 
 			part.Tracks = append(part.Tracks, &fmp4.PartTrack{
 				ID:       track.id,
-				BaseTime: uint64(track.firstDTS),
+				BaseTime: uint64(track.firstDTS + durationGoToMp4(w.baseOffset, track.timeScale)),
 				Samples:  samples,
 			})
 

--- a/internal/playback/on_get.go
+++ b/internal/playback/on_get.go
@@ -145,13 +145,35 @@ func (s *Server) onGet(ctx *gin.Context) {
 		return
 	}
 
+	// origin numbers the output timeline from a moment of the caller's
+	// choosing instead of from start. It exists so that consecutive requests
+	// over one recording can be served as segments of a single stream: without
+	// it every response begins at zero and a player stacks them on top of one
+	// another rather than laying them end to end.
+	//
+	// It shifts the timeline only. Which samples are returned, and which of
+	// them are visible rather than decode-only, still follow start.
+	origin := start
+	if rawOrigin := ctx.Query("origin"); rawOrigin != "" {
+		origin, err = time.Parse(time.RFC3339, rawOrigin)
+		if err != nil {
+			s.writeError(ctx, http.StatusBadRequest, fmt.Errorf("invalid origin: %w", err))
+			return
+		}
+		if origin.After(start) {
+			s.writeError(ctx, http.StatusBadRequest,
+				fmt.Errorf("origin is after start"))
+			return
+		}
+	}
+
 	ww := &writerWrapper{ctx: ctx}
 	var m muxer
 
 	format := ctx.Query("format")
 	switch format {
 	case "", "fmp4":
-		m = &muxerFMP4{w: ww}
+		m = &muxerFMP4{w: ww, baseOffset: start.Sub(origin)}
 
 	case "mp4":
 		m = &muxerMP4{w: ww}

--- a/internal/playback/on_get_test.go
+++ b/internal/playback/on_get_test.go
@@ -1079,3 +1079,148 @@ func TestOnGetBetweenSegments(t *testing.T) {
 		})
 	}
 }
+
+func TestOnGetOrigin(t *testing.T) {
+	dir := t.TempDir()
+
+	err := os.Mkdir(filepath.Join(dir, "mypath"), 0o755)
+	require.NoError(t, err)
+
+	writeSegment1(t, filepath.Join(dir, "mypath", "2008-11-07_11-22-00-500000.mp4"))
+	writeSegment2(t, filepath.Join(dir, "mypath", "2008-11-07_11-23-02-500000.mp4"))
+
+	s := &Server{
+		Address:      "127.0.0.1:9996",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		PathConfs: map[string]*conf.Path{
+			"mypath": {
+				Name:         "mypath",
+				RecordPath:   filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
+				RecordFormat: conf.RecordFormatFMP4,
+			},
+		},
+		AuthManager: test.NilAuthManager,
+		Parent:      test.NilLogger,
+	}
+	err = s.Initialize()
+	require.NoError(t, err)
+	defer s.Close()
+
+	start := time.Date(2008, 11, 7, 11, 23, 1, 500000000, time.Local)
+
+	fetch := func(origin string) fmp4.Parts {
+		u, err2 := url.Parse("http://myuser:mypass@localhost:9996/get")
+		require.NoError(t, err2)
+
+		v := url.Values{}
+		v.Set("path", "mypath")
+		v.Set("start", start.Format(time.RFC3339Nano))
+		v.Set("duration", "2")
+		v.Set("format", "fmp4")
+		if origin != "" {
+			v.Set("origin", origin)
+		}
+		u.RawQuery = v.Encode()
+
+		res, err2 := http.DefaultClient.Do(mustRequest(t, u.String()))
+		require.NoError(t, err2)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		buf, err2 := io.ReadAll(res.Body)
+		require.NoError(t, err2)
+
+		var parts fmp4.Parts
+		err2 = parts.Unmarshal(buf)
+		require.NoError(t, err2)
+		return parts
+	}
+
+	plain := fetch("")
+	shifted := fetch(start.Add(-2 * time.Second).Format(time.RFC3339Nano))
+
+	timeScales := map[int]uint32{1: 90000, 2: 48000}
+
+	require.Equal(t, len(plain), len(shifted))
+	for i := range plain {
+		require.Equal(t, len(plain[i].Tracks), len(shifted[i].Tracks))
+		for j, track := range plain[i].Tracks {
+			other := shifted[i].Tracks[j]
+			require.Equal(t, track.ID, other.ID)
+
+			// the timeline moves by exactly the distance from origin to start
+			require.Equal(t,
+				track.BaseTime+uint64(2*timeScales[track.ID]),
+				other.BaseTime)
+
+			// and nothing else does: same samples, same order, same payloads
+			require.Equal(t, track.Samples, other.Samples)
+		}
+	}
+}
+
+func TestOnGetInvalidOrigin(t *testing.T) {
+	dir := t.TempDir()
+
+	err := os.Mkdir(filepath.Join(dir, "mypath"), 0o755)
+	require.NoError(t, err)
+
+	writeSegment1(t, filepath.Join(dir, "mypath", "2008-11-07_11-22-00-500000.mp4"))
+
+	s := &Server{
+		Address:      "127.0.0.1:9996",
+		ReadTimeout:  conf.Duration(10 * time.Second),
+		WriteTimeout: conf.Duration(10 * time.Second),
+		PathConfs: map[string]*conf.Path{
+			"mypath": {
+				Name:         "mypath",
+				RecordPath:   filepath.Join(dir, "%path/%Y-%m-%d_%H-%M-%S-%f"),
+				RecordFormat: conf.RecordFormatFMP4,
+			},
+		},
+		AuthManager: test.NilAuthManager,
+		Parent:      test.NilLogger,
+	}
+	err = s.Initialize()
+	require.NoError(t, err)
+	defer s.Close()
+
+	start := time.Date(2008, 11, 7, 11, 23, 1, 500000000, time.Local)
+
+	for _, ca := range []struct {
+		name   string
+		origin string
+	}{
+		{"not a timestamp", "yesterday"},
+		// an origin after start would shift the timeline backwards, which is
+		// not a stream a caller can assemble
+		{"after start", start.Add(time.Second).Format(time.RFC3339Nano)},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			u, err2 := url.Parse("http://myuser:mypass@localhost:9996/get")
+			require.NoError(t, err2)
+
+			v := url.Values{}
+			v.Set("path", "mypath")
+			v.Set("start", start.Format(time.RFC3339Nano))
+			v.Set("duration", "2")
+			v.Set("format", "fmp4")
+			v.Set("origin", ca.origin)
+			u.RawQuery = v.Encode()
+
+			res, err2 := http.DefaultClient.Do(mustRequest(t, u.String()))
+			require.NoError(t, err2)
+			defer res.Body.Close()
+
+			require.Equal(t, http.StatusBadRequest, res.StatusCode)
+		})
+	}
+}
+
+func mustRequest(t *testing.T, u string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	require.NoError(t, err)
+	return req
+}


### PR DESCRIPTION
## Problem

`/get` numbers every response from zero. That is right for a standalone file — the `<video src="...">` use the docs describe — and wrong for a series of them.

Cutting a recording into consecutive windows and publishing them as HLS fMP4 segments produces several responses that all claim to start at the same instant, so a player stacks them instead of laying them end to end.

Measured with six consecutive 4-second windows published as a VOD playlist and played in WebKit:

| | buffered | reported duration |
|---|---|---|
| today | 4 s of the 24 published | 4.015 s |
| with `origin` | the full 24 s, no errors | 24.02 s |

## Change

An optional `origin` (RFC3339) says which moment the output timeline is numbered from. It defaults to `start`, which leaves the output byte-identical to today.

It shifts the timeline only. Which samples are returned, and which of them are visible rather than decode-only, still follow `start`, so seeking is unchanged.

An `origin` after `start` is refused with 400 rather than clamped: it would move the timeline backwards, and no caller can assemble that into a stream.

Applies to the `fmp4` format.

## Notes

- `BaseTime` in `muxerFMP4.innerFlush` is the only place the timeline origin is written, so the change is one line there plus the parameter.
- Backward compatibility is enforced by the tests already in the repository: making the default origin anything other than `start` fails `TestOnGet` and `TestOnGetDifferentInit`.
- Added `TestOnGetOrigin`, which fetches one window twice, with and without the parameter, and requires the timeline to move by exactly the distance from `origin` to `start` while the samples stay identical; and `TestOnGetInvalidOrigin` for the two rejections.
- Documentation updated in `docs/2-features/10-playback.md`.

