### PR TITLE
rpi: fix crash when secondary stream is enabled (#6060)

### DIFF
--- a/internal/staticsources/rpicamera/source_arm_.go
+++ b/internal/staticsources/rpicamera/source_arm_.go
@@ -213,6 +213,8 @@ func (s *Source) runPrimary(params defs.StaticSourceRunParams) error {
 
 			for _, pkt := range pkts {
 				pkt.Timestamp = uint32(pts)
+				pkt.PayloadType = 96 // we must always use 96 to associate the packet with rpicamera_secondary/90000
+
 				subStream.WriteUnit(mediaSecondary, mediaSecondary.Formats[0], &unit.Unit{
 					PTS:        pts,
 					NTP:        ntp,


### PR DESCRIPTION
Fixes #6060