### PR TITLE
docs: Twitch Enhanced Broadcasting clarification

### DIFF
--- a/docs/2-features/11-forward.md
+++ b/docs/2-features/11-forward.md
@@ -127,3 +127,8 @@ paths:
       # Also replace rtmp:// with rtmps:// in order to enable encryption in-transit.
       - dest: rtmps://ingest.global-contribute.live-video.net/app#streamKey
 ```
+
+**Warning**: Enhanced Broadcasting (2K / HEVC / Dual Format).
+Although MediaMTX supports Enhanced RTMP (including H.265/HEVC and multitrack video), the simple `forward` mechanism above only works with classic single-track H.264.
+Twitch Enhanced Broadcasting requires a special Automatic Stream Configuration (ASC) handshake that returns a dynamic ERTMP ingest endpoint. The static URL listed in the Recommended Ingest Endpoints page does not support this flow and will reject HEVC / multitrack streams.
+For Enhanced Broadcasting use a compatible client (OBS Studio with Enhanced Broadcasting enabled) that performs the ASC handshake itself.


### PR DESCRIPTION
Add a clarification to the Twitch forward documentation regarding Enhanced Broadcasting (HEVC and multitrack video).

Static RTMP/RTMPS forwarding only works for classic single-track H.264 streams. Twitch Enhanced Broadcasting requires an ASC (Automatic Stream Configuration) handshake and dynamic ingest endpoints, which are not supported via the standard `forward` directive.