### PR TITLE
moq: impose a 100MB limit on reordered bytes per session

### DIFF
--- a/internal/protocols/moq/reorderer/orchestrator.go
+++ b/internal/protocols/moq/reorderer/orchestrator.go
@@ -1,0 +1,41 @@
+package reorderer
+
+import (
+	"sync"
+
+	"github.com/bluenviron/mediamtx/internal/logger"
+)
+
+const (
+	maxPendingBytes = 100 * 1024 * 1024
+)
+
+// Orchestrator enforces a memory limit that is shared among multiple reorderers.
+type Orchestrator struct {
+	Parent logger.Writer
+
+	maxPendingBytes int
+
+	mu           sync.Mutex
+	pendingBytes int
+}
+
+// Initialize initializes the orchestrator.
+func (o *Orchestrator) Initialize() {
+	if o.maxPendingBytes == 0 {
+		o.maxPendingBytes = maxPendingBytes
+	}
+}
+
+func (o *Orchestrator) addPendingBytes(n int) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.pendingBytes += n
+	return o.pendingBytes <= o.maxPendingBytes
+}
+
+func (o *Orchestrator) removePendingBytes(n int) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.pendingBytes -= n
+}

--- a/internal/protocols/moq/reorderer/reorderer.go
+++ b/internal/protocols/moq/reorderer/reorderer.go
@@ -9,18 +9,9 @@ import (
 	"github.com/bluenviron/mediamtx/internal/protocols/moq/subgroup"
 )
 
-// Reorderer is a subgroup reorderer.
-type Reorderer struct {
-	MaxReordered    int
-	MaxPendingBytes int
-	Parent          logger.Writer
-
-	initialized  bool
-	mu           sync.Mutex
-	curGroupID   uint64
-	pending      map[uint64]*subgroup.SubGroup
-	pendingBytes int
-}
+const (
+	maxPendingSubGroups = 50
+)
 
 func subGroupPayloadSize(sg *subgroup.SubGroup) int {
 	n := 0
@@ -30,8 +21,24 @@ func subGroupPayloadSize(sg *subgroup.SubGroup) int {
 	return n
 }
 
+// Reorderer is a subgroup reorderer.
+type Reorderer struct {
+	Parent *Orchestrator
+
+	maxPendingSubGroups int
+
+	initialized bool
+	mu          sync.Mutex
+	curGroupID  uint64
+	pending     map[uint64]*subgroup.SubGroup
+}
+
 // Initialize initializes the reorderer.
 func (r *Reorderer) Initialize() {
+	if r.maxPendingSubGroups == 0 {
+		r.maxPendingSubGroups = maxPendingSubGroups
+	}
+
 	r.pending = make(map[uint64]*subgroup.SubGroup)
 }
 
@@ -48,7 +55,7 @@ func (r *Reorderer) Push(sg *subgroup.SubGroup) ([]*subgroup.SubGroup, error) {
 
 	switch {
 	case sg.Header.GroupID <= r.curGroupID:
-		r.Parent.Log(logger.Warn, "skipping out-of-order subgroup")
+		r.Parent.Parent.Log(logger.Warn, "skipping out-of-order subgroup")
 
 	case sg.Header.GroupID == r.curGroupID+1 && len(r.pending) == 0:
 		r.curGroupID = sg.Header.GroupID
@@ -56,10 +63,10 @@ func (r *Reorderer) Push(sg *subgroup.SubGroup) ([]*subgroup.SubGroup, error) {
 
 	default:
 		if prev, ok := r.pending[sg.Header.GroupID]; ok {
-			r.pendingBytes -= subGroupPayloadSize(prev)
+			r.Parent.removePendingBytes(subGroupPayloadSize(prev))
 		}
 		r.pending[sg.Header.GroupID] = sg
-		r.pendingBytes += subGroupPayloadSize(sg)
+		withinLimit := r.Parent.addPendingBytes(subGroupPayloadSize(sg))
 
 		diff := sg.Header.GroupID - r.curGroupID
 
@@ -74,12 +81,12 @@ func (r *Reorderer) Push(sg *subgroup.SubGroup) ([]*subgroup.SubGroup, error) {
 		case countInRange == diff:
 			return r.flushUpTo(sg.Header.GroupID), nil
 
-		case len(r.pending) > r.MaxReordered:
-			r.Parent.Log(logger.Warn, "too many reordered subgroups, flushing")
+		case len(r.pending) > r.maxPendingSubGroups:
+			r.Parent.Parent.Log(logger.Warn, "too many reordered subgroups, flushing")
 			return r.flushUpTo(sg.Header.GroupID), nil
 
-		case r.pendingBytes > r.MaxPendingBytes:
-			r.Parent.Log(logger.Warn, "too many reordered bytes, flushing")
+		case !withinLimit:
+			r.Parent.Parent.Log(logger.Warn, "too many reordered bytes, flushing")
 			return r.flushUpTo(sg.Header.GroupID), nil
 		}
 	}
@@ -99,7 +106,7 @@ func (r *Reorderer) flushUpTo(maxGroupID uint64) []*subgroup.SubGroup {
 	out := make([]*subgroup.SubGroup, 0, len(ids))
 	for _, id := range ids {
 		out = append(out, r.pending[id])
-		r.pendingBytes -= subGroupPayloadSize(r.pending[id])
+		r.Parent.removePendingBytes(subGroupPayloadSize(r.pending[id]))
 		delete(r.pending, id)
 	}
 
@@ -111,7 +118,7 @@ func (r *Reorderer) flushUpTo(maxGroupID uint64) []*subgroup.SubGroup {
 			break
 		}
 		out = append(out, next)
-		r.pendingBytes -= subGroupPayloadSize(next)
+		r.Parent.removePendingBytes(subGroupPayloadSize(next))
 		delete(r.pending, r.curGroupID+1)
 		r.curGroupID++
 	}

--- a/internal/protocols/moq/reorderer/reorderer_test.go
+++ b/internal/protocols/moq/reorderer/reorderer_test.go
@@ -1,4 +1,4 @@
-package reorderer_test
+package reorderer
 
 import (
 	"testing"
@@ -6,13 +6,22 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bluenviron/mediamtx/internal/logger"
-	"github.com/bluenviron/mediamtx/internal/protocols/moq/reorderer"
 	"github.com/bluenviron/mediamtx/internal/protocols/moq/subgroup"
 )
 
 type nopLogger struct{}
 
 func (nopLogger) Log(logger.Level, string, ...any) {}
+
+func newTestReorderer(maxPendingSubGroups int, maxPendingBytes int) *Reorderer {
+	o := &Orchestrator{Parent: nopLogger{}, maxPendingBytes: maxPendingBytes}
+	o.Initialize()
+
+	r := &Reorderer{Parent: o, maxPendingSubGroups: maxPendingSubGroups}
+	r.Initialize()
+
+	return r
+}
 
 func makeSG(groupID uint64) *subgroup.SubGroup {
 	return &subgroup.SubGroup{
@@ -30,8 +39,7 @@ func makeSGWithPayload(groupID uint64, size int) *subgroup.SubGroup {
 }
 
 func TestReordererFirstPush(t *testing.T) {
-	r := &reorderer.Reorderer{MaxReordered: 5, MaxPendingBytes: 100000, Parent: nopLogger{}}
-	r.Initialize()
+	r := newTestReorderer(5, 100000)
 
 	sg0 := makeSG(0)
 	out, err := r.Push(sg0)
@@ -40,8 +48,7 @@ func TestReordererFirstPush(t *testing.T) {
 }
 
 func TestReordererInOrder(t *testing.T) {
-	r := &reorderer.Reorderer{MaxReordered: 5, MaxPendingBytes: 100000, Parent: nopLogger{}}
-	r.Initialize()
+	r := newTestReorderer(5, 100000)
 
 	sg0 := makeSG(0)
 	out, err := r.Push(sg0)
@@ -60,8 +67,7 @@ func TestReordererInOrder(t *testing.T) {
 }
 
 func TestReordererStale(t *testing.T) {
-	r := &reorderer.Reorderer{MaxReordered: 5, MaxPendingBytes: 100000, Parent: nopLogger{}}
-	r.Initialize()
+	r := newTestReorderer(5, 100000)
 
 	sg5 := makeSG(5)
 	out, err := r.Push(sg5)
@@ -80,8 +86,7 @@ func TestReordererStale(t *testing.T) {
 }
 
 func TestReordererOutOfOrderPending(t *testing.T) {
-	r := &reorderer.Reorderer{MaxReordered: 5, MaxPendingBytes: 100000, Parent: nopLogger{}}
-	r.Initialize()
+	r := newTestReorderer(5, 100000)
 
 	sg0 := makeSG(0)
 	out, err := r.Push(sg0)
@@ -95,8 +100,7 @@ func TestReordererOutOfOrderPending(t *testing.T) {
 }
 
 func TestReordererOutOfOrderFilled(t *testing.T) {
-	r := &reorderer.Reorderer{MaxReordered: 5, MaxPendingBytes: 100000, Parent: nopLogger{}}
-	r.Initialize()
+	r := newTestReorderer(5, 100000)
 
 	sg0 := makeSG(0)
 	out, err := r.Push(sg0)
@@ -118,8 +122,7 @@ func TestReordererOutOfOrderFilled(t *testing.T) {
 }
 
 func TestReordererDrainAfterFill(t *testing.T) { //nolint:dupl
-	r := &reorderer.Reorderer{MaxReordered: 5, MaxPendingBytes: 100000, Parent: nopLogger{}}
-	r.Initialize()
+	r := newTestReorderer(5, 100000)
 
 	sg0 := makeSG(0)
 	out, err := r.Push(sg0)
@@ -144,9 +147,8 @@ func TestReordererDrainAfterFill(t *testing.T) { //nolint:dupl
 	require.Equal(t, []*subgroup.SubGroup{sg1, sg2, sg3}, out)
 }
 
-func TestReordererMaxReordered(t *testing.T) { //nolint:dupl
-	r := &reorderer.Reorderer{MaxReordered: 2, MaxPendingBytes: 100000, Parent: nopLogger{}}
-	r.Initialize()
+func TestReorderermaxPendingSubGroups(t *testing.T) { //nolint:dupl
+	r := newTestReorderer(2, 100000)
 
 	sg0 := makeSG(0)
 	out, err := r.Push(sg0)
@@ -165,7 +167,7 @@ func TestReordererMaxReordered(t *testing.T) { //nolint:dupl
 	require.NoError(t, err)
 	require.Nil(t, out)
 
-	// third out-of-order item pushes pending to 3, which exceeds MaxReordered=2;
+	// third out-of-order item pushes pending to 3, which exceeds maxPendingSubGroups=2;
 	// all available items are flushed in order, skipping the missing ones (1, 3)
 	sg5 := makeSG(5)
 	out, err = r.Push(sg5)
@@ -173,9 +175,8 @@ func TestReordererMaxReordered(t *testing.T) { //nolint:dupl
 	require.Equal(t, []*subgroup.SubGroup{sg2, sg4, sg5}, out)
 }
 
-func TestReordererMaxPendingBytes(t *testing.T) {
-	r := &reorderer.Reorderer{MaxReordered: 10, MaxPendingBytes: 100, Parent: nopLogger{}}
-	r.Initialize()
+func TestReorderermaxPendingBytes(t *testing.T) {
+	r := newTestReorderer(10, 100)
 
 	sg0 := makeSG(0)
 	out, err := r.Push(sg0)

--- a/internal/servers/moq/session.go
+++ b/internal/servers/moq/session.go
@@ -29,14 +29,13 @@ import (
 	"github.com/bluenviron/mediamtx/internal/protocols/moq/controlmessage"
 	"github.com/bluenviron/mediamtx/internal/protocols/moq/parameter"
 	"github.com/bluenviron/mediamtx/internal/protocols/moq/property"
+	"github.com/bluenviron/mediamtx/internal/protocols/moq/reorderer"
 	"github.com/bluenviron/mediamtx/internal/protocols/moq/subgroup"
 	"github.com/bluenviron/mediamtx/internal/stream"
 )
 
 const (
-	maxReorderedSubGroups    = 50
-	maxReorderedPendingBytes = 100 * 1024 * 1024
-	maxCatalogTracks         = 50
+	maxCatalogTracks = 50
 )
 
 func findAuthorizationToken(parameters []parameter.Parameter) *parameter.AuthorizationToken {
@@ -617,11 +616,14 @@ func (s *session) onPublishCatalog(wstream io.ReadWriteCloser, m *controlmessage
 
 		s.inboundTracks = make(map[uint64]*inboundTrack)
 
+		orchestrator := &reorderer.Orchestrator{Parent: s}
+		orchestrator.Initialize()
+
 		for i := range cat.Tracks {
 			trackAlias := uint64(i + 1)
 			tr := &inboundTrack{
-				onSubGroup: writeFuncs[trackAlias],
-				parent:     s,
+				onSubGroup:   writeFuncs[trackAlias],
+				orchestrator: orchestrator,
 			}
 			tr.initialize()
 			s.inboundTracks[trackAlias] = tr

--- a/internal/staticsources/moq/inbound_track.go
+++ b/internal/staticsources/moq/inbound_track.go
@@ -6,8 +6,9 @@ import (
 )
 
 type inboundTrack struct {
-	onSubGroup   func(sg *subgroup.SubGroup) error
-	orchestrator *reorderer.Orchestrator
+	onSubGroup      func(sg *subgroup.SubGroup) error
+	orchestrator    *reorderer.Orchestrator
+	addInboundBytes func(objects []subgroup.Object)
 
 	reorderer *reorderer.Reorderer
 }
@@ -20,13 +21,15 @@ func (t *inboundTrack) initialize() {
 }
 
 func (t *inboundTrack) push(sg *subgroup.SubGroup) error {
+	t.addInboundBytes(sg.Objects)
+
 	sgs, err := t.reorderer.Push(sg)
 	if err != nil {
 		return err
 	}
 
-	for _, s := range sgs {
-		err = t.onSubGroup(s)
+	for _, sg := range sgs {
+		err = t.onSubGroup(sg)
 		if err != nil {
 			return err
 		}

--- a/internal/staticsources/moq/source.go
+++ b/internal/staticsources/moq/source.go
@@ -20,46 +20,10 @@ import (
 	"github.com/bluenviron/mediamtx/internal/stream"
 )
 
-const maxReorderedSubGroups = 50
-
 type parent interface {
 	logger.Writer
 	SetReady(req defs.PathSourceStaticSetReadyReq) defs.PathSourceStaticSetReadyRes
 	SetNotReady(req defs.PathSourceStaticSetNotReadyReq)
-}
-
-type inboundTrack struct {
-	onSubGroup      func(sg *subgroup.SubGroup) error
-	parent          logger.Writer
-	addInboundBytes func(objects []subgroup.Object)
-
-	reorderer *reorderer.Reorderer
-}
-
-func (t *inboundTrack) initialize() {
-	t.reorderer = &reorderer.Reorderer{
-		MaxReordered: maxReorderedSubGroups,
-		Parent:       t.parent,
-	}
-	t.reorderer.Initialize()
-}
-
-func (t *inboundTrack) push(sg *subgroup.SubGroup) error {
-	t.addInboundBytes(sg.Objects)
-
-	sgs, err := t.reorderer.Push(sg)
-	if err != nil {
-		return err
-	}
-
-	for _, sg := range sgs {
-		err = t.onSubGroup(sg)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // Source is a MoQ static source.
@@ -196,13 +160,16 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 
 	subStream = res.SubStream
 
+	orchestrator := &reorderer.Orchestrator{Parent: s}
+	orchestrator.Initialize()
+
 	for i, track := range cat.Tracks {
 		writer := writeFuncs[uint64(i+1)]
 		if writer == nil {
 			return fmt.Errorf("missing writer for track %s", track.Name)
 		}
 
-		tr := &inboundTrack{onSubGroup: writer, parent: s, addInboundBytes: s.addInboundBytes}
+		tr := &inboundTrack{onSubGroup: writer, orchestrator: orchestrator, addInboundBytes: s.addInboundBytes}
 		tr.initialize()
 
 		err = client.Subscribe(params.Context, track.Name, tr.push)


### PR DESCRIPTION
previously, the limit was per-track. This decreases the probability of OOM situations.