### PR TITLE
hls: prefer hls.js on iOS too

### DIFF
--- a/internal/servers/hls/index.html
+++ b/internal/servers/hls/index.html
@@ -93,17 +93,9 @@
         message.innerText = str;
       };
 
-      const isIOS = () =>
-        /iPad|iPhone|iPod/.test(navigator.platform) ||
-        (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
-
       const loadStream = () => {
-        // Prefer hls.js over native HLS.
-        // This is because some Android versions support native HLS
-        // but don't support fMP4s.
-        // Skip iPad iOS >= 13 and iPhone iOS >= 17,
-        // which support hls.js but don't support well maxLiveSyncPlaybackRate.
-        if (Hls.isSupported() && !isIOS()) {
+        // Prefer hls.js over native HLS, due to better protocol support.
+        if (Hls.isSupported()) {
           const hls = new Hls({
             maxLiveSyncPlaybackRate: 1.5,
           });


### PR DESCRIPTION
In the embedded HLS reader, use hls.js on iOS, that was previously disabled due to compatibility issues that should have been solved.