### PR TITLE
impose a minimum value to clock rate of always-available tracks

### DIFF
--- a/internal/conf/always_available_track.go
+++ b/internal/conf/always_available_track.go
@@ -31,9 +31,23 @@ func (t *AlwaysAvailableTrack) UnmarshalJSON(b []byte) error {
 			return fmt.Errorf("channelCount must not be specified for codec '%s'", t.Codec)
 		}
 
-	case CodecMPEG4Audio, CodecG711, CodecLPCM:
+	case CodecMPEG4Audio:
 		if t.SampleRate == 0 {
 			return fmt.Errorf("sampleRate is mandatory for codec '%s'", t.Codec)
+		}
+		if t.SampleRate < 22050 {
+			return fmt.Errorf("sampleRate must be greater than or equal to 22050 for codec '%s'", t.Codec)
+		}
+		if t.ChannelCount == 0 {
+			return fmt.Errorf("channelCount is mandatory for codec '%s'", t.Codec)
+		}
+
+	case CodecG711, CodecLPCM:
+		if t.SampleRate == 0 {
+			return fmt.Errorf("sampleRate is mandatory for codec '%s'", t.Codec)
+		}
+		if t.SampleRate < 8000 {
+			return fmt.Errorf("sampleRate must be greater than or equal to 8000 for codec '%s'", t.Codec)
 		}
 		if t.ChannelCount == 0 {
 			return fmt.Errorf("channelCount is mandatory for codec '%s'", t.Codec)

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -842,6 +842,28 @@ func TestConfErrors(t *testing.T) {
 			"'alwaysAvailableFile' and 'alwaysAvailableTracks' cannot be used together",
 		},
 		{
+			"alwaysAvailableTracks g711 sampleRate too low",
+			"paths:\n" +
+				"  mypath:\n" +
+				"    alwaysAvailable: yes\n" +
+				"    alwaysAvailableTracks:\n" +
+				"    - codec: G711\n" +
+				"      sampleRate: 7999\n" +
+				"      channelCount: 1\n",
+			"sampleRate must be greater than or equal to 8000 for codec 'G711'",
+		},
+		{
+			"alwaysAvailableTracks mpeg4audio sampleRate too low",
+			"paths:\n" +
+				"  mypath:\n" +
+				"    alwaysAvailable: yes\n" +
+				"    alwaysAvailableTracks:\n" +
+				"    - codec: MPEG4Audio\n" +
+				"      sampleRate: 22049\n" +
+				"      channelCount: 1\n",
+			"sampleRate must be greater than or equal to 22050 for codec 'MPEG4Audio'",
+		},
+		{
 			"missing udp port",
 			"paths:\n" +
 				"  mypath:\n" +


### PR DESCRIPTION
Clock rates below 10 caused the emission of empty samples. Fix the issue by imposing a minimum of 8khz.