### PR TITLE
conf: support YAML version directives

### DIFF
--- a/internal/conf/yamlwrapper/unmarshal.go
+++ b/internal/conf/yamlwrapper/unmarshal.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/lexer"
 	"github.com/goccy/go-yaml/parser"
 	"github.com/goccy/go-yaml/token"
 
@@ -77,20 +78,45 @@ func convertLegacyBools(node ast.Node) ast.Node {
 
 // Unmarshal loads the configuration from YAML.
 func Unmarshal(buf []byte, dest any) error {
-	file, err := parser.ParseBytes(buf, parser.ParseComments)
+	tokens := lexer.Tokenize(string(buf))
+	// Empty documents are not always represented in file.Docs.
+	documentHeaders := 0
+	for _, tk := range tokens {
+		if tk.Type == token.DocumentHeaderType {
+			documentHeaders++
+		}
+	}
+
+	if documentHeaders > 1 {
+		return fmt.Errorf("invalid YAML")
+	}
+
+	file, err := parser.Parse(tokens, parser.ParseComments)
 	if err != nil {
 		return err
 	}
 
-	if len(file.Docs) != 1 {
+	var doc *ast.DocumentNode
+	for _, candidate := range file.Docs {
+		if _, ok := candidate.Body.(*ast.DirectiveNode); ok {
+			continue
+		}
+
+		if doc != nil {
+			return fmt.Errorf("invalid YAML")
+		}
+		doc = candidate
+	}
+
+	if doc == nil {
 		return fmt.Errorf("invalid YAML")
 	}
 
-	file.Docs[0] = convertLegacyBools(file.Docs[0]).(*ast.DocumentNode)
+	doc = convertLegacyBools(doc).(*ast.DocumentNode)
 
 	var temp any
-	if file.Docs[0].Body != nil {
-		err = yaml.NodeToValue(file.Docs[0].Body, &temp)
+	if doc.Body != nil {
+		err = yaml.NodeToValue(doc.Body, &temp)
 		if err != nil {
 			return err
 		}

--- a/internal/conf/yamlwrapper/unmarshal.go
+++ b/internal/conf/yamlwrapper/unmarshal.go
@@ -76,18 +76,42 @@ func convertLegacyBools(node ast.Node) ast.Node {
 	return node
 }
 
-// Unmarshal loads the configuration from YAML.
-func Unmarshal(buf []byte, dest any) error {
-	tokens := lexer.Tokenize(string(buf))
-	// Empty documents are not always represented in file.Docs.
+func countDocumentHeaders(tokens token.Tokens) int {
 	documentHeaders := 0
 	for _, tk := range tokens {
 		if tk.Type == token.DocumentHeaderType {
 			documentHeaders++
 		}
 	}
+	return documentHeaders
+}
 
-	if documentHeaders > 1 {
+func findDocument(docs []*ast.DocumentNode) (*ast.DocumentNode, error) {
+	var doc *ast.DocumentNode
+
+	for _, candidate := range docs {
+		if _, ok := candidate.Body.(*ast.DirectiveNode); ok {
+			continue
+		}
+
+		if doc != nil {
+			return nil, fmt.Errorf("invalid YAML")
+		}
+		doc = candidate
+	}
+
+	if doc == nil {
+		return nil, fmt.Errorf("invalid YAML")
+	}
+
+	return doc, nil
+}
+
+// Unmarshal loads the configuration from YAML.
+func Unmarshal(buf []byte, dest any) error {
+	tokens := lexer.Tokenize(string(buf))
+
+	if countDocumentHeaders(tokens) > 1 {
 		return fmt.Errorf("invalid YAML")
 	}
 
@@ -96,20 +120,9 @@ func Unmarshal(buf []byte, dest any) error {
 		return err
 	}
 
-	var doc *ast.DocumentNode
-	for _, candidate := range file.Docs {
-		if _, ok := candidate.Body.(*ast.DirectiveNode); ok {
-			continue
-		}
-
-		if doc != nil {
-			return fmt.Errorf("invalid YAML")
-		}
-		doc = candidate
-	}
-
-	if doc == nil {
-		return fmt.Errorf("invalid YAML")
+	doc, err := findDocument(file.Docs)
+	if err != nil {
+		return err
 	}
 
 	doc = convertLegacyBools(doc).(*ast.DocumentNode)

--- a/internal/conf/yamlwrapper/unmarshal_test.go
+++ b/internal/conf/yamlwrapper/unmarshal_test.go
@@ -64,6 +64,108 @@ func TestUnmarshalLegacyBools(t *testing.T) {
 	require.Equal(t, true, result.Field1)
 }
 
+func TestUnmarshalDirective(t *testing.T) {
+	t.Run("mapping", func(t *testing.T) {
+		input := []byte("%YAML 1.1\n" +
+			"---\n" +
+			"# --- inside a comment\n" +
+			"field: yes\n")
+
+		var result struct {
+			Field bool `json:"field"`
+		}
+		err := Unmarshal(input, &result)
+		require.NoError(t, err)
+		require.True(t, result.Field)
+	})
+
+	t.Run("version 1.2", func(t *testing.T) {
+		input := []byte("%YAML 1.2\n" +
+			"---\n" +
+			"field: value\n")
+
+		var result map[string]string
+		err := Unmarshal(input, &result)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"field": "value"}, result)
+	})
+
+	t.Run("document marker in literal", func(t *testing.T) {
+		input := []byte("%YAML 1.1\n" +
+			"---\n" +
+			"field: |\n" +
+			"  ---\n")
+
+		var result map[string]string
+		err := Unmarshal(input, &result)
+		require.NoError(t, err)
+		require.Equal(t, map[string]string{"field": "---\n"}, result)
+	})
+
+	t.Run("empty document", func(t *testing.T) {
+		input := []byte("%YAML 1.1\n" +
+			"---\n")
+
+		var result any
+		err := Unmarshal(input, &result)
+		require.NoError(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("duplicate key", func(t *testing.T) {
+		input := []byte("%YAML 1.1\n" +
+			"---\n" +
+			"key: value1\n" +
+			"key: value2\n")
+
+		err := Unmarshal(input, &map[string]string{})
+		require.ErrorContains(t, err, "mapping key \"key\" already defined")
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		input := []byte("%YAML 1.1\n" +
+			"---\n" +
+			"unknown: value\n")
+
+		var result struct{}
+		err := Unmarshal(input, &result)
+		require.EqualError(t, err, "json: unknown field \"unknown\"")
+	})
+}
+
+func TestUnmarshalMultipleDocuments(t *testing.T) {
+	for _, ca := range []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "without directive",
+			input: "field: one\n---\nfield: two\n",
+		},
+		{
+			name:  "with directive",
+			input: "%YAML 1.1\n---\nfield: one\n---\nfield: two\n",
+		},
+		{
+			name:  "empty before document",
+			input: "%YAML 1.1\n---\n# empty\n---\nfield: two\n",
+		},
+		{
+			name:  "empty after document",
+			input: "%YAML 1.1\n---\nfield: one\n---\n",
+		},
+		{
+			name:  "empty before document without directive",
+			input: "---\n---\nfield: two\n",
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			err := Unmarshal([]byte(ca.input), &map[string]string{})
+			require.EqualError(t, err, "invalid YAML")
+		})
+	}
+}
+
 func TestUnmarshalEmpty(t *testing.T) {
 	input := []byte(``)
 


### PR DESCRIPTION
Fixes #6049.

goccy/go-yaml represents a YAML version directive as a separate document node. This change excludes directive nodes when selecting the configuration document, while continuing to reject streams with multiple document headers or multiple actual documents.

Tests:
- `go test ./internal/conf/yamlwrapper -count=1`
- `go test ./internal/conf/... -count=1`
- `GOARCH=386 CGO_ENABLED=0 go test ./internal/conf/yamlwrapper -count=1`
- `go test ./internal/conf/yamlwrapper -run '^$' -fuzz '^FuzzUnmarshal$' -fuzztime=10s`