### PR TITLE
rpi: prevent invalid MJPEG sizes

### DIFF
--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -415,6 +415,24 @@ func TestConfErrors(t *testing.T) {
 			"'rpiCamera' with same camera ID 0 is used as source in two paths, 'cam1' and 'cam2'",
 		},
 		{
+			"invalid rpi camera mjpeg width",
+			"paths:\n" +
+				"  cam:\n" +
+				"    source: rpiCamera\n" +
+				"    rpiCameraCodec: mjpeg\n" +
+				"    rpiCameraWidth: 1921\n",
+			"'rpiCameraWidth' must be a multiple of 8 and less than 2048 when using MJPEG",
+		},
+		{
+			"invalid rpi camera mjpeg height",
+			"paths:\n" +
+				"  cam:\n" +
+				"    source: rpiCamera\n" +
+				"    rpiCameraCodec: mjpeg\n" +
+				"    rpiCameraHeight: 2048\n",
+			"'rpiCameraHeight' must be a multiple of 8 and less than 2048 when using MJPEG",
+		},
+		{
 			"invalid srt publish passphrase",
 			"paths:\n" +
 				"  mypath:\n" +

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -585,13 +585,23 @@ func (pconf *Path) validate(
 		}
 
 	case pconf.Source == "rpiCamera":
-
 		if pconf.RPICameraWidth == 0 {
 			return fmt.Errorf("invalid 'rpiCameraWidth' value")
 		}
 
 		if pconf.RPICameraHeight == 0 {
 			return fmt.Errorf("invalid 'rpiCameraHeight' value")
+		}
+
+		if pconf.RPICameraCodec == "mjpeg" ||
+			(pconf.RPICameraSecondary && pconf.RPICameraCodec == "auto") {
+			if pconf.RPICameraWidth >= 2048 || (pconf.RPICameraWidth%8) != 0 {
+				return fmt.Errorf("'rpiCameraWidth' must be a multiple of 8 and less than 2048 when using MJPEG")
+			}
+
+			if pconf.RPICameraHeight >= 2048 || (pconf.RPICameraHeight%8) != 0 {
+				return fmt.Errorf("'rpiCameraHeight' must be a multiple of 8 and less than 2048 when using MJPEG")
+			}
 		}
 
 		switch pconf.RPICameraExposure {


### PR DESCRIPTION
width and height of MJPEG frames must be multiple of 8 and less than 2048, otherwise they cannot be routed with RTP/RTSP.