### PR TITLE
Add rtspRequire and rtspRateControl to RTSP sources

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1144,6 +1144,10 @@ components:
           type: string
         rtspRangeType:
           $ref: "#/components/schemas/RTSPRangeType"
+        rtspRateControl:
+          type: string
+        rtspRequire:
+          type: string
         rtspScale:
           type: string
         rtspTransport:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1150,6 +1150,10 @@ components:
           type: string
         rtspRangeType:
           $ref: "#/components/schemas/RTSPRangeType"
+        rtspRateControl:
+          type: boolean
+        rtspRequire:
+          type: string
         rtspScale:
           type: string
         rtspTransport:

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -55,6 +55,7 @@ func TestConfFromFile(t *testing.T) {
 			RecordMaxPartSize:          50 * 1024 * 1024,
 			RecordSegmentDuration:      3600000000000,
 			RecordDeleteAfter:          86400000000000,
+			RTSPRateControl:            true,
 			RTSPUDPSourcePortRange:     []uint{32768, 60999},
 			MoQTransport:               MoQTransportQUIC,
 			WHEPSTUNGatherTimeout:      5 * Duration(time.Second),
@@ -589,6 +590,15 @@ func TestConfErrors(t *testing.T) {
 				"    recordSegmentDuration: 30m\n" +
 				"    recordDeleteAfter: 20m\n",
 			`'recordDeleteAfter' cannot be lower than 'recordSegmentDuration'`,
+		},
+		{
+			"scale with rate control disabled",
+			"paths:\n" +
+				"  my_path:\n" +
+				"    source: rtsp://localhost/stream\n" +
+				"    rtspRateControl: false\n" +
+				"    rtspScale: '2'\n",
+			`'rtspScale' must be 1 or -1 when 'rtspRateControl' is false`,
 		},
 		{
 			"missing rtpAddress with UDP and no encryption",

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -262,6 +262,8 @@ type Path struct {
 	RTSPRangeType          RTSPRangeType  `json:"rtspRangeType"`
 	RTSPRangeStart         string         `json:"rtspRangeStart"`
 	RTSPScale              string         `json:"rtspScale"`
+	RTSPRequire            string         `json:"rtspRequire"`
+	RTSPRateControl        string         `json:"rtspRateControl"`
 	RTSPUDPReadBufferSize  *uint          `json:"rtspUDPReadBufferSize,omitempty" deprecated:"true"`
 	RTSPUDPSourcePortRange []uint         `json:"rtspUDPSourcePortRange"`
 

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -262,6 +262,8 @@ type Path struct {
 	RTSPRangeType          RTSPRangeType  `json:"rtspRangeType"`
 	RTSPRangeStart         string         `json:"rtspRangeStart"`
 	RTSPScale              string         `json:"rtspScale"`
+	RTSPRequire            string         `json:"rtspRequire"`
+	RTSPRateControl        bool           `json:"rtspRateControl"`
 	RTSPUDPReadBufferSize  *uint          `json:"rtspUDPReadBufferSize,omitempty" deprecated:"true"`
 	RTSPUDPSourcePortRange []uint         `json:"rtspUDPSourcePortRange"`
 
@@ -382,6 +384,7 @@ func (pconf *Path) setDefaults() {
 	pconf.OverridePublisher = true
 
 	// RTSP source
+	pconf.RTSPRateControl = true
 	pconf.RTSPUDPSourcePortRange = []uint{32768, 60999}
 
 	// MoQ source
@@ -505,6 +508,16 @@ func (pconf *Path) validate(
 		if pconf.SourceAnyPortEnable != nil {
 			l.Log(logger.Warn, "parameter 'sourceAnyPortEnable' is deprecated and has been replaced with 'rtspAnyPort'")
 			pconf.RTSPAnyPort = *pconf.SourceAnyPortEnable
+		}
+
+		// with rate control disabled, the client paces the stream,
+		// therefore the ONVIF streaming specification allows no scale other than 1 and -1.
+		if !pconf.RTSPRateControl {
+			switch pconf.RTSPScale {
+			case "", "1", "1.0", "-1", "-1.0":
+			default:
+				return fmt.Errorf("'rtspScale' must be 1 or -1 when 'rtspRateControl' is false")
+			}
 		}
 
 	case strings.HasPrefix(pconf.Source, "rtmp://") ||

--- a/internal/staticsources/rtsp/source.go
+++ b/internal/staticsources/rtsp/source.go
@@ -139,11 +139,29 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 			uint16(params.Conf.RTSPUDPSourcePortRange[1]),
 		},
 		OnRequest: func(req *base.Request) {
-			if params.Conf.RTSPScale != "" && req.Method == base.Play {
-				if req.Header == nil {
-					req.Header = base.Header{}
+			if req.Method == base.Play {
+				if params.Conf.RTSPScale != "" {
+					if req.Header == nil {
+						req.Header = base.Header{}
+					}
+					req.Header["Scale"] = base.HeaderValue{params.Conf.RTSPScale}
 				}
-				req.Header["Scale"] = base.HeaderValue{params.Conf.RTSPScale}
+
+				// appended rather than assigned: the client already sets Require when it
+				// is reading a back channel, and both feature tags have to survive.
+				if params.Conf.RTSPRequire != "" {
+					if req.Header == nil {
+						req.Header = base.Header{}
+					}
+					req.Header["Require"] = append(req.Header["Require"], params.Conf.RTSPRequire)
+				}
+
+				if params.Conf.RTSPRateControl != "" {
+					if req.Header == nil {
+						req.Header = base.Header{}
+					}
+					req.Header["Rate-Control"] = base.HeaderValue{params.Conf.RTSPRateControl}
+				}
 			}
 			s.Log(logger.Debug, "[c->s] %v", req)
 		},

--- a/internal/staticsources/rtsp/source.go
+++ b/internal/staticsources/rtsp/source.go
@@ -139,11 +139,24 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 			uint16(params.Conf.RTSPUDPSourcePortRange[1]),
 		},
 		OnRequest: func(req *base.Request) {
-			if params.Conf.RTSPScale != "" && req.Method == base.Play {
+			if req.Method == base.Play {
 				if req.Header == nil {
 					req.Header = base.Header{}
 				}
-				req.Header["Scale"] = base.HeaderValue{params.Conf.RTSPScale}
+
+				if params.Conf.RTSPScale != "" {
+					req.Header["Scale"] = base.HeaderValue{params.Conf.RTSPScale}
+				}
+
+				// appended rather than assigned: the client already sets Require when it
+				// is reading a back channel, and both feature tags have to survive.
+				if params.Conf.RTSPRequire != "" {
+					req.Header["Require"] = append(req.Header["Require"], params.Conf.RTSPRequire)
+				}
+
+				if !params.Conf.RTSPRateControl {
+					req.Header["Rate-Control"] = base.HeaderValue{"no"}
+				}
 			}
 			s.Log(logger.Debug, "[c->s] %v", req)
 		},

--- a/internal/staticsources/rtsp/source_test.go
+++ b/internal/staticsources/rtsp/source_test.go
@@ -396,6 +396,101 @@ func TestScale(t *testing.T) {
 	<-p.Unit
 }
 
+// ONVIF Profile G replay sends both headers on PLAY: "Require: onvif-replay" so that a
+// device without the extensions answers 551 rather than streaming something else, and
+// "Rate-Control: no" so the recording arrives as fast as the transport allows.
+func TestRequireAndRateControl(t *testing.T) {
+	var strm *gortsplib.ServerStream
+
+	media0 := test.UniqueMediaH264()
+
+	s := gortsplib.Server{
+		Handler: &testServer{
+			onDescribe: func(_ *gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
+				return &base.Response{
+					StatusCode: base.StatusOK,
+				}, strm, nil
+			},
+			onSetup: func(_ *gortsplib.ServerHandlerOnSetupCtx) (*base.Response, *gortsplib.ServerStream, error) {
+				return &base.Response{
+					StatusCode: base.StatusOK,
+				}, strm, nil
+			},
+			onPlay: func(ctx *gortsplib.ServerHandlerOnPlayCtx) (*base.Response, error) {
+				require.Equal(t, base.HeaderValue{"onvif-replay"}, ctx.Request.Header["Require"])
+				require.Equal(t, base.HeaderValue{"no"}, ctx.Request.Header["Rate-Control"])
+
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					err := strm.WritePacketRTP(media0, &rtp.Packet{
+						Header: rtp.Header{
+							Version:        0x02,
+							PayloadType:    96,
+							SequenceNumber: 57899,
+							Timestamp:      345234345,
+							SSRC:           978651231,
+							Marker:         true,
+						},
+						Payload: []byte{5, 1, 2, 3, 4},
+					})
+					require.NoError(t, err)
+				}()
+
+				return &base.Response{
+					StatusCode: base.StatusOK,
+				}, nil
+			},
+		},
+		RTSPAddress: "127.0.0.1:8555",
+	}
+
+	err := s.Start()
+	require.NoError(t, err)
+	defer s.Close()
+
+	strm = &gortsplib.ServerStream{
+		Server: &s,
+		Desc:   &description.Session{Medias: []*description.Media{media0}},
+	}
+	err = strm.Initialize()
+	require.NoError(t, err)
+	defer strm.Close()
+
+	cnf := &conf.Path{
+		RTSPUDPSourcePortRange: []uint{32768, 60999},
+		RTSPRequire:            "onvif-replay",
+		RTSPRateControl:        "no",
+	}
+
+	p := &test.StaticSourceParent{}
+	p.Initialize()
+	defer p.Close()
+
+	so := &rtsp.Source{
+		ReadTimeout:    conf.Duration(10 * time.Second),
+		WriteTimeout:   conf.Duration(10 * time.Second),
+		WriteQueueSize: 2048,
+		Parent:         p,
+	}
+
+	done := make(chan struct{})
+	defer func() { <-done }()
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+
+	go func() {
+		so.Run(defs.StaticSourceRunParams{ //nolint:errcheck
+			Context:        ctx,
+			ResolvedSource: "rtsp://127.0.0.1:8555/teststream",
+			Conf:           cnf,
+		})
+		close(done)
+	}()
+
+	<-p.Unit
+}
+
 func TestRange(t *testing.T) {
 	for _, ca := range []string{"clock", "npt", "smpte"} {
 		t.Run(ca, func(t *testing.T) {

--- a/internal/staticsources/rtsp/source_test.go
+++ b/internal/staticsources/rtsp/source_test.go
@@ -396,6 +396,101 @@ func TestScale(t *testing.T) {
 	<-p.Unit
 }
 
+// ONVIF Profile G replay sends both headers on PLAY: "Require: onvif-replay" so that a
+// device without the extensions answers 551 rather than streaming something else, and
+// "Rate-Control: no" so the recording arrives as fast as the transport allows.
+func TestRequireAndRateControl(t *testing.T) {
+	var strm *gortsplib.ServerStream
+
+	media0 := test.UniqueMediaH264()
+
+	s := gortsplib.Server{
+		Handler: &testServer{
+			onDescribe: func(_ *gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
+				return &base.Response{
+					StatusCode: base.StatusOK,
+				}, strm, nil
+			},
+			onSetup: func(_ *gortsplib.ServerHandlerOnSetupCtx) (*base.Response, *gortsplib.ServerStream, error) {
+				return &base.Response{
+					StatusCode: base.StatusOK,
+				}, strm, nil
+			},
+			onPlay: func(ctx *gortsplib.ServerHandlerOnPlayCtx) (*base.Response, error) {
+				require.Equal(t, base.HeaderValue{"onvif-replay"}, ctx.Request.Header["Require"])
+				require.Equal(t, base.HeaderValue{"no"}, ctx.Request.Header["Rate-Control"])
+
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					err := strm.WritePacketRTP(media0, &rtp.Packet{
+						Header: rtp.Header{
+							Version:        0x02,
+							PayloadType:    96,
+							SequenceNumber: 57899,
+							Timestamp:      345234345,
+							SSRC:           978651231,
+							Marker:         true,
+						},
+						Payload: []byte{5, 1, 2, 3, 4},
+					})
+					require.NoError(t, err)
+				}()
+
+				return &base.Response{
+					StatusCode: base.StatusOK,
+				}, nil
+			},
+		},
+		RTSPAddress: "127.0.0.1:8555",
+	}
+
+	err := s.Start()
+	require.NoError(t, err)
+	defer s.Close()
+
+	strm = &gortsplib.ServerStream{
+		Server: &s,
+		Desc:   &description.Session{Medias: []*description.Media{media0}},
+	}
+	err = strm.Initialize()
+	require.NoError(t, err)
+	defer strm.Close()
+
+	cnf := &conf.Path{
+		RTSPUDPSourcePortRange: []uint{32768, 60999},
+		RTSPRequire:            "onvif-replay",
+		RTSPRateControl:        false,
+	}
+
+	p := &test.StaticSourceParent{}
+	p.Initialize()
+	defer p.Close()
+
+	so := &rtsp.Source{
+		ReadTimeout:    conf.Duration(10 * time.Second),
+		WriteTimeout:   conf.Duration(10 * time.Second),
+		WriteQueueSize: 2048,
+		Parent:         p,
+	}
+
+	done := make(chan struct{})
+	defer func() { <-done }()
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+
+	go func() {
+		so.Run(defs.StaticSourceRunParams{ //nolint:errcheck
+			Context:        ctx,
+			ResolvedSource: "rtsp://127.0.0.1:8555/teststream",
+			Conf:           cnf,
+		})
+		close(done)
+	}()
+
+	<-p.Unit
+}
+
 func TestRange(t *testing.T) {
 	for _, ca := range []string{"clock", "npt", "smpte"} {
 		t.Run(ca, func(t *testing.T) {

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -614,6 +614,17 @@ pathDefaults:
   # Negative values play in reverse, values > 1 fast-forward,
   # values 0 < x < 1 play slow motion.
   rtspScale:
+  # Require header value to send to the source, in order to declare support for a RTSP feature.
+  # Set this to "onvif-replay" to declare support for the ONVIF Profile G replay extensions:
+  # a source that does not support them then replies with 551 (Option not supported),
+  # instead of silently streaming something else.
+  rtspRequire:
+  # Rate-Control header value to send to the source.
+  # Set this to "no" to receive a recording as fast as the transport allows,
+  # instead of in real time. This is the mechanism ONVIF Profile G devices are required
+  # to support; rtspScale is an alternative that devices only optionally support, and the
+  # two are mutually exclusive.
+  rtspRateControl:
   # Range of ports used as source port in outgoing UDP packets.
   rtspUDPSourcePortRange: [32768, 60999]
 

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -622,6 +622,18 @@ pathDefaults:
   # Negative values play in reverse, values > 1 fast-forward,
   # values 0 < x < 1 play slow motion.
   rtspScale:
+  # Require header value to send to the source, in order to declare support for a RTSP feature.
+  # Set this to "onvif-replay" to declare support for the ONVIF Profile G replay extensions:
+  # a source that does not support them then replies with 551 (Option not supported),
+  # instead of silently streaming something else.
+  rtspRequire:
+  # Whether the source is asked to pace the stream in real time.
+  # Disable this in order to send "Rate-Control: no" and receive a recording as fast as
+  # the transport allows. This is the mechanism ONVIF Profile G devices are required to
+  # support; rtspScale is an alternative that devices only optionally support.
+  # With rate control disabled, the client paces the stream, therefore the ONVIF streaming
+  # specification allows no rtspScale other than 1 and -1.
+  rtspRateControl: true
   # Range of ports used as source port in outgoing UDP packets.
   rtspUDPSourcePortRange: [32768, 60999]
 


### PR DESCRIPTION
mediamtx can already pull ONVIF Profile G recordings: rtspRangeType/rtspRangeStart produce the "Range: clock=" header on PLAY, and rtspScale accelerates delivery beyond real time. Two headers from the ONVIF Streaming Specification are still unreachable, and both matter for replay.

"Rate-Control: no" (section 6.5.2) asks for a recording as fast as the transport allows rather than in real time. It matters because rtspScale is not an equivalent: section 6.5 says a device MAY accept Scale values other than 1.0/-1.0, while section 6.5.2 says an ONVIF compliant server SHALL support Rate-Control=no for playback. So today's only fast-replay option rests on an optional feature while the mandatory one cannot be sent.

"Require: onvif-replay" (section 6.4) declares that the client understands the replay extensions. Without it a device that does not implement them does not fail, it streams something else -- live, or the recording from its start -- so a request for a specific past window can silently return different footage. With the tag the same device answers 551 (Option not supported), which is a much better outcome than plausible-looking wrong data.

`rtspRequire` follows the rtspScale pattern: a per-path string, applied to PLAY through OnRequest. It is APPENDED rather than assigned, because gortsplib already sets that header when the client is reading a back channel and both feature tags have to survive.

`rtspRateControl` is a boolean instead, defaulting to true, which sends no header at all and leaves the source pacing the stream, as before. A string would have been close to unusable: yamlwrapper converts an unquoted `no` into a YAML boolean before the JSON unmarshal, so the one value the option exists for could only ever be written as `rtspRateControl: "no"`, and the unquoted spelling failed with `cannot unmarshal bool into Go value of type string`. As a boolean the natural spelling is the correct one, and env.go already accepts yes/no for booleans, so both configuration surfaces agree.

The two headers are not mutually exclusive, but section 6.5 does constrain Scale to 1.0 or -1.0 while rate control is off, since the client rather than the server then paces the stream. `validate()` rejects exactly that combination and leaves reverse replay at transport speed available:

```
'rtspScale' must be 1 or -1 when 'rtspRateControl' is false
```

Tested with TestRequireAndRateControl, alongside the existing TestScale, plus a conf error case for the Scale constraint.
