### PR TITLE
hls: unlock the session-in-query+iOS combination

### DIFF
--- a/docs/3-publish/05-webrtc-clients.md
+++ b/docs/3-publish/05-webrtc-clients.md
@@ -19,7 +19,7 @@ WHIP is a WebRTC extension that allows to publish streams by using a URL, withou
 http://localhost:8889/mystream/whip
 ```
 
-Be aware that not all browsers can read any codec, check [Codec support in browsers](../2-features/26-webrtc-specific-features.md#codec-support-in-browsers).
+Be aware that not all browsers can publish tracks with any codec, check [Codec support in browsers](../2-features/26-webrtc-specific-features.md#codec-support-in-browsers).
 
 Depending on the network it might be difficult to establish a connection between server and clients, read [Solving WebRTC connectivity issues](../2-features/26-webrtc-specific-features.md#solving-webrtc-connectivity-issues).
 

--- a/docs/3-publish/16-web-browsers.md
+++ b/docs/3-publish/16-web-browsers.md
@@ -28,6 +28,8 @@ http://localhost:8889/mystream/publish
 
 The resulting stream will be available on path `/mystream`.
 
+Be aware that not all browsers can publish tracks with any codec, check [Codec support in browsers](../2-features/26-webrtc-specific-features.md#codec-support-in-browsers).
+
 This web page can be embedded into another web page by using an iframe:
 
 ```html

--- a/docs/4-read/03-webrtc.md
+++ b/docs/4-read/03-webrtc.md
@@ -18,8 +18,8 @@ WHEP is a WebRTC extension that allows to read streams by using a URL, without p
 http://localhost:8889/mystream/whep
 ```
 
-Be aware that not all browsers can read any codec, check [Codec support in browsers](../2-features/26-webrtc-specific-features.md#codec-support-in-browsers).
+Be aware that not all browsers can read tracks with any codec, check [Codec support in browsers](../2-features/26-webrtc-specific-features.md#codec-support-in-browsers).
 
 Depending on the network it may be difficult to establish a connection between server and clients, read [Solving WebRTC connectivity issues](../2-features/26-webrtc-specific-features.md#solving-webrtc-connectivity-issues).
 
-Some clients that can read with WebRTC and WHEP are [GStreamer](09-gstreamer.md), [Unity](14-unity.md) and [web browsers](07-web-browsers.md).
+Some clients that can read with WebRTC and WHEP are [web browsers](07-web-browsers.md), [GStreamer](09-gstreamer.md) and [Unity](14-unity.md).

--- a/docs/4-read/06-hls.md
+++ b/docs/4-read/06-hls.md
@@ -18,7 +18,7 @@ and can also be accessed without using the browsers, by software that supports t
 http://localhost:8888/mystream/index.m3u8
 ```
 
-Some clients that can read with HLS are [FFmpeg](08-ffmpeg.md), [GStreamer](09-gstreamer.md), [VLC](10-vlc.md) and [web browsers](07-web-browsers.md).
+Some clients that can read with HLS are [web browsers](07-web-browsers.md), [FFmpeg](08-ffmpeg.md), [GStreamer](09-gstreamer.md) and [VLC](10-vlc.md).
 
 _MediaMTX_ supports generating HLS in several variants (including Low-Latency mode), and provides various parameters to tune HLS generation. These are listed in the [configuration file](../5-references/1-configuration-file.md).
 

--- a/docs/4-read/07-web-browsers.md
+++ b/docs/4-read/07-web-browsers.md
@@ -24,6 +24,8 @@ http://localhost:8889/mystream
 
 Replace `mystream` with the path name.
 
+Be aware that not all browsers can read tracks with any codec, check [Codec support in browsers](../2-features/26-webrtc-specific-features.md#codec-support-in-browsers).
+
 ### HLS
 
 The HLS protocol has a higher latency with respect to WebRTC, but there are fewer problems related to connectivity between server and clients. Visit the web page:
@@ -161,6 +163,8 @@ The iframe method is fit for most use cases, but it has some limitations:
 
 In order to overcome the limitations of the iframe-based method, it is possible to load the stream directly inside a `<video>` tag in the web page, through the _hls.js_ library.
 
+Be aware that _hls.js_ is not compatible with browsers that do not expose the [Media Source Extensions API](https://caniuse.com/mediasource), in particular old iOS versions (iPad iOS `< 13`, iPhone iOS `< 17`).
+
 If you are using a JavaScript bundler, you can import _hls.js_ by adding [its npm package](https://www.npmjs.com/package/hls.js) as dependency and then importing it:
 
 ```js
@@ -192,28 +196,34 @@ After the video tag, add a script that initializes the stream when the page is f
 ```html
 <script>
   window.addEventListener("load", () => {
-    if (Hls.isSupported()) {
-      const hls = new Hls({
-        xhrSetup: function (xhr, url) {
-          let user = ""; // fill if needed
-          let pass = ""; // fill if needed
-          let token = ""; // fill if needed
+    const video = document.getElementById("myvideo");
 
-          if (user !== "") {
-            const credentials = btoa(`${user}:${pass}`);
-            xhr.setRequestHeader("Authorization", `Basic ${credentials}`);
-          } else if (token !== "") {
-            xhr.setRequestHeader("Authorization", `Bearer ${token}`);
-          }
-        },
-      });
+    const hls = new Hls({
+      xhrSetup: function (xhr, url) {
+        let user = ""; // fill if needed
+        let pass = ""; // fill if needed
+        let token = ""; // fill if needed
 
-      hls.on(Hls.Events.MEDIA_ATTACHED, () => {
-        hls.loadSource("http://mediamtx-ip:8888/mystream/index.m3u8");
-      });
+        if (user !== "") {
+          const credentials = btoa(`${user}:${pass}`);
+          xhr.setRequestHeader("Authorization", `Basic ${credentials}`);
+        } else if (token !== "") {
+          xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+        }
+      },
+    });
 
-      hls.attachMedia(document.getElementById("myvideo"));
-    }
+    hls.on(Hls.Events.MEDIA_ATTACHED, () => {
+      hls.loadSource("http://mediamtx-ip:8888/mystream/index.m3u8");
+    });
+
+    // when the video is resumed after a manual or forced pause
+    // (i.e. when the window is minimized), restore live streaming.
+    video.onplay = () => {
+      video.currentTime = hls.liveSyncPosition;
+    };
+
+    hls.attachMedia(video);
   });
 </script>
 ```

--- a/internal/servers/hls/http_server.go
+++ b/internal/servers/hls/http_server.go
@@ -51,12 +51,6 @@ func sanitizeLocation(rawPath string, rawQuery string) string {
 	return res
 }
 
-func isIOS(userAgent string) bool {
-	return strings.Contains(userAgent, "iPad") ||
-		strings.Contains(userAgent, "iPhone") ||
-		strings.Contains(userAgent, "iPod")
-}
-
 type httpServer struct {
 	address        string
 	dumpPackets    bool
@@ -293,11 +287,13 @@ func (s *httpServer) onRequest(ctx *gin.Context) {
 		}
 
 		if ctx.Request.URL.Query().Get("cookieCheck") != "1" {
+			// this is for plain HTTP
 			http.SetCookie(ctx.Writer, &http.Cookie{
 				Name:  "cookieCheck",
 				Value: "1",
 			})
 
+			// this is for HTTPS
 			http.SetCookie(ctx.Writer, &http.Cookie{
 				Name:        "cookieCheck",
 				Value:       "1",
@@ -313,11 +309,6 @@ func (s *httpServer) onRequest(ctx *gin.Context) {
 			ctx.Writer.Header().Set("Location", sanitizeLocation(ctx.Request.URL.Path, ctx.Request.URL.RawQuery))
 
 			ctx.Writer.WriteHeader(http.StatusFound)
-			return
-		}
-
-		if _, err := ctx.Request.Cookie("cookieCheck"); err != nil && isIOS(ctx.Request.UserAgent()) {
-			s.writeErrorNoLog(ctx, http.StatusBadRequest, fmt.Errorf("HLS on iOS requires the server to set and read cookies"))
 			return
 		}
 
@@ -355,11 +346,13 @@ func (s *httpServer) onRequest(ctx *gin.Context) {
 		}
 
 		if cookie, err2 := ctx.Request.Cookie("cookieCheck"); err2 == nil && cookie.Value == "1" {
+			// this is for plain HTTP
 			http.SetCookie(ctx.Writer, &http.Cookie{
 				Name:  sessionCookieName,
 				Value: sx.secret.String(),
 			})
 
+			// this is for HTTPS
 			http.SetCookie(ctx.Writer, &http.Cookie{
 				Name:        sessionCookieName,
 				Value:       sx.secret.String(),


### PR DESCRIPTION
this was previously blocked because the session in query was meant to be dynamic, therefore incompatible with static playlists required by iOS. It is not anymore, so we can support that.