### PR TITLE
drop support for Debian Bullseye

### DIFF
--- a/docker/ffmpeg-rpi.Dockerfile
+++ b/docker/ffmpeg-rpi.Dockerfile
@@ -6,15 +6,15 @@ ADD binaries/mediamtx_*_linux_armv7.tar.gz /linux/arm/v7
 ADD binaries/mediamtx_*_linux_arm64.tar.gz /linux/arm64
 
 #################################################################
-FROM --platform=linux/arm/v7 debian:bullseye-slim AS base-arm-v7
+FROM --platform=linux/arm/v7 debian:bookworm-slim AS base-arm-v7
 
 # even though the base image is armv7,
 # Raspbian libraries and compilers provide armv6 compatibility.
 
 RUN apt update \
 	&& apt install -y wget gpg \
-	&& echo "deb http://archive.raspbian.org/raspbian bullseye main rpi firmware" > /etc/apt/sources.list \
-	&& echo "deb http://archive.raspberrypi.org/debian bullseye main" > /etc/apt/sources.list.d/raspi.list \
+	&& echo "deb http://archive.raspbian.org/raspbian bookworm main rpi firmware" > /etc/apt/sources.list \
+	&& echo "deb http://archive.raspberrypi.org/debian bookworm main" > /etc/apt/sources.list.d/raspi.list \
 	&& wget -O- https://archive.raspbian.org/raspbian.public.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspbian.gpg \
 	&& wget -O- https://archive.raspberrypi.org/debian/raspberrypi.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspberrypi.gpg \
 	&& rm -rf /var/lib/apt/lists/*
@@ -26,11 +26,11 @@ RUN apt update && apt install --reinstall -y \
     && rm -rf /var/lib/apt/lists/*
 
 #################################################################
-FROM --platform=linux/arm64 debian:bullseye-slim AS base-arm64
+FROM --platform=linux/arm64 debian:bookworm-slim AS base-arm64
 
 RUN apt update \
 	&& apt install -y wget gpg \
-	&& echo "deb http://archive.raspberrypi.org/debian bullseye main" > /etc/apt/sources.list.d/raspi.list \
+	&& echo "deb http://archive.raspberrypi.org/debian bookworm main" > /etc/apt/sources.list.d/raspi.list \
 	&& wget -O- https://archive.raspberrypi.org/debian/raspberrypi.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspberrypi.gpg \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/docker/rpi.Dockerfile
+++ b/docker/rpi.Dockerfile
@@ -6,15 +6,15 @@ ADD binaries/mediamtx_*_linux_armv7.tar.gz /linux/arm/v7
 ADD binaries/mediamtx_*_linux_arm64.tar.gz /linux/arm64
 
 #################################################################
-FROM --platform=linux/arm/v7 debian:bullseye-slim AS base-arm-v7
+FROM --platform=linux/arm/v7 debian:bookworm-slim AS base-arm-v7
 
 # even though the base image is armv7,
 # Raspbian libraries and compilers provide armv6 compatibility.
 
 RUN apt update \
 	&& apt install -y wget gpg \
-	&& echo "deb http://archive.raspbian.org/raspbian bullseye main rpi firmware" > /etc/apt/sources.list \
-	&& echo "deb http://archive.raspberrypi.org/debian bullseye main" > /etc/apt/sources.list.d/raspi.list \
+	&& echo "deb http://archive.raspbian.org/raspbian bookworm main rpi firmware" > /etc/apt/sources.list \
+	&& echo "deb http://archive.raspberrypi.org/debian bookworm main" > /etc/apt/sources.list.d/raspi.list \
 	&& wget -O- https://archive.raspbian.org/raspbian.public.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspbian.gpg \
 	&& wget -O- https://archive.raspberrypi.org/debian/raspberrypi.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspberrypi.gpg \
 	&& rm -rf /var/lib/apt/lists/*
@@ -26,11 +26,11 @@ RUN apt update && apt install --reinstall -y \
     && rm -rf /var/lib/apt/lists/*
 
 #################################################################
-FROM --platform=linux/arm64 debian:bullseye-slim AS base-arm64
+FROM --platform=linux/arm64 debian:bookworm-slim AS base-arm64
 
 RUN apt update \
 	&& apt install -y wget gpg \
-	&& echo "deb http://archive.raspberrypi.org/debian bullseye main" > /etc/apt/sources.list.d/raspi.list \
+	&& echo "deb http://archive.raspberrypi.org/debian bookworm main" > /etc/apt/sources.list.d/raspi.list \
 	&& wget -O- https://archive.raspberrypi.org/debian/raspberrypi.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/raspberrypi.gpg \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/docs/3-publish/14-raspberry-pi-cameras.md
+++ b/docs/3-publish/14-raspberry-pi-cameras.md
@@ -1,15 +1,13 @@
 # Raspberry Pi Cameras
 
-_MediaMTX_ natively supports most Raspberry Pi Camera models, enabling high-quality and low-latency video streaming from the camera to any user, for any purpose. There are some additional requirements:
+_MediaMTX_ natively supports most Raspberry Pi Camera models, enabling high-quality and low-latency video streaming from the camera to any user, for any purpose.
 
-1. The server must run on a Raspberry Pi, with one of the following operating systems:
-   - Raspberry Pi OS Trixie
-   - Raspberry Pi OS Bookworm
-   - Raspberry Pi OS Bullseye
+The server must run on a Raspberry Pi, with one of the following operating systems:
 
-   Both 32-bit and 64-bit architectures are supported.
+- Raspberry Pi OS Trixie
+- Raspberry Pi OS Bookworm
 
-2. If you are using Raspberry Pi OS Bullseye, make sure that the legacy camera stack is disabled. Type `sudo raspi-config`, then go to `Interfacing options`, `enable/disable legacy camera support`, choose `no`. Reboot the system.
+Both 32-bit and 64-bit architectures are supported.
 
 The setup procedure depends on whether you want to run the server outside or inside Docker:
 


### PR DESCRIPTION
Bullseye reached EOL on 31st august 2026.