### PR TITLE
fix external command exit code reporting on non-Windows platforms

### DIFF
--- a/internal/externalcmd/cmd_os.go
+++ b/internal/externalcmd/cmd_os.go
@@ -44,7 +44,7 @@ func (c *Cmd) runOSSpecific(cmdstr string, env []string) error {
 				return 0
 			}
 			if ee, ok := errors.AsType[*exec.ExitError](err2); ok {
-				ee.ExitCode()
+				return ee.ExitCode()
 			}
 			return 0
 		}()

--- a/internal/externalcmd/cmd_test.go
+++ b/internal/externalcmd/cmd_test.go
@@ -42,3 +42,44 @@ func TestCmdRunExpandAfterSplit(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "it's\n", string(byts))
 }
+
+func TestCmdExitCode(t *testing.T) {
+	for _, ca := range []struct {
+		name    string
+		restart bool
+	}{
+		{"standard", false},
+		{"restart", true},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			p := &Pool{}
+			p.Initialize()
+			// Close() only waits on the WaitGroup: cmd.Close() must run first
+			// (defers are LIFO), otherwise the restart case never returns.
+			defer p.Close()
+
+			exited := make(chan error, 1)
+
+			cmd := &Cmd{
+				Pool:    p,
+				Cmdstr:  "sh -c 'exit 5'",
+				Restart: ca.restart,
+				OnExit: func(err error) {
+					select {
+					case exited <- err:
+					default:
+					}
+				},
+			}
+			cmd.Start()
+			defer cmd.Close()
+
+			select {
+			case err := <-exited:
+				require.EqualError(t, err, "command exited with code 5")
+			case <-time.After(10 * time.Second):
+				t.Fatal("timeout")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Since v1.4.2, the exit of a hook command that returns a non-zero code is reported incorrectly on non-Windows platforms. This affects every hook that logs its command's exit (`runOnInit`, `runOnDemand`, `runOnConnect`, `runOnOnline`, `runOnAvailable`, `runOnRead`):

* with `runOn*Restart: no` (the default), no "command exited" line is emitted — MediaMTX itself reports nothing about the failure;
* with `runOn*Restart: yes`, each non-zero exit is logged as `command exited with code 0`.

## Reproduction

```yaml
paths:
  test:
    runOnInit: sh -c 'exit 1'
    runOnInitRestart: yes
```

Current `main`:

```
INF [path test] runOnInit command started
INF [path test] runOnInit command exited: command exited with code 0
(repeats every 5 seconds)
```

With this PR:

```
INF [path test] runOnInit command started
INF [path test] runOnInit command exited: command exited with code 1
(repeats every 5 seconds)
```

With `runOnInitRestart: no`, current `main` prints no "runOnInit command exited" line; with this PR the same `code 1` line is printed.

## Cause

Regression introduced in #2868 (`7437ee7a`; the file was named `internal/externalcmd/cmd_unix.go` at the time): while converting the type assertion to `errors.As`, the `return` was dropped:

```diff
-			ee, ok := err.(*exec.ExitError)
-			if !ok {
-				return 0
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
+				ee.ExitCode()
 			}
-			return ee.ExitCode()
+			return 0
```

Since then `ee.ExitCode()` is computed and discarded and the goroutine always returns 0, so a non-zero exit can never be reported on these platforms. Later refactors (the file rename in #5787 and the `errors.As` → `errors.AsType` conversion in #5834) carried the broken shape over unchanged. The Windows implementation is not affected (`cmd_os_windows.go` still has `return ee.ExitCode()`).

## Fix

Restore the dropped `return` in `internal/externalcmd/cmd_os.go` (single line), matching the Windows implementation, and add a regression test that asserts the reported code for a command exiting with code 5, in both restart modes.

## Impact

User-visible impact is limited to log output. Restart decisions remain controlled exclusively by the `runOn*Restart` flags; restart timing, hook lifecycle and path handling are unchanged. The fix only restores the real exit code to the existing `OnExit` logging callbacks; as a consequence, a non-zero exit with `runOn*Restart: no` is now logged instead of being silent. As before the regression, a command terminated by a signal is reported with code -1 (the value `(*exec.ExitError).ExitCode()` returns in that case); commands stopped by MediaMTX itself are unaffected, since that path returns before `OnExit` is invoked.
