### PR TITLE
moq: make /moq URL suffix optional

### DIFF
--- a/internal/servers/moq/http_server.go
+++ b/internal/servers/moq/http_server.go
@@ -310,14 +310,18 @@ func (s *httpServer) onRequestHTTPS2(ctx *gin.Context) {
 }
 
 func (s *httpServer) onRequestHTTPS3(ctx *gin.Context) {
-	if ctx.Request.Method != http.MethodConnect ||
-		!strings.HasSuffix(ctx.Request.URL.Path, "/moq") ||
-		len(ctx.Request.URL.Path) <= len("/moq") {
+	if ctx.Request.Method != http.MethodConnect {
 		return
 	}
 
-	pathName := ctx.Request.URL.Path[1 : len(ctx.Request.URL.Path)-len("/moq")]
-	if len(pathName) == 0 {
+	pathName := ctx.Request.URL.Path[1:]
+
+	// support legacy /moq suffix
+	if strings.HasSuffix(pathName, "/moq") && len(pathName) > len("/moq") {
+		pathName = strings.TrimSuffix(pathName, "/moq")
+	}
+
+	if pathName == "" {
 		return
 	}
 

--- a/internal/servers/moq/publish_index.html
+++ b/internal/servers/moq/publish_index.html
@@ -192,9 +192,12 @@
       const onStream = (stream) => {
         video.srcObject = stream;
 
+        const wtURL = new URL(window.location.href);
+        wtURL.pathname = wtURL.pathname.replace(/\/publish$/, ""); // remove /publish
+
         publisher = new MediaMTXMoQPublisher({
           fingerprintUrl: new URL("fingerprint", window.location.href),
-          url: new URL("moq", window.location.href) + window.location.search,
+          url: wtURL.toString(),
           user: creds?.user,
           pass: creds?.pass,
           stream,

--- a/internal/servers/moq/read_index.html
+++ b/internal/servers/moq/read_index.html
@@ -78,10 +78,12 @@
         fetch(new URL("authmirror", window.location.href))
           .then((r) => (r.status !== 200 ? null : r.json()))
           .then((creds) => {
+            const wtURL = new URL(window.location.href);
+            wtURL.pathname = wtURL.pathname.replace(/\/$/, ""); // remove trailing slash
+
             reader = new MediaMTXMoQReader({
               fingerprintUrl: new URL("fingerprint", window.location.href),
-              url:
-                new URL("moq", window.location.href) + window.location.search,
+              url: wtURL.toString(),
               user: creds?.user,
               pass: creds?.pass,
               videoElement: document.getElementById("video"),

--- a/internal/servers/moq/server_test.go
+++ b/internal/servers/moq/server_test.go
@@ -234,7 +234,7 @@ func TestServer(t *testing.T) {
 			}
 			defer d.Close() //nolint:errcheck
 
-			res, sx, err := d.Dial(ctx, "https://127.0.0.1:19896/teststream/moq", nil)
+			res, sx, err := d.Dial(ctx, "https://127.0.0.1:19896/teststream", nil)
 			require.NoError(t, err)
 			defer sx.CloseWithError(0, "") //nolint:errcheck
 			defer res.Body.Close()         //nolint:errcheck
@@ -597,7 +597,7 @@ func TestServerAuthError(t *testing.T) {
 				}
 				defer d.Close() //nolint:errcheck
 
-				res, sx, err := d.Dial(ctx, "https://127.0.0.1:19896/teststream/moq", nil)
+				res, sx, err := d.Dial(ctx, "https://127.0.0.1:19896/teststream", nil)
 				require.NoError(t, err)
 				defer sx.CloseWithError(0, "") //nolint:errcheck
 				defer res.Body.Close()         //nolint:errcheck
@@ -723,7 +723,7 @@ func TestServerErrorUnsupportedVersion(t *testing.T) {
 	}
 	defer d.Close() //nolint:errcheck
 
-	res, _, err := d.Dial(ctx, "https://127.0.0.1:19896/teststream/moq", nil)
+	res, _, err := d.Dial(ctx, "https://127.0.0.1:19896/teststream", nil)
 	require.Error(t, err)
 	defer res.Body.Close()
 }
@@ -771,7 +771,7 @@ func TestServerErrorTooManyTracks(t *testing.T) {
 	}
 	defer d.Close() //nolint:errcheck
 
-	res, sx, err := d.Dial(ctx, "https://127.0.0.1:19896/teststream/moq", nil)
+	res, sx, err := d.Dial(ctx, "https://127.0.0.1:19896/teststream", nil)
 	require.NoError(t, err)
 	defer sx.CloseWithError(0, "") //nolint:errcheck
 	defer res.Body.Close()         //nolint:errcheck


### PR DESCRIPTION
In order to establish a MoQ session with WebTransport, a /moq suffix was required until now. This is now optional in order to allow connecting to the server with the standard MoQ URL format.