### PR TITLE
hls: validate hlsSegmentCount according to the HLS variant

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -948,6 +948,20 @@ func (conf *Conf) Validate(l logger.Writer) error {
 		if conf.HLSAddress == "" {
 			return fmt.Errorf("'hlsAddress' must be set when HLS is enabled")
 		}
+
+		// gohlslib enforces these minimums when the muxer is started:
+		// https://github.com/bluenviron/gohlslib/blob/0df41de8f33f2e1f2231e4c4bec9a9331bc6449b/muxer.go#L316-L326
+		switch conf.HLSVariant {
+		case HLSVariant(gohlslib.MuxerVariantLowLatency):
+			if conf.HLSSegmentCount < 7 {
+				return fmt.Errorf("'hlsSegmentCount' must be at least 7 when 'hlsVariant' is 'lowLatency'")
+			}
+
+		default:
+			if conf.HLSSegmentCount < 3 {
+				return fmt.Errorf("'hlsSegmentCount' must be at least 3")
+			}
+		}
 	}
 
 	if conf.HLSCDNSecret != "" {

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -806,6 +806,48 @@ func TestConfErrors(t *testing.T) {
 			"'hlsAddress' must be set when HLS is enabled",
 		},
 		{
+			"hlsSegmentCount below lowLatency variant minimum",
+			"hls: yes\n" +
+				"hlsVariant: lowLatency\n" +
+				"hlsSegmentCount: 6\n",
+			"'hlsSegmentCount' must be at least 7 when 'hlsVariant' is 'lowLatency'",
+		},
+		{
+			"hlsSegmentCount at lowLatency variant minimum",
+			"hls: yes\n" +
+				"hlsVariant: lowLatency\n" +
+				"hlsSegmentCount: 7\n",
+			"",
+		},
+		{
+			"hlsSegmentCount below fmp4 variant minimum",
+			"hls: yes\n" +
+				"hlsVariant: fmp4\n" +
+				"hlsSegmentCount: 2\n",
+			"'hlsSegmentCount' must be at least 3",
+		},
+		{
+			"hlsSegmentCount at fmp4 variant minimum",
+			"hls: yes\n" +
+				"hlsVariant: fmp4\n" +
+				"hlsSegmentCount: 3\n",
+			"",
+		},
+		{
+			"hlsSegmentCount zero with lowLatency variant",
+			"hls: yes\n" +
+				"hlsVariant: lowLatency\n" +
+				"hlsSegmentCount: 0\n",
+			"'hlsSegmentCount' must be at least 7 when 'hlsVariant' is 'lowLatency'",
+		},
+		{
+			"hlsSegmentCount not validated when HLS is disabled",
+			"hls: no\n" +
+				"hlsVariant: lowLatency\n" +
+				"hlsSegmentCount: 1\n",
+			"",
+		},
+		{
 			"missing webrtcAddress with WebRTC enabled",
 			"webrtc: yes\n" +
 				"webrtcAddress: ''\n",


### PR DESCRIPTION
## Description

A `hlsSegmentCount` below the muxer's minimum is not rejected at startup. The server starts normally, and the misconfiguration only appears at runtime, when an HLS muxer is actually created.

gohlslib refuses to start a muxer whose segment count is below the minimum of the selected variant: 7 for `lowLatency`, 3 for the other variants ([muxer.go lines 316-326 at v2.4.3](https://github.com/bluenviron/gohlslib/blob/v2.4.3/muxer.go#L316-L326)). MediaMTX passes `hlsSegmentCount` to the muxer without checking it ([muxer_instance.go#L95](https://github.com/bluenviron/mediamtx/blob/e175003c71a9f8f154632fe45c73c99abd606e99/internal/servers/hls/muxer_instance.go#L95)). With `hlsAlwaysRemux: true`, the muxer is created automatically and the server recreates the crashed instance every 10 seconds (`recreateInstancePause`), filling the log with the same error over and over. Without it, every playback attempt creates an on-demand muxer that fails immediately, leaving only an INF-level `destroyed` line to explain why. For anyone not watching the logs, the only visible symptom is that HLS playback doesn't work.

### Reproduction

Configuration with an invalid segment count:

```yaml
hlsVariant: lowLatency
hlsSegmentCount: 6
hlsAlwaysRemux: true
```

Startup succeeds. As soon as a stream is published:

```
18:33:19 INF [HLS] [muxer test] created automatically
18:33:19 ERR [HLS] [muxer test] muxer instance crashed: Low-Latency HLS requires at least 7 segments
18:33:29 ERR [HLS] [muxer test] muxer instance crashed: Low-Latency HLS requires at least 7 segments
18:33:39 ERR [HLS] [muxer test] muxer instance crashed: Low-Latency HLS requires at least 7 segments
(repeats every 10 seconds while the stream remains available)
```

### Fix

`Conf.Validate()` now checks `hlsSegmentCount` against the same limits, mirroring gohlslib's own check: at least 7 with the `lowLatency` variant, at least 3 with the other variants. Since the check lives in the common validation step, it applies to the configuration file, environment variables and the API config endpoints alike. It runs only when HLS is enabled, like the existing `hlsAddress` check.

The same configuration is now rejected with:

```
ERR: 'hlsSegmentCount' must be at least 7 when 'hlsVariant' is 'lowLatency'
```

Note: `hlsSegmentCount: 0`, which currently works because gohlslib silently replaces it with its default of 7 ([muxer.go lines 225-227](https://github.com/bluenviron/gohlslib/blob/v2.4.3/muxer.go#L225-L227)), is rejected as well.

Boundary values keep working: `lowLatency` with 7 and `mpegts`/`fmp4` with 3 start normally, and `lowLatency` with 7 was verified against a live publisher (no muxer crash, multivariant playlist served).
