### PR TITLE
feat(srt): set kernel UDP read buffer via gosrt ListenerControl callback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/bluenviron/gortmplib v1.0.1-0.20260813085012-9c63c23d6928
 	github.com/bluenviron/gortsplib/v5 v5.6.3
 	github.com/bluenviron/mediacommon/v2 v2.9.2
-	github.com/datarhei/gosrt v0.11.1-0.20260811092139-103c469da1f1
+	github.com/datarhei/gosrt v0.11.1-0.20260812091715-a77b40bb4b76
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gin-contrib/pprof v1.5.4
 	github.com/gin-gonic/gin v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gE
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
-github.com/datarhei/gosrt v0.11.1-0.20260811092139-103c469da1f1 h1:6iE77zVV3LRHoyKfNvpe6W172E8dBguaHs5YMBskL38=
-github.com/datarhei/gosrt v0.11.1-0.20260811092139-103c469da1f1/go.mod h1:Jc34G/QwMzPMJdHNcaxc9ddbx95h2FumO2h/rgV/eRA=
+github.com/datarhei/gosrt v0.11.1-0.20260812091715-a77b40bb4b76 h1:fwEWQ7L/p952NbtyIKPHzLkMGzIzOa29ivQyTQgye5Q=
+github.com/datarhei/gosrt v0.11.1-0.20260812091715-a77b40bb4b76/go.mod h1:Jc34G/QwMzPMJdHNcaxc9ddbx95h2FumO2h/rgV/eRA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -702,6 +702,7 @@ func (p *Core) createResources(initial bool) error {
 			ReadTimeout:         p.conf.ReadTimeout,
 			WriteTimeout:        p.conf.WriteTimeout,
 			UDPMaxPayloadSize:   p.conf.UDPMaxPayloadSize,
+			UDPReadBufferSize:   p.conf.UDPReadBufferSize,
 			RunOnConnect:        p.conf.RunOnConnect,
 			RunOnConnectRestart: p.conf.RunOnConnectRestart,
 			RunOnDisconnect:     p.conf.RunOnDisconnect,

--- a/internal/servers/srt/raw_socket_other.go
+++ b/internal/servers/srt/raw_socket_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package srt
+
+func rawSocket(fd uintptr) int {
+	return int(fd)
+}

--- a/internal/servers/srt/raw_socket_windows.go
+++ b/internal/servers/srt/raw_socket_windows.go
@@ -1,0 +1,7 @@
+package srt
+
+import "syscall"
+
+func rawSocket(fd uintptr) syscall.Handle {
+	return syscall.Handle(fd)
+}

--- a/internal/servers/srt/server.go
+++ b/internal/servers/srt/server.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"syscall"
 	"time"
 
 	srt "github.com/datarhei/gosrt"
@@ -79,6 +80,7 @@ type Server struct {
 	ReadTimeout         conf.Duration
 	WriteTimeout        conf.Duration
 	UDPMaxPayloadSize   int
+	UDPReadBufferSize   uint
 	RunOnConnect        string
 	RunOnConnectRestart bool
 	RunOnDisconnect     string
@@ -108,6 +110,19 @@ func (s *Server) Initialize() error {
 	conf.ConnectionTimeout = time.Duration(s.ReadTimeout)
 	conf.PeerIdleTimeout = time.Duration(s.ReadTimeout)
 	conf.PayloadSize = uint32(srtMaxPayloadSize(s.UDPMaxPayloadSize))
+	if s.UDPReadBufferSize > 0 {
+		bufSize := int(s.UDPReadBufferSize)
+		conf.ListenerControl = func(_, _ string, c syscall.RawConn) error {
+			var opErr error
+			err := c.Control(func(fd uintptr) {
+				opErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, bufSize)
+			})
+			if err != nil {
+				return err
+			}
+			return opErr
+		}
+	}
 
 	var err error
 	s.ln, err = srt.Listen("srt", s.Address, conf)

--- a/internal/servers/srt/server.go
+++ b/internal/servers/srt/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 	"sort"
 	"sync"
 	"syscall"
@@ -110,17 +111,45 @@ func (s *Server) Initialize() error {
 	conf.ConnectionTimeout = time.Duration(s.ReadTimeout)
 	conf.PeerIdleTimeout = time.Duration(s.ReadTimeout)
 	conf.PayloadSize = uint32(srtMaxPayloadSize(s.UDPMaxPayloadSize))
+
 	if s.UDPReadBufferSize > 0 {
 		bufSize := int(s.UDPReadBufferSize)
-		conf.ListenerControl = func(_, _ string, c syscall.RawConn) error {
-			var opErr error
-			err := c.Control(func(fd uintptr) {
-				opErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, bufSize)
+		conf.ListenerControl = func(_, _ string, rawConn syscall.RawConn) error {
+			var err2 error
+			err := rawConn.Control(func(fd uintptr) {
+				err2 = syscall.SetsockoptInt(rawSocket(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, bufSize)
 			})
 			if err != nil {
 				return err
 			}
-			return opErr
+
+			if err2 != nil {
+				return err2
+			}
+
+			var v int
+
+			err = rawConn.Control(func(fd uintptr) {
+				v, err2 = syscall.GetsockoptInt(rawSocket(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+			})
+			if err != nil {
+				return err
+			}
+
+			if err2 != nil {
+				return err2
+			}
+
+			if runtime.GOOS != "windows" {
+				v /= 2 // on Linux, SO_RCVBUF is double the size of the actual buffer
+			}
+
+			if v != bufSize {
+				return fmt.Errorf("unable to set UDP read buffer size to %d, got %d, check that the operating system allows that",
+					bufSize, v)
+			}
+
+			return nil
 		}
 	}
 

--- a/internal/servers/srt/server_test.go
+++ b/internal/servers/srt/server_test.go
@@ -542,7 +542,7 @@ func TestUDPReadBufferSize(t *testing.T) {
 	var kernelBuf int
 	var opErr error
 	err = raw.Control(func(fd uintptr) {
-		kernelBuf, opErr = syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+		kernelBuf, opErr = syscall.GetsockoptInt(rawSocket(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
 	})
 	require.NoError(t, err)
 	require.NoError(t, opErr)

--- a/internal/servers/srt/server_test.go
+++ b/internal/servers/srt/server_test.go
@@ -3,8 +3,12 @@ package srt
 import (
 	"bufio"
 	"fmt"
+	"net"
+	"reflect"
+	"syscall"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	"github.com/bluenviron/mediacommon/v2/pkg/formats/mpegts"
@@ -489,4 +493,61 @@ func TestServerRead(t *testing.T) {
 			},
 		},
 	}, list)
+}
+
+// listenerUDPConn extracts the underlying *net.UDPConn from a gosrt.Listener
+// by reaching through the unexported *listener → *packetConn → PacketConn chain.
+func listenerUDPConn(ln srt.Listener) *net.UDPConn {
+	v := reflect.ValueOf(ln).Elem()
+	pcPtr := *(*unsafe.Pointer)(unsafe.Pointer(v.FieldByName("pc").UnsafeAddr()))
+
+	// packetConn's first field is net.PacketConn (exported)
+	pktConnField := reflect.NewAt(
+		reflect.StructOf([]reflect.StructField{
+			{Name: "PacketConn", Type: reflect.TypeOf((*net.PacketConn)(nil)).Elem()},
+		}),
+		pcPtr,
+	).Elem().Field(0).Interface().(net.PacketConn)
+
+	return pktConnField.(*net.UDPConn)
+}
+
+func TestUDPReadBufferSize(t *testing.T) {
+	externalCmdPool := &externalcmd.Pool{}
+	externalCmdPool.Initialize()
+	defer externalCmdPool.Close()
+
+	// Pick a size well above the default 212992 so the effect is unambiguous.
+	bufSize := uint(1048576) // 1 MB
+
+	s := &Server{
+		Address:           "127.0.0.1:0",
+		ReadTimeout:       conf.Duration(10 * time.Second),
+		WriteTimeout:      conf.Duration(10 * time.Second),
+		UDPMaxPayloadSize: 1472,
+		UDPReadBufferSize: bufSize,
+		ExternalCmdPool:   externalCmdPool,
+		PathManager:       &test.PathManager{},
+		Parent:            test.NilLogger,
+	}
+	err := s.Initialize()
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Verify the kernel receive buffer was increased.
+	udpConn := listenerUDPConn(s.ln)
+	raw, err := udpConn.SyscallConn()
+	require.NoError(t, err)
+
+	var kernelBuf int
+	var opErr error
+	err = raw.Control(func(fd uintptr) {
+		kernelBuf, opErr = syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+	})
+	require.NoError(t, err)
+	require.NoError(t, opErr)
+
+	// The kernel doubles the value passed to setsockopt SO_RCVBUF.
+	require.GreaterOrEqual(t, kernelBuf, int(bufSize),
+		"SO_RCVBUF = %d, expected >= %d", kernelBuf, bufSize)
 }


### PR DESCRIPTION
### Summary

Apply the global `udpReadBufferSize` config to the SRT listener's kernel UDP receive buffer (`SO_RCVBUF`) using `datarhei/gosrt`'s `ListenerControl` callback (merged in [datarhei/gosrt#144](https://github.com/datarhei/gosrt/pull/144)).

### Changes

**`internal/servers/srt/server.go`**
- Add `UDPReadBufferSize uint` field to `Server` struct
- In `Initialize()`, when >0, set `conf.ListenerControl` to call `SetsockoptInt(SO_RCVBUF)` on the raw socket fd before bind
- Import `"syscall"`

**`internal/core/core.go`**
- Pass `p.conf.UDPReadBufferSize` to `srt.Server`

### How it works

The kernel caps the `setsockopt(SO_RCVBUF)` input at `net.core.rmem_max` then doubles it. E.g. requesting 26214400 with `rmem_max=26214400` yields `sk_rcvbuf = 52428800`.

**System prerequisite**: `net.core.rmem_max` must be >= desired `sk_rcvbuf / 2`:
```
echo "net.core.rmem_max = 26214400" | sudo tee /etc/sysctl.d/99-mediamtx-srt.conf
sudo sysctl --system
```

### Testing

- **Unit test** `TestUDPReadBufferSize`: starts the SRT server with `UDPReadBufferSize=1MB`, extracts the underlying `*net.UDPConn` from the gosrt listener via unsafe/reflect, and uses `syscall.GetsockoptInt(SO_RCVBUF)` to assert the kernel buffer >= the requested value
- **Manual**: `ss -nlu -m` confirms `rb52428800` with `udpReadBufferSize: 26214400`
- All existing SRT tests pass (`TestAuthError`, `TestServerPublish`, `TestServerRead`, `TestStreamIDUnmarshal`)
