### PR TITLE
remove useless JPEG checks from recorder

### DIFF
--- a/internal/recorder/format_fmp4.go
+++ b/internal/recorder/format_fmp4.go
@@ -89,25 +89,12 @@ func mpeg1audioChannelCount(cm mpeg1audio.ChannelMode) int {
 	}
 }
 
-func jpegExtractSize(image []byte) (int, int, error) {
-	l := len(image)
-	if l < 2 || image[0] != 0xFF || image[1] != jpeg.MarkerStartOfImage {
-		return 0, 0, fmt.Errorf("invalid header")
-	}
-
+func jpegExtractSize(image []byte) (int, int) {
 	image = image[2:]
 
 	for {
-		if len(image) < 2 {
-			return 0, 0, fmt.Errorf("not enough bits")
-		}
-
-		h0, h1 := image[0], image[1]
+		h1 := image[1]
 		image = image[2:]
-
-		if h0 != 0xFF {
-			return 0, 0, fmt.Errorf("invalid image")
-		}
 
 		switch h1 {
 		case 0xE0, 0xE1, 0xE2, // JFIF
@@ -116,30 +103,18 @@ func jpegExtractSize(image []byte) (int, int, error) {
 			jpeg.MarkerDefineQuantizationTable,
 			jpeg.MarkerDefineRestartInterval:
 			mlen := int(image[0])<<8 | int(image[1])
-			if len(image) < mlen {
-				return 0, 0, fmt.Errorf("not enough bits")
-			}
 			image = image[mlen:]
 
 		case jpeg.MarkerStartOfFrame1:
 			mlen := int(image[0])<<8 | int(image[1])
-			if len(image) < mlen {
-				return 0, 0, fmt.Errorf("not enough bits")
-			}
 
 			var sof jpeg.StartOfFrame1
 			err := sof.Unmarshal(image[2:mlen])
 			if err != nil {
-				return 0, 0, err
+				panic(err)
 			}
 
-			return sof.Width, sof.Height, nil
-
-		case jpeg.MarkerStartOfScan:
-			return 0, 0, fmt.Errorf("SOF not found")
-
-		default:
-			return 0, 0, fmt.Errorf("unknown marker: 0x%.2x", h1)
+			return sof.Width, sof.Height
 		}
 	}
 }
@@ -623,12 +598,7 @@ func (f *formatFMP4) initialize() bool {
 
 						if !parsed {
 							parsed = true
-							width, height, err := jpegExtractSize(u.Payload.(unit.PayloadMJPEG))
-							if err != nil {
-								return err
-							}
-							codec.Width = width
-							codec.Height = height
+							codec.Width, codec.Height = jpegExtractSize(u.Payload.(unit.PayloadMJPEG))
 							f.updateCodecParams()
 						}
 


### PR DESCRIPTION
MJPEG frames are already validated before reaching the recorder, there's no need to validate them twice.