### PR TITLE
httpp: propagate Flush() through the response writer wrappers

### DIFF
--- a/internal/protocols/httpp/handler_flush_test.go
+++ b/internal/protocols/httpp/handler_flush_test.go
@@ -1,0 +1,90 @@
+package httpp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bluenviron/mediamtx/internal/test"
+)
+
+// A handler that flushes mid-response must have its bytes reach the client
+// before it returns. Both wrappers between the http.Server and the handler
+// (handlerLogger's responseRecorder and handlerWriteTimeout's
+// writeTimeoutWriter) sit in that path, so a missing Flusher on either one
+// silently withholds the output until the handler is done — which defeats
+// server-sent events and any other long response.
+func TestResponseWriterWrappersPropagateFlush(t *testing.T) {
+	flushed := make(chan struct{})
+	release := make(chan struct{})
+
+	var h http.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		f, ok := w.(http.Flusher)
+		require.True(t, ok, "handler must see a Flusher")
+
+		_, err := w.Write([]byte("data: first\n\n"))
+		require.NoError(t, err)
+		f.Flush()
+
+		close(flushed)
+		<-release
+	})
+
+	h = &handlerLogger{h, test.NilLogger}
+	h = &handlerWriteTimeout{h, 10 * time.Second}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	s := &http.Server{Handler: h, ReadHeaderTimeout: 10 * time.Second}
+	go s.Serve(ln)
+	defer s.Shutdown(context.Background())
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"))
+	require.NoError(t, err)
+
+	<-flushed
+
+	// The handler is still blocked on `release`, so anything that arrives now
+	// arrived because of the Flush, not because the response was closed. Without
+	// the flush propagating, nothing arrives and the deadline below fires.
+	err = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+
+	// Skip the status line and headers.
+	for {
+		line, err2 := br.ReadString('\n')
+		require.NoError(t, err2)
+		if line == "\r\n" {
+			break
+		}
+	}
+
+	// No Content-Length, so the body is chunked: accumulate until the payload
+	// shows up, since a single Read may return just the chunk size line.
+	var got []byte
+	buf := make([]byte, 256)
+	for !bytes.Contains(got, []byte("data: first")) {
+		n, err2 := br.Read(buf)
+		require.NoError(t, err2)
+		got = append(got, buf[:n]...)
+	}
+
+	close(release)
+}

--- a/internal/protocols/httpp/handler_logger.go
+++ b/internal/protocols/httpp/handler_logger.go
@@ -158,3 +158,16 @@ func (h *handlerLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	h.log.Log(logger.Debug, "[conn %v] [s->c] %s", r.RemoteAddr, resRecorder.dump())
 }
+
+// Flush propagates the flush to the wrapped writer, so that handlers streaming
+// a long response (server-sent events) are not held until they return.
+func (w *responseRecorder) Flush() {
+	if f, ok := w.w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap lets http.ResponseController reach the underlying writer.
+func (w *responseRecorder) Unwrap() http.ResponseWriter {
+	return w.w
+}

--- a/internal/protocols/httpp/handler_write_timeout.go
+++ b/internal/protocols/httpp/handler_write_timeout.go
@@ -42,3 +42,17 @@ func (h *handlerWriteTimeout) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	h.h.ServeHTTP(ww, r)
 }
+
+// Flush propagates the flush to the wrapped writer. Without it, a handler that
+// streams a long response (server-sent events) has its output held until it
+// returns, which is exactly the case the type was written to support.
+func (w *writeTimeoutWriter) Flush() {
+	if f, ok := w.w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap lets http.ResponseController reach the underlying writer.
+func (w *writeTimeoutWriter) Unwrap() http.ResponseWriter {
+	return w.w
+}


### PR DESCRIPTION
### Problem

`handlerLogger`'s `responseRecorder` and `handlerWriteTimeout`'s `writeTimeoutWriter` both wrap `http.ResponseWriter` but implement neither `http.Flusher` nor `Unwrap()`.

Since both sit between `http.Server` and the handler, any handler that flushes mid-response has that flush silently dropped — the output only reaches the client when the handler returns.

This defeats the stated purpose of `writeTimeoutWriter`, whose own comment says it exists so one can:

> write long responses, splitted in chunks, without causing timeouts

The deadline is indeed reset per `Write()`, but nothing ever leaves the buffer until the end.

### How I ran into it

Adding a `text/event-stream` endpoint on a local branch: events written and flushed at t=0.4s only reached the client at t=2.2s, when the handler returned. The server logged each flush at the right time, which made it look like a client problem for a while.

### Fix

`Flush()` on both wrappers, plus `Unwrap()` so `http.ResponseController` can reach the underlying writer.

### Test

`TestResponseWriterWrappersPropagateFlush` drives a real listener through both wrappers and reads the body **while the handler is still blocked**, so anything that arrives arrived because of the flush and not because the response closed. It fails on current `main` by hitting the read deadline.

I kept this PR to the `httpp` fix alone — it is independent of what I was building when I found it.