### PR TITLE
webrtc: add webrtcIPFromHostHeader option to derive an ICE candidate from the Host header

### DIFF
--- a/docs/2-features/25-webrtc-specific-features.md
+++ b/docs/2-features/25-webrtc-specific-features.md
@@ -40,6 +40,12 @@ The first thing to do is making sure that `webrtcAdditionalHosts` includes your 
 webrtcAdditionalHosts: [192.168.x.x, 1.2.3.4, my-dns.example.org, ...]
 ```
 
+If the server's IP isn't known in advance (for instance because it's assigned by DHCP, or the server runs inside a Docker container without host networking), enable `webrtcIPFromHostHeader` instead, which advertises the host contained in the HTTP Host header of each request. For security reasons, only IP addresses are accepted; hostnames in the Host header are ignored:
+
+```yml
+webrtcIPFromHostHeader: true
+```
+
 If there's a NAT / container between server and clients, it must be configured to route all incoming UDP packets on port 8189 to the server. If you're using Docker, this can be achieved with the flag:
 
 ```sh

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -383,6 +383,7 @@ type Conf struct {
 	WebRTCIPsFromInterfaces     bool              `json:"webrtcIPsFromInterfaces"`
 	WebRTCIPsFromInterfacesList []string          `json:"webrtcIPsFromInterfacesList"`
 	WebRTCAdditionalHosts       []string          `json:"webrtcAdditionalHosts"`
+	WebRTCIPFromHostHeader      bool              `json:"webrtcIPFromHostHeader"`
 	WebRTCICEServers2           []WebRTCICEServer `json:"webrtcICEServers2"`
 	WebRTCSTUNGatherTimeout     Duration          `json:"webrtcSTUNGatherTimeout"`
 	WebRTCHandshakeTimeout      Duration          `json:"webrtcHandshakeTimeout"`
@@ -1044,8 +1045,9 @@ func (conf *Conf) Validate(l logger.Writer) error {
 		}
 
 		if conf.WebRTCLocalUDPAddress != "" || conf.WebRTCLocalTCPAddress != "" {
-			if !conf.WebRTCIPsFromInterfaces && len(conf.WebRTCAdditionalHosts) == 0 {
-				return fmt.Errorf("at least one between 'webrtcIPsFromInterfaces' or 'webrtcAdditionalHosts' must be filled")
+			if !conf.WebRTCIPsFromInterfaces && len(conf.WebRTCAdditionalHosts) == 0 && !conf.WebRTCIPFromHostHeader {
+				return fmt.Errorf("at least one between 'webrtcIPsFromInterfaces', 'webrtcAdditionalHosts'" +
+					" or 'webrtcIPFromHostHeader' must be filled")
 			}
 		}
 	}

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -867,7 +867,8 @@ func TestConfErrors(t *testing.T) {
 				"webrtcLocalUDPAddress: ':8189'\n" +
 				"webrtcIPsFromInterfaces: false\n" +
 				"webrtcAdditionalHosts: []\n",
-			"at least one between 'webrtcIPsFromInterfaces' or 'webrtcAdditionalHosts' must be filled",
+			"at least one between 'webrtcIPsFromInterfaces', 'webrtcAdditionalHosts'" +
+				" or 'webrtcIPFromHostHeader' must be filled",
 		},
 		{
 			"missing apiAddress with API enabled",

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -789,6 +789,7 @@ func (p *Core) createResources(initial bool) error {
 			IPsFromInterfaces:     currentConf.WebRTCIPsFromInterfaces,
 			IPsFromInterfacesList: currentConf.WebRTCIPsFromInterfacesList,
 			AdditionalHosts:       currentConf.WebRTCAdditionalHosts,
+			IPFromHostHeader:      currentConf.WebRTCIPFromHostHeader,
 			ICEServers:            currentConf.WebRTCICEServers2,
 			STUNGatherTimeout:     currentConf.WebRTCSTUNGatherTimeout,
 			HandshakeTimeout:      currentConf.WebRTCHandshakeTimeout,
@@ -1116,6 +1117,7 @@ func (p *Core) closeResources(newConf *conf.Conf) {
 		newConf.WebRTCIPsFromInterfaces != currentConf.WebRTCIPsFromInterfaces ||
 		!reflect.DeepEqual(newConf.WebRTCIPsFromInterfacesList, currentConf.WebRTCIPsFromInterfacesList) ||
 		!reflect.DeepEqual(newConf.WebRTCAdditionalHosts, currentConf.WebRTCAdditionalHosts) ||
+		newConf.WebRTCIPFromHostHeader != currentConf.WebRTCIPFromHostHeader ||
 		!reflect.DeepEqual(newConf.WebRTCICEServers2, currentConf.WebRTCICEServers2) ||
 		newConf.WebRTCSTUNGatherTimeout != currentConf.WebRTCSTUNGatherTimeout ||
 		newConf.WebRTCHandshakeTimeout != currentConf.WebRTCHandshakeTimeout ||

--- a/internal/servers/webrtc/server.go
+++ b/internal/servers/webrtc/server.go
@@ -201,6 +201,7 @@ type Server struct {
 	IPsFromInterfaces     bool
 	IPsFromInterfacesList []string
 	AdditionalHosts       []string
+	IPFromHostHeader      bool
 	ICEServers            []conf.WebRTCICEServer
 	STUNGatherTimeout     conf.Duration
 	HandshakeTimeout      conf.Duration
@@ -371,6 +372,7 @@ outer:
 				ipsFromInterfaces:     s.IPsFromInterfaces,
 				ipsFromInterfacesList: s.IPsFromInterfacesList,
 				additionalHosts:       s.AdditionalHosts,
+				ipFromHostHeader:      s.IPFromHostHeader,
 				iceUDPMux:             s.iceUDPMux,
 				iceTCPMux:             s.iceTCPMux,
 				supportsIPv6:          s.SupportsIPv6,

--- a/internal/servers/webrtc/session.go
+++ b/internal/servers/webrtc/session.go
@@ -350,7 +350,13 @@ func (s *session) hostsToAdvertise() []string {
 		host = s.httpRequest.Host
 	}
 
-	if host == "" {
+	// unlike additionalHosts, which is admin-configured and trusted, the
+	// Host header is fully controlled by the client and is not
+	// authenticated by default. It must never reach the DNS resolver in
+	// addAdditionalCandidates(), otherwise any client could force the
+	// server to perform a synchronous, unbounded lookup on an arbitrary
+	// name. Only accept it when it's already an IP literal.
+	if net.ParseIP(host) == nil {
 		return s.additionalHosts
 	}
 

--- a/internal/servers/webrtc/session.go
+++ b/internal/servers/webrtc/session.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -241,6 +242,7 @@ type session struct {
 	ipsFromInterfaces     bool
 	ipsFromInterfacesList []string
 	additionalHosts       []string
+	ipFromHostHeader      bool
 	iceUDPMux             ice.UDPMux
 	iceTCPMux             *webrtc.TCPMuxWrapper
 	supportsIPv6          bool
@@ -335,6 +337,26 @@ func (s *session) runInner2(req *initialRequestReq) (int, error) {
 	return s.runRead(req)
 }
 
+// hostsToAdvertise returns the hosts that must be advertised to the client as
+// additional ICE candidates, optionally including the host contained in the
+// HTTP Host header of the request that created the session.
+func (s *session) hostsToAdvertise() []string {
+	if !s.ipFromHostHeader {
+		return s.additionalHosts
+	}
+
+	host, _, err := net.SplitHostPort(s.httpRequest.Host)
+	if err != nil {
+		host = s.httpRequest.Host
+	}
+
+	if host == "" {
+		return s.additionalHosts
+	}
+
+	return slices.Concat(s.additionalHosts, []string{host})
+}
+
 func (s *session) runPublish(req *initialRequestReq) (int, error) {
 	ip, _, _ := net.SplitHostPort(s.remoteAddr)
 
@@ -373,7 +395,7 @@ func (s *session) runPublish(req *initialRequestReq) (int, error) {
 		ICEServers:            iceServers,
 		IPsFromInterfaces:     s.ipsFromInterfaces,
 		IPsFromInterfacesList: s.ipsFromInterfacesList,
-		AdditionalHosts:       s.additionalHosts,
+		AdditionalHosts:       s.hostsToAdvertise(),
 		STUNGatherTimeout:     time.Duration(s.stunGatherTimeout),
 		Publish:               false,
 		Log:                   s,
@@ -524,7 +546,7 @@ func (s *session) runRead(req *initialRequestReq) (int, error) {
 		ICEServers:            iceServers,
 		IPsFromInterfaces:     s.ipsFromInterfaces,
 		IPsFromInterfacesList: s.ipsFromInterfacesList,
-		AdditionalHosts:       s.additionalHosts,
+		AdditionalHosts:       s.hostsToAdvertise(),
 		STUNGatherTimeout:     time.Duration(s.stunGatherTimeout),
 		Publish:               true,
 		Log:                   s,

--- a/internal/servers/webrtc/session_test.go
+++ b/internal/servers/webrtc/session_test.go
@@ -1,0 +1,57 @@
+package webrtc
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionHostsToAdvertise(t *testing.T) {
+	for _, ca := range []struct {
+		name             string
+		ipFromHostHeader bool
+		additionalHosts  []string
+		host             string
+		expected         []string
+	}{
+		{
+			name:             "disabled",
+			ipFromHostHeader: false,
+			additionalHosts:  []string{"1.2.3.4"},
+			host:             "example.com:8889",
+			expected:         []string{"1.2.3.4"},
+		},
+		{
+			name:             "enabled, host with port",
+			ipFromHostHeader: true,
+			additionalHosts:  []string{"1.2.3.4"},
+			host:             "example.com:8889",
+			expected:         []string{"1.2.3.4", "example.com"},
+		},
+		{
+			name:             "enabled, host without port",
+			ipFromHostHeader: true,
+			additionalHosts:  []string{},
+			host:             "example.com",
+			expected:         []string{"example.com"},
+		},
+		{
+			name:             "enabled, empty host",
+			ipFromHostHeader: true,
+			additionalHosts:  []string{"1.2.3.4"},
+			host:             "",
+			expected:         []string{"1.2.3.4"},
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			s := &session{
+				additionalHosts:  ca.additionalHosts,
+				ipFromHostHeader: ca.ipFromHostHeader,
+				httpRequest:      &http.Request{Host: ca.host},
+			}
+
+			require.Equal(t, ca.expected, s.hostsToAdvertise())
+		})
+	}
+}

--- a/internal/servers/webrtc/session_test.go
+++ b/internal/servers/webrtc/session_test.go
@@ -23,24 +23,35 @@ func TestSessionHostsToAdvertise(t *testing.T) {
 			expected:         []string{"1.2.3.4"},
 		},
 		{
-			name:             "enabled, host with port",
+			name:             "enabled, IP host with port",
 			ipFromHostHeader: true,
 			additionalHosts:  []string{"1.2.3.4"},
-			host:             "example.com:8889",
-			expected:         []string{"1.2.3.4", "example.com"},
+			host:             "203.0.113.10:8889",
+			expected:         []string{"1.2.3.4", "203.0.113.10"},
 		},
 		{
-			name:             "enabled, host without port",
+			name:             "enabled, IP host without port",
 			ipFromHostHeader: true,
 			additionalHosts:  []string{},
-			host:             "example.com",
-			expected:         []string{"example.com"},
+			host:             "203.0.113.11",
+			expected:         []string{"203.0.113.11"},
 		},
 		{
 			name:             "enabled, empty host",
 			ipFromHostHeader: true,
 			additionalHosts:  []string{"1.2.3.4"},
 			host:             "",
+			expected:         []string{"1.2.3.4"},
+		},
+		{
+			// the Host header is client-controlled and unauthenticated by
+			// default; a non-IP value must never be forwarded to the DNS
+			// resolver in addAdditionalCandidates(), so it's dropped rather
+			// than advertised.
+			name:             "enabled, non-IP host is rejected",
+			ipFromHostHeader: true,
+			additionalHosts:  []string{"1.2.3.4"},
+			host:             "example.com:8889",
 			expected:         []string{"1.2.3.4"},
 		},
 	} {

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -410,6 +410,11 @@ webrtcIPsFromInterfaces: true
 webrtcIPsFromInterfacesList: []
 # Additional hosts or IPs to send to clients.
 webrtcAdditionalHosts: []
+# Send the host contained in the HTTP Host header (port excluded) to clients
+# as an additional host. Useful when the server is reachable through a host
+# or IP that is not known in advance, for instance when it runs inside a
+# Docker container without host networking.
+webrtcIPFromHostHeader: false
 # ICE servers. Needed only when local listeners can't be reached by clients.
 # STUN servers allow to obtain and share the public IP of the server.
 # TURN/TURNS servers force all traffic through them.

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -413,7 +413,9 @@ webrtcAdditionalHosts: []
 # Send the host contained in the HTTP Host header (port excluded) to clients
 # as an additional host. Useful when the server is reachable through a host
 # or IP that is not known in advance, for instance when it runs inside a
-# Docker container without host networking.
+# Docker container without host networking. Since the Host header is set by
+# the client and is unauthenticated by default, only IP addresses are
+# accepted; hostnames are ignored.
 webrtcIPFromHostHeader: false
 # ICE servers. Needed only when local listeners can't be reached by clients.
 # STUN servers allow to obtain and share the public IP of the server.


### PR DESCRIPTION
### What

`webrtcAdditionalHosts` requires the server's reachable host/IP to be known in advance. When mediamtx runs in a Docker container without `network=host`, and the host is reachable through a dynamic address (DHCP, mobile hotspot, dynamic DNS, etc.), that address can't be pinned ahead of time.

This adds a new option, `webrtcIPFromHostHeader` (default `false`). When enabled, the WebRTC server extracts the host (port stripped) from the HTTP `Host` header of the request that opened the session, and appends it to the additional hosts advertised as ICE candidates for that session. It composes with a statically configured `webrtcAdditionalHosts` rather than replacing it.

The change is wired into both the publish (WHIP) and read (WHEP) session paths in `internal/servers/webrtc/session.go`, via a new `hostsToAdvertise()` helper on `session`.

**Security note:** unlike `webrtcAdditionalHosts`, which is admin-configured and trusted, the `Host` header is set by the client and is unauthenticated by default. If an arbitrary hostname from that header were forwarded into `AdditionalHosts`, it would eventually reach `net.LookupIP()` in `addAdditionalCandidates()` (`internal/protocols/webrtc/peer_connection.go`), letting any client force the server into a synchronous DNS lookup on a name of their choosing. To avoid that, `hostsToAdvertise()` only forwards the header value when it's already an IP literal (`net.ParseIP` succeeds); anything else (hostnames, empty header) is dropped and only the configured `webrtcAdditionalHosts` are advertised. This does not change the existing, trusted hostname-resolution behavior of `webrtcAdditionalHosts` itself.

### Why

Fixes #5744. The primary use case described in the issue is a dynamic IP (DHCP, mobile hotspots) reaching the container without host networking, which the IP-literal restriction still fully covers. A proof-of-concept posted on the issue patched only the read (WHEP) path and forwarded the raw header value unrestricted; this PR covers both publish and read sessions, and restricts the derived value to IP literals for the reason above.

### How this was tested

- `go test ./internal/servers/webrtc/... -run TestSessionHostsToAdvertise -v` — new table-driven test covering: option disabled, IP host with port, IP host without port, empty host, and a non-IP (hostname) header being rejected. All 5 subtests `PASS`, `ok github.com/bluenviron/mediamtx/internal/servers/webrtc`.
- `go test ./internal/servers/webrtc/...` (full package) — `ok github.com/bluenviron/mediamtx/internal/servers/webrtc 22.502s`.
- `go test ./internal/conf/...` (full package, plus `conf/env`, `conf/jsonwrapper`, `conf/yamlwrapper`) — all `ok`, including the updated `TestConfErrors` assertion for the new validation error message.
- `go test -tags enable_linters ./internal/linters/conf/...` — `PASS` (validates `mediamtx.yml`'s new `webrtcIPFromHostHeader: false` line against the repo's boolean-style linter).
- `go vet ./internal/servers/webrtc/... ./internal/conf/... ./internal/core/...` — clean, no output.
- `gofmt -l` on all touched `.go` files — no output.
- `golangci-lint run ./internal/servers/webrtc/... ./internal/conf/...` — 0 issues.
- `go mod tidy -diff` — no diff; no new dependency was added (only the stdlib `slices` package is newly imported).

Not run: a full `go build ./...` / `go vet ./...` across the whole repository. A fresh shallow clone is missing two generated, gitignored files unrelated to this change (`internal/core/VERSION`, normally produced by `go:generate go run ./versiongetter`, and `internal/servers/hls/hls.min.js`, normally fetched by a network downloader), so those packages don't build standalone. I confirmed the 2-line `internal/core/core.go` wiring change type-checks by temporarily writing throwaway placeholder files for both (never committed) and running `go vet ./internal/core/...`, which passed. `golangci-lint` was otherwise run directly rather than through the repo's Docker-based `scripts/lint.mk`, since it produced identical results.
