### PR TITLE
metrics: add remoteAddr field to forward section entry

### DIFF
--- a/docs/2-features/22-metrics.md
+++ b/docs/2-features/22-metrics.md
@@ -156,8 +156,8 @@ moq_sessions_inbound_bytes{id="[id]",path="[path]",remoteAddr="[remoteAddr]",sta
 moq_sessions_outbound_bytes{id="[id]",path="[path]",remoteAddr="[remoteAddr]",state="[state]"} 187
 
 # Forward destinations
-forward_dests{id="[id]",path="[path]",protocol="[protocol]",state="[state]"} 1
-forward_dests_outbound_bytes{id="[id]",path="[path]",protocol="[protocol]",state="[state]"} 1234
+forward_dests{id="[id]",path="[path]",protocol="[protocol]",remoteAddr="[remoteAddr]",state="[state]"} 1
+forward_dests_outbound_bytes{id="[id]",path="[path]",protocol="[protocol]",remoteAddr="[remoteAddr]",state="[state]"} 1234
 ```
 
 Bitrates are not provided directly as metrics because they can be computed from received and sent bytes by any metrics analyzer (i.e. Grafana).

--- a/internal/core/forward_test.go
+++ b/internal/core/forward_test.go
@@ -392,6 +392,14 @@ func TestPathForwardRTMP(t *testing.T) {
 			item.Protocol == defs.APIForwardDestProtocolRTMP &&
 			item.OutboundBytes > 0
 	}, 5*time.Second, 100*time.Millisecond)
+
+	destURL, err := url.Parse(dest)
+	require.NoError(t, err)
+
+	var item defs.APIForwardDest
+	httpRequest(t, hc, http.MethodGet,
+		"http://localhost:9997/v3/paths/forward/get?path=source&id="+added.ID.String(), nil, &item)
+	require.Equal(t, destURL.Host, item.RemoteAddr)
 }
 
 func TestPathForwardRTMPReconnectsAfterSourceUnavailable(t *testing.T) {

--- a/internal/defs/api_forward.go
+++ b/internal/defs/api_forward.go
@@ -42,6 +42,7 @@ type APIForwardDest struct {
 	State         APIForwardDestState    `json:"state"`
 	LastError     string                 `json:"lastError"`
 	OutboundBytes uint64                 `json:"outboundBytes"`
+	RemoteAddr    string                 `json:"remoteAddr"`
 }
 
 // APIForwardDestList is a list of forward destinations.

--- a/internal/forward/dest.go
+++ b/internal/forward/dest.go
@@ -8,4 +8,5 @@ import (
 type Dest interface {
 	Run(context.Context) error
 	OutboundBytes() uint64
+	RemoteAddr() string
 }

--- a/internal/forward/dest_handler.go
+++ b/internal/forward/dest_handler.go
@@ -112,6 +112,13 @@ func (h *DestHandler) outboundBytesLocked() uint64 {
 	return outboundBytes
 }
 
+func (h *DestHandler) remoteAddrLocked() string {
+	if h.activeDest != nil {
+		return h.activeDest.RemoteAddr()
+	}
+	return ""
+}
+
 func destProtocol(dest string) defs.APIForwardDestProtocol {
 	switch {
 	case strings.HasPrefix(dest, "rtmp://"):
@@ -263,6 +270,7 @@ func (h *DestHandler) APIItem() defs.APIForwardDest {
 	defer h.mutex.RUnlock()
 
 	outboundBytes := h.outboundBytesLocked()
+	remoteAddr := h.remoteAddrLocked()
 
 	return defs.APIForwardDest{
 		ID:            h.uuid,
@@ -273,5 +281,6 @@ func (h *DestHandler) APIItem() defs.APIForwardDest {
 		State:         h.state,
 		LastError:     h.lastError,
 		OutboundBytes: outboundBytes,
+		RemoteAddr:    remoteAddr,
 	}
 }

--- a/internal/forward/rtmp/dest.go
+++ b/internal/forward/rtmp/dest.go
@@ -74,6 +74,7 @@ type Dest struct {
 
 	mutex             sync.RWMutex
 	outboundBytesFunc func() uint64
+	remoteAddr        string
 }
 
 // Log implements logger.Writer.
@@ -90,6 +91,13 @@ func (d *Dest) OutboundBytes() uint64 {
 		return 0
 	}
 	return d.outboundBytesFunc()
+}
+
+// RemoteAddr returns the address of the remote peer.
+func (d *Dest) RemoteAddr() string {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.remoteAddr
 }
 
 // Run runs the destination.
@@ -133,6 +141,7 @@ func (d *Dest) Run(ctx context.Context) error {
 func (d *Dest) runInner(conn *gortmplib.Client, terminate <-chan struct{}) error {
 	d.mutex.Lock()
 	d.outboundBytesFunc = conn.BytesSent
+	d.remoteAddr = conn.NetConn().RemoteAddr().String()
 	d.mutex.Unlock()
 
 	r := &stream.Reader{Parent: d}

--- a/internal/forward/rtsp/dest.go
+++ b/internal/forward/rtsp/dest.go
@@ -29,6 +29,7 @@ type Dest struct {
 
 	mutex             sync.RWMutex
 	outboundBytesFunc func() uint64
+	remoteAddr        string
 }
 
 // Log implements logger.Writer.
@@ -45,6 +46,13 @@ func (d *Dest) OutboundBytes() uint64 {
 		return 0
 	}
 	return d.outboundBytesFunc()
+}
+
+// RemoteAddr returns the address of the remote peer.
+func (d *Dest) RemoteAddr() string {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.remoteAddr
 }
 
 // Run runs the destination.
@@ -123,6 +131,7 @@ func (d *Dest) runInner(client *gortsplib.Client, desc *description.Session, ter
 	d.outboundBytesFunc = func() uint64 {
 		return client.Stats().Session.OutboundBytes
 	}
+	d.remoteAddr = client.NetConn().RemoteAddr().String()
 	d.mutex.Unlock()
 
 	r := &stream.Reader{Parent: d}

--- a/internal/forward/srt/dest.go
+++ b/internal/forward/srt/dest.go
@@ -30,6 +30,7 @@ type Dest struct {
 
 	mutex             sync.RWMutex
 	outboundBytesFunc func() uint64
+	remoteAddr        string
 }
 
 // Log implements logger.Writer.
@@ -46,6 +47,13 @@ func (d *Dest) OutboundBytes() uint64 {
 		return 0
 	}
 	return d.outboundBytesFunc()
+}
+
+// RemoteAddr returns the address of the remote peer.
+func (d *Dest) RemoteAddr() string {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.remoteAddr
 }
 
 // Run runs the destination.
@@ -98,6 +106,7 @@ func (d *Dest) runInner(ctx context.Context, address string, srtConf srtlib.Conf
 		conn.Stats(&stats)
 		return stats.Accumulated.ByteSent
 	}
+	d.remoteAddr = conn.RemoteAddr().String()
 	d.mutex.Unlock()
 
 	r := &stream.Reader{Parent: d}

--- a/internal/forward/webrtc/dest.go
+++ b/internal/forward/webrtc/dest.go
@@ -49,6 +49,19 @@ func (d *Dest) OutboundBytes() uint64 {
 	return client.PeerConnection().Stats().BytesSent
 }
 
+// RemoteAddr returns the address of the remote peer.
+func (d *Dest) RemoteAddr() string {
+	d.mutex.RLock()
+	client := d.client
+	d.mutex.RUnlock()
+
+	if client == nil || client.PeerConnection() == nil {
+		return ""
+	}
+
+	return client.PeerConnection().RemoteAddr()
+}
+
 // Run runs the destination.
 func (d *Dest) Run(ctx context.Context) error {
 	u, err := url.Parse(d.Dest)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -380,10 +380,11 @@ func (m *Metrics) onMetrics(ctx *gin.Context) {
 				out.WriteString("# Forward destinations\n")
 				for _, i := range items {
 					ta := tags(map[string]string{
-						"id":       i.item.ID.String(),
-						"path":     i.path,
-						"protocol": string(i.item.Protocol),
-						"state":    string(i.item.State),
+						"id":         i.item.ID.String(),
+						"path":       i.path,
+						"protocol":   string(i.item.Protocol),
+						"state":      string(i.item.State),
+						"remoteAddr": i.item.RemoteAddr,
 					})
 
 					metric(&out, "forward_dests", ta, 1)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1121,9 +1121,9 @@ func TestForwardMetrics(t *testing.T) {
 	require.Equal(t,
 		"# Forward destinations\n"+
 			"forward_dests{id=\"5b9a82ca-3cb8-46d1-a80b-6b716ccfcafe\","+
-			"path=\"mypath\",protocol=\"rtmp\",state=\"forwarding\"} 1\n"+
+			"path=\"mypath\",protocol=\"rtmp\",remoteAddr=\"\",state=\"forwarding\"} 1\n"+
 			"forward_dests_outbound_bytes{id=\"5b9a82ca-3cb8-46d1-a80b-6b716ccfcafe\",path=\"mypath\","+
-			"protocol=\"rtmp\",state=\"forwarding\"} 321\n"+
+			"protocol=\"rtmp\",remoteAddr=\"\",state=\"forwarding\"} 321\n"+
 			"\n",
 		string(byts))
 }

--- a/internal/protocols/webrtc/peer_connection.go
+++ b/internal/protocols/webrtc/peer_connection.go
@@ -1028,6 +1028,17 @@ func (co *PeerConnection) RemoteCandidate() string {
 	return candidateLabel(cp.Remote)
 }
 
+// RemoteAddr returns the address of the selected remote candidate.
+// It returns an empty string if the candidate pair has not been selected yet.
+func (co *PeerConnection) RemoteAddr() string {
+	cp, err := co.wr.SCTP().Transport().ICETransport().GetSelectedCandidatePair()
+	if err != nil || cp == nil || cp.Remote == nil {
+		return ""
+	}
+
+	return net.JoinHostPort(cp.Remote.Address, strconv.FormatInt(int64(cp.Remote.Port), 10))
+}
+
 func bytesStats(wr *webrtc.PeerConnection) (uint64, uint64) {
 	for _, stats := range wr.GetStats() {
 		if tstats, ok := stats.(webrtc.TransportStats); ok {


### PR DESCRIPTION
Add `remoteAddr` to forward destination metrics

### Motivation

There is currently no way to correlate MediaMTX outgoing forward connections with OS-level network statistics
(netstat, ss, firewall counters, etc.), because neither the metrics nor the API expose the address of the remote peer each forward destination is connected to.

This adds a remoteAddr field to the forward destinations item and a remoteAddr label to the forward_dests metric.

### Implementation

- Dest interface (internal/forward/dest.go) gains a RemoteAddr() string method; DestHandler exposes it through the existing activeDest mechanism, so it's only populated while a connection is actually active.
- Each protocol reports its peer address once the connection is established:
  - RTMP / RTSP: taken from the underlying control connection (client.NetConn().RemoteAddr()).
  - SRT: taken from conn.RemoteAddr() after dial.
  - WHIP: resolved on demand from the selected ICE candidate pair (GetSelectedCandidatePair()); new PeerConnection.RemoteAddr() helper in internal/protocols/webrtc.
- The value is empty ("") when no connection is established - i.e. while the destination is idle, during connection attempts, and in the error state between retries. This is consistent across all protocols.

### Notes

- For RTSP destinations using UDP transport, the address reported is that of the TCP control connection (server host), not the UDP flow.

Closes https://github.com/bluenviron/mediamtx/issues/6058