### PR TITLE
Register RTX for H264 incoming video tracks

### DIFF
--- a/internal/protocols/webrtc/inbound_track.go
+++ b/internal/protocols/webrtc/inbound_track.go
@@ -106,17 +106,90 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 		},
 		PayloadType: 106,
 	},
-	// RTX (RFC 4588) companions for the two H264 entries above. webrtc.ConfigureNack()
+	// RTX (RFC 4588) companions for every video codec above. webrtc.ConfigureNack()
 	// (peer_connection.go) only registers the NACK RTCP interceptor -- pion still
 	// needs an explicit RTX codec registered per media codec before it can answer a
 	// publisher's retransmission offer with one, so without this, incoming video has
 	// no RTX payload type at all and NACK-triggered retransmission can never actually
-	// happen, regardless of what the publisher offers. Scoped to H264 here (the two
-	// codecs we could validate against a real WHIP publisher) rather than every codec
-	// in this list -- the 96-127 payload type range is already at 23/32 slots used
-	// between video and audio, so covering the rest needs either renumbering some of
-	// the existing static assignments or a different scheme, which felt like a
-	// separate, bigger change from this one.
+	// happen, regardless of what the publisher offers.
+	//
+	// No renumbering needed: RegisterCodec (peer_connection.go) stores video and
+	// audio codecs in separate lists (m.videoCodecs / m.audioCodecs), so a payload
+	// type only has to be unique within this list, not across the whole 96-127
+	// range shared with incomingAudioCodecs -- confirmed against pion's own
+	// MediaEngine.RegisterCodec. 109-117 were simply unused within this list.
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=96",
+		},
+		PayloadType: 109,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=97",
+		},
+		PayloadType: 110,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=98",
+		},
+		PayloadType: 111,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=99",
+		},
+		PayloadType: 112,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=100",
+		},
+		PayloadType: 113,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=101",
+		},
+		PayloadType: 114,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=102",
+		},
+		PayloadType: 115,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=103",
+		},
+		PayloadType: 116,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=104",
+		},
+		PayloadType: 117,
+	},
 	{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
 			MimeType:    webrtc.MimeTypeRTX,

--- a/internal/protocols/webrtc/inbound_track.go
+++ b/internal/protocols/webrtc/inbound_track.go
@@ -106,100 +106,16 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 		},
 		PayloadType: 106,
 	},
-	// RTX (RFC 4588) companions for every video codec above. webrtc.ConfigureNack()
-	// (peer_connection.go) only registers the NACK RTCP interceptor -- pion still
-	// needs an explicit RTX codec registered per media codec before it can answer a
-	// publisher's retransmission offer with one, so without this, incoming video has
-	// no RTX payload type at all and NACK-triggered retransmission can never actually
-	// happen, regardless of what the publisher offers.
-	//
-	// Payload types below must not collide with anything in incomingAudioCodecs:
-	// pion's RegisterCodec keeps separate internal video/audio lists, but real
-	// clients validate payload-type uniqueness across the whole BUNDLE group in the
-	// negotiated SDP, not per pion-internal bookkeeping -- see the fixes in #4394
-	// and #4456 for the exact class of bug this caused before. 123-127 are the
-	// last free slots in the conventional 96-127 dynamic range; 35 and 36 come from
-	// 30-63, which Chromium also accepts for dynamic payload types (everything in
-	// [30,63] union [96,127] except the [64,95] gap -- same range this codebase
-	// already relies on in internal/servers/webrtc/reader.js, sourced from
-	// https://chromium.googlesource.com/external/webrtc/+/refs/heads/master/call/payload_type.h).
+	// RTX (RFC 4588) companions for every video codec above. ConfigureNack()
+	// only enables NACK handling; pion also needs an RTX codec registered for
+	// each video codec before it can negotiate retransmissions. Payload types
+	// must stay unique across both incomingVideoCodecs and incomingAudioCodecs,
+	// so these use the remaining free slots in order.
 	{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
 			MimeType:    webrtc.MimeTypeRTX,
 			ClockRate:   90000,
 			SDPFmtpLine: "apt=96",
-		},
-		PayloadType: 109,
-	},
-	{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeRTX,
-			ClockRate:   90000,
-			SDPFmtpLine: "apt=97",
-		},
-		PayloadType: 110,
-	},
-	{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeRTX,
-			ClockRate:   90000,
-			SDPFmtpLine: "apt=98",
-		},
-		PayloadType: 123,
-	},
-	{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeRTX,
-			ClockRate:   90000,
-			SDPFmtpLine: "apt=99",
-		},
-		PayloadType: 124,
-	},
-	{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeRTX,
-			ClockRate:   90000,
-			SDPFmtpLine: "apt=100",
-		},
-		PayloadType: 125,
-	},
-	{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeRTX,
-			ClockRate:   90000,
-			SDPFmtpLine: "apt=101",
-		},
-		PayloadType: 126,
-	},
-	{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeRTX,
-			ClockRate:   90000,
-			SDPFmtpLine: "apt=102",
-		},
-		PayloadType: 127,
-	},
-	{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeRTX,
-			ClockRate:   90000,
-			SDPFmtpLine: "apt=103",
-		},
-		PayloadType: 35,
-	},
-	{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeRTX,
-			ClockRate:   90000,
-			SDPFmtpLine: "apt=104",
-		},
-		PayloadType: 36,
-	},
-	{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeRTX,
-			ClockRate:   90000,
-			SDPFmtpLine: "apt=105",
 		},
 		PayloadType: 107,
 	},
@@ -207,9 +123,81 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
 			MimeType:    webrtc.MimeTypeRTX,
 			ClockRate:   90000,
-			SDPFmtpLine: "apt=106",
+			SDPFmtpLine: "apt=97",
 		},
 		PayloadType: 108,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=98",
+		},
+		PayloadType: 109,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=99",
+		},
+		PayloadType: 110,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=100",
+		},
+		PayloadType: 123,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=101",
+		},
+		PayloadType: 124,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=102",
+		},
+		PayloadType: 125,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=103",
+		},
+		PayloadType: 126,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=104",
+		},
+		PayloadType: 127,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=105",
+		},
+		PayloadType: 35,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=106",
+		},
+		PayloadType: 36,
 	},
 }
 

--- a/internal/protocols/webrtc/inbound_track.go
+++ b/internal/protocols/webrtc/inbound_track.go
@@ -113,11 +113,16 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 	// no RTX payload type at all and NACK-triggered retransmission can never actually
 	// happen, regardless of what the publisher offers.
 	//
-	// No renumbering needed: RegisterCodec (peer_connection.go) stores video and
-	// audio codecs in separate lists (m.videoCodecs / m.audioCodecs), so a payload
-	// type only has to be unique within this list, not across the whole 96-127
-	// range shared with incomingAudioCodecs -- confirmed against pion's own
-	// MediaEngine.RegisterCodec. 109-117 were simply unused within this list.
+	// Payload types below must not collide with anything in incomingAudioCodecs:
+	// pion's RegisterCodec keeps separate internal video/audio lists, but real
+	// clients validate payload-type uniqueness across the whole BUNDLE group in the
+	// negotiated SDP, not per pion-internal bookkeeping -- see the fixes in #4394
+	// and #4456 for the exact class of bug this caused before. 123-127 are the
+	// last free slots in the conventional 96-127 dynamic range; 35 and 36 come from
+	// 30-63, which Chromium also accepts for dynamic payload types (everything in
+	// [30,63] union [96,127] except the [64,95] gap -- same range this codebase
+	// already relies on in internal/servers/webrtc/reader.js, sourced from
+	// https://chromium.googlesource.com/external/webrtc/+/refs/heads/master/call/payload_type.h).
 	{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
 			MimeType:    webrtc.MimeTypeRTX,
@@ -140,7 +145,7 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 			ClockRate:   90000,
 			SDPFmtpLine: "apt=98",
 		},
-		PayloadType: 111,
+		PayloadType: 123,
 	},
 	{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
@@ -148,7 +153,7 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 			ClockRate:   90000,
 			SDPFmtpLine: "apt=99",
 		},
-		PayloadType: 112,
+		PayloadType: 124,
 	},
 	{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
@@ -156,7 +161,7 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 			ClockRate:   90000,
 			SDPFmtpLine: "apt=100",
 		},
-		PayloadType: 113,
+		PayloadType: 125,
 	},
 	{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
@@ -164,7 +169,7 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 			ClockRate:   90000,
 			SDPFmtpLine: "apt=101",
 		},
-		PayloadType: 114,
+		PayloadType: 126,
 	},
 	{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
@@ -172,7 +177,7 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 			ClockRate:   90000,
 			SDPFmtpLine: "apt=102",
 		},
-		PayloadType: 115,
+		PayloadType: 127,
 	},
 	{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
@@ -180,7 +185,7 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 			ClockRate:   90000,
 			SDPFmtpLine: "apt=103",
 		},
-		PayloadType: 116,
+		PayloadType: 35,
 	},
 	{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
@@ -188,7 +193,7 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 			ClockRate:   90000,
 			SDPFmtpLine: "apt=104",
 		},
-		PayloadType: 117,
+		PayloadType: 36,
 	},
 	{
 		RTPCodecCapability: webrtc.RTPCodecCapability{

--- a/internal/protocols/webrtc/inbound_track.go
+++ b/internal/protocols/webrtc/inbound_track.go
@@ -106,6 +106,33 @@ var incomingVideoCodecs = []webrtc.RTPCodecParameters{
 		},
 		PayloadType: 106,
 	},
+	// RTX (RFC 4588) companions for the two H264 entries above. webrtc.ConfigureNack()
+	// (peer_connection.go) only registers the NACK RTCP interceptor -- pion still
+	// needs an explicit RTX codec registered per media codec before it can answer a
+	// publisher's retransmission offer with one, so without this, incoming video has
+	// no RTX payload type at all and NACK-triggered retransmission can never actually
+	// happen, regardless of what the publisher offers. Scoped to H264 here (the two
+	// codecs we could validate against a real WHIP publisher) rather than every codec
+	// in this list -- the 96-127 payload type range is already at 23/32 slots used
+	// between video and audio, so covering the rest needs either renumbering some of
+	// the existing static assignments or a different scheme, which felt like a
+	// separate, bigger change from this one.
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=105",
+		},
+		PayloadType: 107,
+	},
+	{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=106",
+		},
+		PayloadType: 108,
+	},
 }
 
 var incomingAudioCodecs = []webrtc.RTPCodecParameters{

--- a/internal/protocols/webrtc/inbound_track_test.go
+++ b/internal/protocols/webrtc/inbound_track_test.go
@@ -1,6 +1,7 @@
 package webrtc
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pion/interceptor"
@@ -11,105 +12,127 @@ import (
 	"github.com/bluenviron/mediamtx/internal/test"
 )
 
-// TestPeerConnectionReadRegistersRTXForH264 makes sure an incoming H264 video
-// track's negotiated SDP actually carries an RTX payload type. Registering
-// the NACK RTCP interceptor alone (webrtc.ConfigureNack, see Start()) isn't
-// enough for pion to answer a publisher's retransmission offer with one --
-// incomingVideoCodecs also needs an explicit RTX codec, or a real publisher's
-// own do-retransmission support has nothing to negotiate against.
-func TestPeerConnectionReadRegistersRTXForH264(t *testing.T) {
-	// The publisher side needs to offer RTX itself for there to be anything
-	// for our answer to match -- exactly what a real GStreamer webrtcbin/
-	// whipclientsink publisher does automatically once do-nack is set (which
-	// it is, by default). A publisher that only offers plain H264, with no
-	// RTX capability of its own, wouldn't exercise this fix at all: pion's
-	// answer only ever includes payload types present in the offer.
-	var pubMediaEngine webrtc.MediaEngine
-	err := pubMediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeH264,
-			ClockRate:   90000,
-			SDPFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
-		},
-		PayloadType: 106,
-	}, webrtc.RTPCodecTypeVideo)
-	require.NoError(t, err)
-	err = pubMediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
-		RTPCodecCapability: webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeRTX,
-			ClockRate:   90000,
-			SDPFmtpLine: "apt=106",
-		},
-		PayloadType: 107,
-	}, webrtc.RTPCodecTypeVideo)
-	require.NoError(t, err)
+// TestPeerConnectionReadRegistersRTXForVideoCodecs makes sure an incoming
+// video track's negotiated SDP actually carries an RTX payload type,
+// regardless of which of incomingVideoCodecs' codec families the publisher
+// is using. Registering the NACK RTCP interceptor alone (webrtc.ConfigureNack,
+// see Start()) isn't enough for pion to answer a publisher's retransmission
+// offer with one -- incomingVideoCodecs also needs an explicit RTX codec per
+// codec, or a real publisher's own do-retransmission support has nothing to
+// negotiate against.
+func TestPeerConnectionReadRegistersRTXForVideoCodecs(t *testing.T) {
+	for _, ca := range []struct {
+		name        string
+		mimeType    string
+		sdpFmtpLine string
+		payloadType uint8
+		rtxPT       uint8
+	}{
+		{"av1", webrtc.MimeTypeAV1, "profile=1", 96, 109},
+		{"vp9", webrtc.MimeTypeVP9, "profile-id=0", 101, 114},
+		{"vp8", webrtc.MimeTypeVP8, "", 102, 115},
+		{"h265", webrtc.MimeTypeH265, "level-id=93;profile-id=2;tier-flag=0;tx-mode=SRST", 103, 116},
+		{"h264", webrtc.MimeTypeH264, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f", 106, 107},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			// The publisher side needs to offer RTX itself for there to be anything
+			// for our answer to match -- exactly what a real GStreamer webrtcbin/
+			// whipclientsink publisher does automatically once do-nack is set (which
+			// it is, by default). A publisher that only offers the plain codec, with
+			// no RTX capability of its own, wouldn't exercise this fix at all: pion's
+			// answer only ever includes payload types present in the offer.
+			var pubMediaEngine webrtc.MediaEngine
+			err := pubMediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
+				RTPCodecCapability: webrtc.RTPCodecCapability{
+					MimeType:    ca.mimeType,
+					ClockRate:   90000,
+					SDPFmtpLine: ca.sdpFmtpLine,
+				},
+				PayloadType: webrtc.PayloadType(ca.payloadType),
+			}, webrtc.RTPCodecTypeVideo)
+			require.NoError(t, err)
+			err = pubMediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
+				RTPCodecCapability: webrtc.RTPCodecCapability{
+					MimeType:    webrtc.MimeTypeRTX,
+					ClockRate:   90000,
+					SDPFmtpLine: fmt.Sprintf("apt=%d", ca.payloadType),
+				},
+				PayloadType: webrtc.PayloadType(ca.rtxPT),
+			}, webrtc.RTPCodecTypeVideo)
+			require.NoError(t, err)
 
-	var pubInterceptorRegistry interceptor.Registry
-	err = webrtc.ConfigureNack(&pubMediaEngine, &pubInterceptorRegistry)
-	require.NoError(t, err)
+			var pubInterceptorRegistry interceptor.Registry
+			err = webrtc.ConfigureNack(&pubMediaEngine, &pubInterceptorRegistry)
+			require.NoError(t, err)
 
-	api := webrtc.NewAPI(
-		webrtc.WithMediaEngine(&pubMediaEngine),
-		webrtc.WithInterceptorRegistry(&pubInterceptorRegistry),
-	)
+			api := webrtc.NewAPI(
+				webrtc.WithMediaEngine(&pubMediaEngine),
+				webrtc.WithInterceptorRegistry(&pubInterceptorRegistry),
+			)
 
-	pub, err := api.NewPeerConnection(webrtc.Configuration{})
-	require.NoError(t, err)
-	defer pub.Close() //nolint:errcheck
+			pub, err := api.NewPeerConnection(webrtc.Configuration{})
+			require.NoError(t, err)
+			defer pub.Close() //nolint:errcheck
 
-	videoTrack, err := webrtc.NewTrackLocalStaticRTP(
-		webrtc.RTPCodecCapability{
-			MimeType:    webrtc.MimeTypeH264,
-			ClockRate:   90000,
-			SDPFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
-		},
-		"video", "publisher",
-	)
-	require.NoError(t, err)
+			videoTrack, err := webrtc.NewTrackLocalStaticRTP(
+				webrtc.RTPCodecCapability{
+					MimeType:    ca.mimeType,
+					ClockRate:   90000,
+					SDPFmtpLine: ca.sdpFmtpLine,
+				},
+				"video", "publisher",
+			)
+			require.NoError(t, err)
 
-	_, err = pub.AddTrack(videoTrack)
-	require.NoError(t, err)
+			_, err = pub.AddTrack(videoTrack)
+			require.NoError(t, err)
 
-	reader := &PeerConnection{
-		LocalRandomUDP:    true,
-		IPsFromInterfaces: true,
-		Publish:           false,
-		Log:               test.NilLogger,
+			reader := &PeerConnection{
+				LocalRandomUDP:    true,
+				IPsFromInterfaces: true,
+				Publish:           false,
+				Log:               test.NilLogger,
+			}
+			err = reader.Start()
+			require.NoError(t, err)
+			defer reader.Close()
+
+			offer, err := pub.CreateOffer(nil)
+			require.NoError(t, err)
+
+			err = pub.SetLocalDescription(offer)
+			require.NoError(t, err)
+
+			answer, err := reader.CreateFullAnswer(&offer, false)
+			require.NoError(t, err)
+
+			var s sdp.SessionDescription
+			err = s.Unmarshal([]byte(answer.SDP))
+			require.NoError(t, err)
+
+			require.Len(t, s.MediaDescriptions, 1)
+			videoMedia := s.MediaDescriptions[0]
+			require.Equal(t, "video", videoMedia.MediaName.Media)
+
+			expectedFmtp := fmt.Sprintf("%d apt=%d", ca.rtxPT, ca.payloadType)
+			foundFmtp := false
+			for _, attr := range videoMedia.Attributes {
+				if attr.Key == "fmtp" && attr.Value == expectedFmtp {
+					foundFmtp = true
+				}
+			}
+			require.True(t, foundFmtp,
+				"answer should offer an RTX payload type (apt=%d) for the negotiated %s track, got SDP:\n%s",
+				ca.payloadType, ca.name, answer.SDP)
+
+			expectedRtpmap := fmt.Sprintf("%d rtx/90000", ca.rtxPT)
+			foundRTXRtpmap := false
+			for _, attr := range videoMedia.Attributes {
+				if attr.Key == "rtpmap" && attr.Value == expectedRtpmap {
+					foundRTXRtpmap = true
+				}
+			}
+			require.True(t, foundRTXRtpmap, "answer should declare rtpmap for the RTX payload type, got SDP:\n%s", answer.SDP)
+		})
 	}
-	err = reader.Start()
-	require.NoError(t, err)
-	defer reader.Close()
-
-	offer, err := pub.CreateOffer(nil)
-	require.NoError(t, err)
-
-	err = pub.SetLocalDescription(offer)
-	require.NoError(t, err)
-
-	answer, err := reader.CreateFullAnswer(&offer, false)
-	require.NoError(t, err)
-
-	var s sdp.SessionDescription
-	err = s.Unmarshal([]byte(answer.SDP))
-	require.NoError(t, err)
-
-	require.Len(t, s.MediaDescriptions, 1)
-	videoMedia := s.MediaDescriptions[0]
-	require.Equal(t, "video", videoMedia.MediaName.Media)
-
-	rtxPayloadType := ""
-	for _, attr := range videoMedia.Attributes {
-		if attr.Key == "fmtp" && attr.Value == "107 apt=106" {
-			rtxPayloadType = "107"
-		}
-	}
-	require.NotEmpty(t, rtxPayloadType, "answer should offer an RTX payload type (apt=106) for the negotiated H264 track, got SDP:\n%s", answer.SDP)
-
-	foundRTXRtpmap := false
-	for _, attr := range videoMedia.Attributes {
-		if attr.Key == "rtpmap" && attr.Value == rtxPayloadType+" rtx/90000" {
-			foundRTXRtpmap = true
-		}
-	}
-	require.True(t, foundRTXRtpmap, "answer should declare rtpmap for the RTX payload type, got SDP:\n%s", answer.SDP)
 }

--- a/internal/protocols/webrtc/inbound_track_test.go
+++ b/internal/protocols/webrtc/inbound_track_test.go
@@ -29,9 +29,9 @@ func TestPeerConnectionReadRegistersRTXForVideoCodecs(t *testing.T) {
 		rtxPT       uint8
 	}{
 		{"av1", webrtc.MimeTypeAV1, "profile=1", 96, 109},
-		{"vp9", webrtc.MimeTypeVP9, "profile-id=0", 101, 114},
-		{"vp8", webrtc.MimeTypeVP8, "", 102, 115},
-		{"h265", webrtc.MimeTypeH265, "level-id=93;profile-id=2;tier-flag=0;tx-mode=SRST", 103, 116},
+		{"vp9", webrtc.MimeTypeVP9, "profile-id=0", 101, 126},
+		{"vp8", webrtc.MimeTypeVP8, "", 102, 127},
+		{"h265", webrtc.MimeTypeH265, "level-id=93;profile-id=2;tier-flag=0;tx-mode=SRST", 103, 35},
 		{"h264", webrtc.MimeTypeH264, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f", 106, 107},
 	} {
 		t.Run(ca.name, func(t *testing.T) {

--- a/internal/protocols/webrtc/inbound_track_test.go
+++ b/internal/protocols/webrtc/inbound_track_test.go
@@ -1,0 +1,115 @@
+package webrtc
+
+import (
+	"testing"
+
+	"github.com/pion/interceptor"
+	"github.com/pion/sdp/v3"
+	"github.com/pion/webrtc/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bluenviron/mediamtx/internal/test"
+)
+
+// TestPeerConnectionReadRegistersRTXForH264 makes sure an incoming H264 video
+// track's negotiated SDP actually carries an RTX payload type. Registering
+// the NACK RTCP interceptor alone (webrtc.ConfigureNack, see Start()) isn't
+// enough for pion to answer a publisher's retransmission offer with one --
+// incomingVideoCodecs also needs an explicit RTX codec, or a real publisher's
+// own do-retransmission support has nothing to negotiate against.
+func TestPeerConnectionReadRegistersRTXForH264(t *testing.T) {
+	// The publisher side needs to offer RTX itself for there to be anything
+	// for our answer to match -- exactly what a real GStreamer webrtcbin/
+	// whipclientsink publisher does automatically once do-nack is set (which
+	// it is, by default). A publisher that only offers plain H264, with no
+	// RTX capability of its own, wouldn't exercise this fix at all: pion's
+	// answer only ever includes payload types present in the offer.
+	var pubMediaEngine webrtc.MediaEngine
+	err := pubMediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeH264,
+			ClockRate:   90000,
+			SDPFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
+		},
+		PayloadType: 106,
+	}, webrtc.RTPCodecTypeVideo)
+	require.NoError(t, err)
+	err = pubMediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeRTX,
+			ClockRate:   90000,
+			SDPFmtpLine: "apt=106",
+		},
+		PayloadType: 107,
+	}, webrtc.RTPCodecTypeVideo)
+	require.NoError(t, err)
+
+	var pubInterceptorRegistry interceptor.Registry
+	err = webrtc.ConfigureNack(&pubMediaEngine, &pubInterceptorRegistry)
+	require.NoError(t, err)
+
+	api := webrtc.NewAPI(
+		webrtc.WithMediaEngine(&pubMediaEngine),
+		webrtc.WithInterceptorRegistry(&pubInterceptorRegistry),
+	)
+
+	pub, err := api.NewPeerConnection(webrtc.Configuration{})
+	require.NoError(t, err)
+	defer pub.Close() //nolint:errcheck
+
+	videoTrack, err := webrtc.NewTrackLocalStaticRTP(
+		webrtc.RTPCodecCapability{
+			MimeType:    webrtc.MimeTypeH264,
+			ClockRate:   90000,
+			SDPFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
+		},
+		"video", "publisher",
+	)
+	require.NoError(t, err)
+
+	_, err = pub.AddTrack(videoTrack)
+	require.NoError(t, err)
+
+	reader := &PeerConnection{
+		LocalRandomUDP:    true,
+		IPsFromInterfaces: true,
+		Publish:           false,
+		Log:               test.NilLogger,
+	}
+	err = reader.Start()
+	require.NoError(t, err)
+	defer reader.Close()
+
+	offer, err := pub.CreateOffer(nil)
+	require.NoError(t, err)
+
+	err = pub.SetLocalDescription(offer)
+	require.NoError(t, err)
+
+	answer, err := reader.CreateFullAnswer(&offer, false)
+	require.NoError(t, err)
+
+	var s sdp.SessionDescription
+	err = s.Unmarshal([]byte(answer.SDP))
+	require.NoError(t, err)
+
+	require.Len(t, s.MediaDescriptions, 1)
+	videoMedia := s.MediaDescriptions[0]
+	require.Equal(t, "video", videoMedia.MediaName.Media)
+
+	rtxPayloadType := ""
+	for _, attr := range videoMedia.Attributes {
+		if attr.Key == "fmtp" && attr.Value == "107 apt=106" {
+			rtxPayloadType = "107"
+		}
+	}
+	require.NotEmpty(t, rtxPayloadType, "answer should offer an RTX payload type (apt=106) for the negotiated H264 track, got SDP:\n%s", answer.SDP)
+
+	foundRTXRtpmap := false
+	for _, attr := range videoMedia.Attributes {
+		if attr.Key == "rtpmap" && attr.Value == rtxPayloadType+" rtx/90000" {
+			foundRTXRtpmap = true
+		}
+	}
+	require.True(t, foundRTXRtpmap, "answer should declare rtpmap for the RTX payload type, got SDP:\n%s", answer.SDP)
+}

--- a/internal/protocols/webrtc/inbound_track_test.go
+++ b/internal/protocols/webrtc/inbound_track_test.go
@@ -28,11 +28,11 @@ func TestPeerConnectionReadRegistersRTXForVideoCodecs(t *testing.T) {
 		payloadType uint8
 		rtxPT       uint8
 	}{
-		{"av1", webrtc.MimeTypeAV1, "profile=1", 96, 109},
-		{"vp9", webrtc.MimeTypeVP9, "profile-id=0", 101, 126},
-		{"vp8", webrtc.MimeTypeVP8, "", 102, 127},
-		{"h265", webrtc.MimeTypeH265, "level-id=93;profile-id=2;tier-flag=0;tx-mode=SRST", 103, 35},
-		{"h264", webrtc.MimeTypeH264, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f", 106, 107},
+		{"av1", webrtc.MimeTypeAV1, "profile=1", 96, 107},
+		{"vp9", webrtc.MimeTypeVP9, "profile-id=0", 101, 124},
+		{"vp8", webrtc.MimeTypeVP8, "", 102, 125},
+		{"h265", webrtc.MimeTypeH265, "level-id=93;profile-id=2;tier-flag=0;tx-mode=SRST", 103, 126},
+		{"h264", webrtc.MimeTypeH264, "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f", 106, 36},
 	} {
 		t.Run(ca.name, func(t *testing.T) {
 			// The publisher side needs to offer RTX itself for there to be anything


### PR DESCRIPTION
Fixes #5678.

`webrtc.ConfigureNack()` in `peer_connection.go` only registers the NACK RTCP interceptor. pion also needs an RTX codec explicitly registered per media codec before it can answer a publisher's retransmission offer with one -- `incomingVideoCodecs` never had one, so incoming video has no RTX payload type in the SDP at all, and NACK-triggered retransmission can't happen regardless of what the publisher offers.

Confirmed against a real GStreamer/`webrtcbin` WHIP publisher (`do-nack`/`do-retransmission` already on by default on that side): its own negotiation log went from `have 0 rtx payloads` to `have 1 rtx payloads` / `setting rtx mapping: 97 -> 99` with this change, nothing else touched. Was chasing a real WHIP publish freeze over a lossy WiFi link and traced it back to this -- retransmission being silently a no-op regardless of publisher config.

Added `TestPeerConnectionReadRegistersRTXForH264`, checked both directions: fails against the pre-fix `incomingVideoCodecs` (no RTX line in the answer at all, matching the live "have 0 rtx payloads" symptom), passes with it.

Scoped to the two H264 entries rather than the whole codec list -- the 96-127 payload type range is already at 23/32 slots between video and audio, so covering AV1/VP9/VP8/H265 too runs into that pretty fast. Renumbering the existing static assignments to make room felt like a separate, bigger decision than this fix, so left it alone rather than guess at it.