### PR TITLE
conf: allow sources and forward destinations with an empty password

### DIFF
--- a/docs/3-publish/08-rtsp-cameras-and-servers.md
+++ b/docs/3-publish/08-rtsp-cameras-and-servers.md
@@ -23,6 +23,8 @@ paths:
 
 If username or password contain special characters (like ?, :, etc), they need to be [url-encoded](https://www.urlencoder.org/).
 
+Some legacy cameras require a username but an empty password. In this case, keep the colon after the username (`rtsp://user:@host:port/path`): a username without a colon (`rtsp://user@host:port/path`) is treated as a missing password and rejected.
+
 The resulting stream will be available on path `/proxied`.
 
 It is possible to tune the connection by using several additional parameters, that are listed in the [configuration file](../5-references/1-configuration-file.md).

--- a/docs/3-publish/08-rtsp-cameras-and-servers.md
+++ b/docs/3-publish/08-rtsp-cameras-and-servers.md
@@ -23,7 +23,7 @@ paths:
 
 If username or password contain special characters (like ?, :, etc), they need to be [url-encoded](https://www.urlencoder.org/).
 
-Some legacy cameras require a username but an empty password. In this case, keep the colon after the username (`rtsp://user:@host:port/path`): a username without a colon (`rtsp://user@host:port/path`) is treated as a missing password and rejected.
+Some cameras require a username but an empty password. In this case, keep the colon after the username (`rtsp://user:@host:port/path`): a username without a colon (`rtsp://user@host:port/path`) is treated as a missing password and rejected.
 
 The resulting stream will be available on path `/proxied`.
 

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -149,6 +149,30 @@ func TestConfFromFile(t *testing.T) {
 			name:   "udp rtp with placeholders",
 			source: "udp+rtp://$G1:$G2",
 		},
+		{
+			name:   "rtsp with username and password",
+			source: "rtsp://user:pass@localhost/stream",
+		},
+		{
+			name:   "rtsp with username and empty password",
+			source: "rtsp://user:@localhost/stream",
+		},
+		{
+			name:   "rtsps with username and empty password",
+			source: "rtsps://user:@localhost/stream",
+		},
+		{
+			name:   "rtsp with empty username and empty password",
+			source: "rtsp://@localhost/stream",
+		},
+		{
+			name:   "rtmp with username and empty password",
+			source: "rtmp://user:@localhost/stream",
+		},
+		{
+			name:   "http with username and empty password",
+			source: "http://user:@localhost/stream.m3u8",
+		},
 	} {
 		t.Run(ca.name, func(t *testing.T) {
 			conf := "paths:\n" +
@@ -944,7 +968,40 @@ func TestConfErrors(t *testing.T) {
 			"paths:\n" +
 				"  mypath:\n" +
 				"    source: rtsp://user@localhost/stream\n",
-			"username and password must be both provided",
+			"username was provided but password is missing; " +
+				"if the password is intentionally empty, use 'user:@host'",
+		},
+		{
+			"rtsp source password without username",
+			"paths:\n" +
+				"  mypath:\n" +
+				"    source: rtsp://:pass@localhost/stream\n",
+			"password was provided but username is missing",
+		},
+		{
+			"rtmp source username without password",
+			"paths:\n" +
+				"  mypath:\n" +
+				"    source: rtmp://user@localhost/stream\n",
+			"username was provided but password is missing; " +
+				"if the password is intentionally empty, use 'user:@host'",
+		},
+		{
+			"forward destination username without password",
+			"paths:\n" +
+				"  mypath:\n" +
+				"    forward:\n" +
+				"    - dest: rtsp://user@localhost/stream\n",
+			"invalid 'forward': entry 0: username was provided but password is missing; " +
+				"if the password is intentionally empty, use 'user:@host'",
+		},
+		{
+			"forward destination username with empty password",
+			"paths:\n" +
+				"  mypath:\n" +
+				"    forward:\n" +
+				"    - dest: rtsp://user:@localhost/stream\n",
+			"",
 		},
 		{
 			"valid moq forward destination",

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -94,11 +94,18 @@ func validateURL(source string) (*url.URL, error) {
 	}
 
 	if u.User != nil {
-		pass, _ := u.User.Password()
+		// An explicitly empty password ("user:@host") is valid and is required
+		// by some legacy devices, whose password cannot be set (#395).
+		// A missing password ("user@host") or a missing username (":pass@host")
+		// is most probably a typo and is rejected.
+		pass, passSet := u.User.Password()
 		user := u.User.Username()
-		if user != "" && pass == "" ||
-			user == "" && pass != "" {
-			return nil, fmt.Errorf("username and password must be both provided")
+		switch {
+		case user != "" && !passSet:
+			return nil, fmt.Errorf("username was provided but password is missing; " +
+				"if the password is intentionally empty, use 'user:@host'")
+		case user == "" && pass != "":
+			return nil, fmt.Errorf("password was provided but username is missing")
 		}
 	}
 


### PR DESCRIPTION
Fixes #5920

## Problem

Since v1.19.1, a source URL with a username and an explicitly empty password is rejected at startup:

```yaml
paths:
  cam:
    source: rtsp://admin:@192.168.1.57:554/videoMain
```

```
ERR: username and password must be both provided
```

This configuration worked from v0.16.2 up to v1.19.0 included. Some legacy cameras (old Foscam models, no-name devices reported in #395) require a username but have an empty password that cannot be changed, so there is no workaround on the camera side.

## Root cause

- In 2021, #395 reported this exact problem and 2bffbe4a deliberately removed the "both provided" check for RTSP sources, adding a `TestSourceRTSPNoPassword` test. The check was kept for RTMP and HLS sources only.
- In v1.19.1, #5779 (regexp groups in source URLs) factored the URL validation of every scheme into a single `validateURL()` function. The RTMP/HLS credential check came along and got applied to RTSP sources too, silently reverting #395. The change was not mentioned in the PR or in the release notes.
- The historical test still exists (`TestNoPassword` in `internal/staticsources/rtsp`) and still passes, but since the 2023 package split it exercises the source layer directly and no longer goes through `internal/conf`, so it could not catch the regression. gortsplib is not involved: v5.5.4 → v5.6.0 has no change in authentication, and its `auth.Sender` handles an empty password correctly.

## Change

`validateURL()` now uses the `ok` flag returned by `url.Userinfo.Password()` to distinguish two cases that were previously treated the same:

| URL | before | after |
| --- | --- | --- |
| `rtsp://user:pass@host` | accepted | accepted |
| `rtsp://user:@host` (explicitly empty password) | rejected | **accepted** |
| `rtsp://user@host` (password missing) | rejected | rejected, clearer message |
| `rtsp://:pass@host` (username missing) | rejected | rejected, clearer message |
| `rtsp://@host` | accepted | accepted |

New error messages:

```
username was provided but password is missing; if the password is intentionally empty, use 'user:@host'
password was provided but username is missing
```

An empty password is valid per RFC 3986 (`userinfo = *( unreserved / pct-encoded / sub-delims / ":" )`), RFC 7617 (Basic) and RFC 7616 (Digest). VLC, FFmpeg and gortsplib all accept it. The original check was only meant to catch a forgotten password, which is still covered by rejecting `user@host`.

Since `validateURL()` is shared, the change applies to every scheme it validates (RTSP, RTMP, HLS, SRT, WHEP, UDP) and to `forward` destinations. gortmplib and the Go HTTP client both handle an empty password.

No configuration option is added: the default behavior stays strict for the typo cases, and the accepted syntax is unambiguous. Client authentication towards MediaMTX (`authInternalUsers`, `internal/auth`) is not touched.

## Tests

- `TestConfFromFile`: new accepted cases for `rtsp://user:@`, `rtsps://user:@`, `rtmp://user:@`, `http://user:@`, `rtsp://@` and `rtsp://user:pass@`.
- `TestConfErrors`: existing `rtsp://user@` case updated to the new message; new rejected cases for `rtsp://:pass@`, `rtmp://user@` and a `forward` destination `rtsp://user@`; new accepted `forward` destination `rtsp://user:@`.
- The existing `TestNoPassword` in `internal/staticsources/rtsp` is unchanged and keeps covering the gortsplib side.
- End-to-end check with a local gortsplib server requiring Digest MD5 with `admin` / empty password: with this patch `rtsp://admin:@127.0.0.1:8554/videoMain` authenticates (DESCRIBE, SETUP, PLAY return 200) and the path becomes ready with one H264 track; a wrong password still yields 401; the unpatched binary still fails at startup with the old error.

## Documentation

`docs/3-publish/08-rtsp-cameras-and-servers.md` now explains that legacy cameras with an empty password must keep the colon (`rtsp://user:@host:port/path`), and that `rtsp://user@host` is treated as a missing password.
