### PR TITLE
confwatcher: add polling fallback for changes fsnotify doesn't report

### DIFF
--- a/docs/2-features/05-configuration.md
+++ b/docs/2-features/05-configuration.md
@@ -14,7 +14,7 @@ There are several ways to change configuration parameters:
      docker run --rm -it --network=host -v "$PWD/mediamtx.yml:/mediamtx.yml:ro" bluenviron/mediamtx:1
      ```
 
-   The configuration can be changed dynamically when the server is running (hot reloading) by writing to the configuration file. Changes are detected and applied without disconnecting existing clients, whenever it's possible.
+   The configuration can be changed dynamically when the server is running (hot reloading) by writing to the configuration file. Changes are detected and applied without disconnecting existing clients, whenever it's possible. Changes are normally detected through filesystem notifications; a periodic check is also performed as a fallback, for setups (for example some Docker bind mounts) where filesystem notifications aren't propagated.
 
 2. Use environment variables, in the format `MTX_PARAMNAME`, where `PARAMNAME` is the uppercase name of a parameter. For instance, the `rtspAddress` parameter can be overridden in the following way:
 

--- a/internal/confwatcher/confwatcher.go
+++ b/internal/confwatcher/confwatcher.go
@@ -12,7 +12,26 @@ import (
 const (
 	minInterval    = 1 * time.Second
 	additionalWait = 10 * time.Millisecond
+
+	// pollInterval is the interval at which the watched file is periodically
+	// stat()ed, as a backstop for setups (for example Docker bind mounts)
+	// where fsnotify never receives events for changes made on the host.
+	pollInterval = 1 * time.Second
 )
+
+// fileState holds the file attributes used to detect changes through polling.
+type fileState struct {
+	modTime time.Time
+	size    int64
+}
+
+func statFileState(path string) (fileState, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fileState{}, false
+	}
+	return fileState{modTime: info.ModTime(), size: info.Size()}, true
+}
 
 // ConfWatcher is a configuration file watcher.
 type ConfWatcher struct {
@@ -71,6 +90,10 @@ func (w *ConfWatcher) run() {
 
 	var lastCalled time.Time
 	previousWatchedPath, _ := filepath.EvalSymlinks(w.absolutePath)
+	lastState, _ := statFileState(w.absolutePath)
+
+	pollTicker := time.NewTicker(pollInterval)
+	defer pollTicker.Stop()
 
 outer:
 	for {
@@ -94,7 +117,31 @@ outer:
 				// wait some additional time to allow the writer to complete its job
 				time.Sleep(additionalWait)
 				previousWatchedPath = currentWatchedPath
+				lastState, _ = statFileState(w.absolutePath)
 
+				lastCalled = time.Now()
+
+				select {
+				case w.signal <- struct{}{}:
+				case <-w.terminate:
+					break outer
+				}
+			}
+
+		case <-pollTicker.C:
+			if time.Since(lastCalled) < minInterval {
+				continue
+			}
+
+			currentState, exists := statFileState(w.absolutePath)
+			if !exists {
+				// watched file was removed; wait for it to reappear before reloading
+				lastState = fileState{}
+				continue
+			}
+
+			if currentState != lastState {
+				lastState = currentState
 				lastCalled = time.Now()
 
 				select {

--- a/internal/confwatcher/confwatcher.go
+++ b/internal/confwatcher/confwatcher.go
@@ -33,6 +33,10 @@ func statFileState(path string) (fileState, bool) {
 	return fileState{modTime: info.ModTime(), size: info.Size()}, true
 }
 
+func (s fileState) equal(other fileState) bool {
+	return s.modTime.Equal(other.modTime) && s.size == other.size
+}
+
 // ConfWatcher is a configuration file watcher.
 type ConfWatcher struct {
 	FilePath string
@@ -99,10 +103,6 @@ outer:
 	for {
 		select {
 		case event := <-w.inner.Events:
-			if time.Since(lastCalled) < minInterval {
-				continue
-			}
-
 			currentWatchedPath, _ := filepath.EvalSymlinks(w.absolutePath)
 			eventPath, _ := filepath.Abs(event.Name)
 			eventPath, _ = filepath.EvalSymlinks(eventPath)
@@ -118,6 +118,13 @@ outer:
 				time.Sleep(additionalWait)
 				previousWatchedPath = currentWatchedPath
 				lastState, _ = statFileState(w.absolutePath)
+
+				// keep lastState in sync even when the signal itself is throttled,
+				// otherwise the poll ticker compares against a stale lastState and
+				// fires a spurious extra reload once minInterval elapses
+				if time.Since(lastCalled) < minInterval {
+					continue
+				}
 
 				lastCalled = time.Now()
 
@@ -140,8 +147,10 @@ outer:
 				continue
 			}
 
-			if currentState != lastState {
-				lastState = currentState
+			if !currentState.equal(lastState) {
+				// wait some additional time to allow the writer to complete its job
+				time.Sleep(additionalWait)
+				lastState, _ = statFileState(w.absolutePath)
 				lastCalled = time.Now()
 
 				select {

--- a/internal/confwatcher/confwatcher_test.go
+++ b/internal/confwatcher/confwatcher_test.go
@@ -79,8 +79,11 @@ func TestWriteMultipleTimes(t *testing.T) {
 		return
 	}
 
+	// the second window must be longer than minInterval+pollInterval: the
+	// throttled second write must not leave the poll fallback with a stale
+	// state that it then (wrongly) reports as a further change
 	select {
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(2500 * time.Millisecond):
 	case <-w.Watch():
 		t.Errorf("should not happen")
 		return

--- a/internal/confwatcher/confwatcher_test.go
+++ b/internal/confwatcher/confwatcher_test.go
@@ -2,6 +2,7 @@ package confwatcher_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -141,6 +142,44 @@ func TestSymlinkDeleteCreate(t *testing.T) {
 	select {
 	case <-w.Watch():
 	case <-time.After(500 * time.Millisecond):
+		t.Errorf("timed out")
+		return
+	}
+}
+
+// TestPollFallback reproduces a setup in which fsnotify never receives
+// events for changes to the watched file, similarly to what happens with
+// Docker bind mounts, where changes made on the host are invisible to the
+// inotify watch running inside the container. fsnotify watches the parent
+// directory of the file it's pointed at; here, the watched path is a
+// symlink whose target lives in a different, unwatched directory, so
+// writes to the target never generate an event in the watched directory.
+// The change must still be detected by the periodic stat-based poll.
+func TestPollFallback(t *testing.T) {
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "conf.yml")
+	err := os.WriteFile(targetPath, []byte("{}"), 0o644)
+	require.NoError(t, err)
+
+	symDir := t.TempDir()
+	symPath := filepath.Join(symDir, "conf.yml")
+	err = os.Symlink(targetPath, symPath)
+	require.NoError(t, err)
+
+	w := &confwatcher.ConfWatcher{FilePath: symPath}
+	err = w.Initialize()
+	require.NoError(t, err)
+	defer w.Close()
+
+	// give the poll loop time to record its initial file state
+	time.Sleep(10 * time.Millisecond)
+
+	err = os.WriteFile(targetPath, []byte(`{"x":1}`), 0o644)
+	require.NoError(t, err)
+
+	select {
+	case <-w.Watch():
+	case <-time.After(3 * time.Second):
 		t.Errorf("timed out")
 		return
 	}


### PR DESCRIPTION
## What

Adds a periodic stat-based polling backstop to `ConfWatcher` so hot-reload still works when fsnotify never receives events for the watched configuration file, as reported in #2661 for Docker bind mounts.

## Why

`ConfWatcher` relies solely on fsnotify watching the parent directory of the configuration file. On some setups — most commonly a configuration file exposed into a container through a Docker bind mount — changes made outside the container never generate an fsnotify event inside it, because fsnotify only watches the parent directory and Docker's bind-mount propagation does not forward host-side inotify events into the container. As a result, hot reloading silently does nothing: no logs, no error, no reload.

This has been reported repeatedly since 2023 (#2661, reopened, with maintainer confirmation that it's a real Docker limitation), and there is no existing fallback path in the code.

## Fix

`ConfWatcher.run()` now also runs a `time.Ticker`-based poll (every second) alongside the existing fsnotify watch. On each tick it `os.Stat()`s the watched file and compares its modification time and size (via a small `fileState`/`equal()` helper, to avoid a direct `time.Time` `!=` comparison) against the last known values; if they differ, it waits `additionalWait` and re-stats — mirroring the existing fsnotify branch's "let the writer finish" behavior — before delivering a signal through the same channel and `minInterval` dedup path used by the fsnotify branch. fsnotify remains the fast path for setups where it works correctly; polling is purely a backstop, and the two paths share `lastState`/`lastCalled` so a change reported by one is not re-reported by the other.

While adding the poll path, a pre-existing edge case surfaced: on a throttled fsnotify event (two writes within `minInterval`), the code used to skip updating `lastState` entirely, leaving it pointing at the first, already-signaled write. Once `minInterval` elapsed, the poll ticker would then compare the real (second-write) mtime against that stale `lastState`, see a mismatch, and fire a spurious extra reload roughly one poll interval later. `lastState` is now refreshed whenever a real on-disk change is observed, whether or not the signal itself gets throttled, so the poll ticker no longer disagrees with what fsnotify already handled.

The hot-reloading paragraph in `docs/2-features/05-configuration.md` now mentions the polling fallback.

## Testing

All verification was run inside `golang:1.26-alpine` via a local Linux VM (Colima/Docker), matching this repo's CI (ubuntu-24.04, Go 1.26, golangci-lint v2.13.2, `RACE=-race`). macOS was intentionally not used for the authoritative runs, since fsnotify's kqueue backend follows symlinks differently than Linux inotify and would give a false pass on the new test.

- Added `TestPollFallback`, which reproduces the "fsnotify never fires" condition without needing Docker: the watched path is a symlink whose target lives in a different, unwatched directory, so fsnotify (which only watches the symlink's parent directory) never sees an event for writes to the target, exercising the poll path exclusively.
- RED (pre-fix `confwatcher.go` + new test): `go test ./internal/confwatcher/... -v` → `confwatcher_test.go:183: timed out`, `--- FAIL: TestPollFallback (3.02s)`, `FAIL github.com/bluenviron/mediamtx/internal/confwatcher [exit FAIL]`; the 5 pre-existing tests still passed unmodified.
- GREEN (fix applied): `go test ./internal/confwatcher/... -v -count=1` → `--- PASS: TestNoFile (0.00s)`, `--- PASS: TestWrite (0.01s)`, `--- PASS: TestWriteMultipleTimes (0.52s)`, `--- PASS: TestDeleteCreate (0.03s)`, `--- PASS: TestSymlinkDeleteCreate (0.02s)`, `--- PASS: TestPollFallback (1.01s)`, `PASS`, `ok github.com/bluenviron/mediamtx/internal/confwatcher 1.587s`.
- A follow-up review pass caught the throttled-event/spurious-reload edge case described above. `TestWriteMultipleTimes`'s post-signal wait window was extended from 500ms to 2500ms (longer than `minInterval` + `pollInterval`) so it also exercises the poll ticker; this reproduces the regression against the pre-fix code (`TestWriteMultipleTimes` fails at ~2.01s with "should not happen") and passes once the `lastState` refresh fix is applied (full 2.52s, genuinely exercising the poll-tick window).
- Race/flake check: `go test ./internal/confwatcher/... -race -count=3 -v` (`CGO_ENABLED=1`) → all 18 sub-runs (6 tests × 3 reps) pass, `ok github.com/bluenviron/mediamtx/internal/confwatcher 5.765s`, no data races reported.
- Lint: `golangci-lint run ./internal/confwatcher/...` (v2.13.2, 30 active linters incl. gofmt/gofumpt/govet/staticcheck/gocritic/revive/dupl/errcheck) → `0 issues`.
- `gofmt -l internal/confwatcher/` → clean, on both macOS host and inside the Linux container.
- `go vet` and `go build` on `internal/confwatcher` and `internal/certloader` (the other `ConfWatcher` consumer, cert/key hot-reload) → clean on macOS host, used only to confirm the package compiles standalone.
- Not run: the full `make test`/`make test-internal` suite (whole-repo, well beyond the scope of this 2-file change) and `make lint-conf`/`lint-docslinks`/`lint-docsorder` (no docs schema or link structure touched — only prose was added to an existing paragraph).

Diff is surgical: `internal/confwatcher/confwatcher.go`, `internal/confwatcher/confwatcher_test.go`, and one sentence added to `docs/2-features/05-configuration.md`. No unrelated refactors, no new dependencies.

Fixes #2661
