### PR TITLE
change default value of authHTTPExclude

### DIFF
--- a/docs/2-features/06-authentication.md
+++ b/docs/2-features/06-authentication.md
@@ -79,7 +79,6 @@ Authentication can be delegated to an external HTTP server:
 ```yml
 authMethod: http
 authHTTPAddress: http://myauthserver/auth
-authHTTPExclude: [] # explicitly clear authHTTPExclude to validate every action
 ```
 
 Each time a user needs to be authenticated, the specified URL will be requested with the POST method and this payload:

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -439,17 +439,6 @@ func (conf *Conf) setDefaults() {
 	// Authentication
 	conf.AuthMethod = AuthMethodInternal
 	conf.AuthInternalUsers = defaultAuthInternalUsers
-	conf.AuthHTTPExclude = []AuthInternalUserPermission{
-		{
-			Action: AuthActionAPI,
-		},
-		{
-			Action: AuthActionMetrics,
-		},
-		{
-			Action: AuthActionPprof,
-		},
-	}
 	conf.AuthJWTClaimKey = "mediamtx_permissions"
 
 	// Control API

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -93,10 +93,10 @@ authInternalUsers:
 
 # HTTP-based authentication.
 # URL called to perform authentication. Every time a user wants
-# to authenticate, the server calls this URL with the POST method
+# to perform an action, the server calls this URL with the POST method
 # and a payload described in the documentation.
-# If the response code is 20x, authentication is accepted, otherwise
-# it is discarded.
+# If the response code is 20x, the action is allowed, otherwise
+# it is forbidden.
 authHTTPAddress:
 # If the HTTP authentication URL has a self-signed or invalid certificate,
 # you can provide the fingerprint of the certificate in order to
@@ -106,10 +106,7 @@ authHTTPAddress:
 authHTTPFingerprint:
 # Actions to exclude from HTTP-based authentication.
 # Format is the same as the one of user permissions.
-authHTTPExclude:
-  - action: api
-  - action: metrics
-  - action: pprof
+authHTTPExclude: []
 
 # JWT-based authentication.
 # Users have to log in through an external identity server and obtain a JWT.


### PR DESCRIPTION
by default, do not exclude any action from HTTP authentication. Old value triggered several security warnings.