### PR TITLE
fix wrong validation of HTTP allowed origins

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -173,6 +173,7 @@ func TestPreflightRequest(t *testing.T) {
 	req, err := http.NewRequest(http.MethodOptions, "http://localhost:9997", nil)
 	require.NoError(t, err)
 
+	req.Header.Add("Origin", "http://example.com")
 	req.Header.Add("Access-Control-Request-Method", "GET")
 
 	res, err := hc.Do(req)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -516,6 +516,7 @@ func TestPreflightRequest(t *testing.T) {
 	req, err := http.NewRequest(http.MethodOptions, "http://localhost:9998", nil)
 	require.NoError(t, err)
 
+	req.Header.Add("Origin", "http://example.com")
 	req.Header.Add("Access-Control-Request-Method", "GET")
 
 	res, err := hc.Do(req)

--- a/internal/playback/server_test.go
+++ b/internal/playback/server_test.go
@@ -34,6 +34,7 @@ func TestPreflightRequest(t *testing.T) {
 	req, err := http.NewRequest(http.MethodOptions, "http://localhost:9996", nil)
 	require.NoError(t, err)
 
+	req.Header.Add("Origin", "http://example.com")
 	req.Header.Add("Access-Control-Request-Method", "GET")
 
 	res, err := hc.Do(req)

--- a/internal/pprof/pprof_test.go
+++ b/internal/pprof/pprof_test.go
@@ -34,6 +34,7 @@ func TestPreflightRequest(t *testing.T) {
 	req, err := http.NewRequest(http.MethodOptions, "http://localhost:9999", nil)
 	require.NoError(t, err)
 
+	req.Header.Add("Origin", "http://example.com")
 	req.Header.Add("Access-Control-Request-Method", "GET")
 
 	res, err := hc.Do(req)

--- a/internal/protocols/httpp/handler_origin.go
+++ b/internal/protocols/httpp/handler_origin.go
@@ -14,49 +14,47 @@ func isOriginAllowed(origin string, allowOrigins []string) (string, bool) {
 		return "", false
 	}
 
-	if origin != "" {
-		originURL, err := url.Parse(origin)
-		if err != nil || originURL.Scheme == "" {
-			return "", false
+	originURL, err := url.Parse(origin)
+	if err != nil || originURL.Scheme == "" {
+		return "", false
+	}
+
+	if originURL.Port() == "" && originURL.Scheme != "" {
+		switch originURL.Scheme {
+		case "http":
+			originURL.Host = net.JoinHostPort(originURL.Host, "80")
+		case "https":
+			originURL.Host = net.JoinHostPort(originURL.Host, "443")
+		}
+	}
+
+	for _, o := range allowOrigins {
+		allowedURL, errAllowed := url.Parse(o)
+		if errAllowed != nil {
+			continue
 		}
 
-		if originURL.Port() == "" && originURL.Scheme != "" {
-			switch originURL.Scheme {
+		if allowedURL.Port() == "" {
+			switch allowedURL.Scheme {
 			case "http":
-				originURL.Host = net.JoinHostPort(originURL.Host, "80")
+				allowedURL.Host = net.JoinHostPort(allowedURL.Host, "80")
 			case "https":
-				originURL.Host = net.JoinHostPort(originURL.Host, "443")
+				allowedURL.Host = net.JoinHostPort(allowedURL.Host, "443")
 			}
 		}
 
-		for _, o := range allowOrigins {
-			allowedURL, errAllowed := url.Parse(o)
-			if errAllowed != nil {
-				continue
-			}
+		if allowedURL.Scheme == originURL.Scheme &&
+			allowedURL.Host == originURL.Host {
+			return origin, true
+		}
 
-			if allowedURL.Port() == "" {
-				switch allowedURL.Scheme {
-				case "http":
-					allowedURL.Host = net.JoinHostPort(allowedURL.Host, "80")
-				case "https":
-					allowedURL.Host = net.JoinHostPort(allowedURL.Host, "443")
-				}
-			}
-
-			if allowedURL.Scheme == originURL.Scheme &&
-				allowedURL.Host == originURL.Host &&
-				allowedURL.Port() == originURL.Port() {
+		if allowedURL.Scheme == originURL.Scheme &&
+			strings.Contains(allowedURL.Host, "*") {
+			pattern := strings.ReplaceAll(allowedURL.Host, "*.", "(.*\\.)?")
+			pattern = strings.ReplaceAll(pattern, "*", ".*")
+			matched, errMatched := regexp.MatchString("^"+pattern+"$", originURL.Host)
+			if errMatched == nil && matched {
 				return origin, true
-			}
-
-			if strings.Contains(allowedURL.Host, "*") {
-				pattern := strings.ReplaceAll(allowedURL.Host, "*.", "(.*\\.)?")
-				pattern = strings.ReplaceAll(pattern, "*", ".*")
-				matched, errMatched := regexp.MatchString("^"+pattern+"$", originURL.Host)
-				if errMatched == nil && matched {
-					return origin, true
-				}
 			}
 		}
 	}
@@ -77,9 +75,11 @@ type handlerOrigin struct {
 }
 
 func (h *handlerOrigin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	origin, ok := isOriginAllowed(r.Header.Get("Origin"), h.allowOrigins)
-	if ok {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
+	if origin := r.Header.Get("Origin"); origin != "" {
+		allowOrigin, ok := isOriginAllowed(r.Header.Get("Origin"), h.allowOrigins)
+		if ok {
+			w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+		}
 	}
 
 	h.h.ServeHTTP(w, r)

--- a/internal/protocols/httpp/handler_origin_test.go
+++ b/internal/protocols/httpp/handler_origin_test.go
@@ -34,7 +34,7 @@ func TestHandlerOrigin(t *testing.T) {
 			"everything allowed, no origin",
 			"",
 			[]string{"*"},
-			"*",
+			"",
 		},
 		{
 			"everything allowed, with origin",
@@ -53,6 +53,12 @@ func TestHandlerOrigin(t *testing.T) {
 			"https://test.example.org",
 			[]string{"https://*.example.org"},
 			"https://test.example.org",
+		},
+		{
+			"wildcard with different scheme",
+			"http://test.example.org:443",
+			[]string{"https://*.example.org"},
+			"",
 		},
 		{
 			"everything allowed plus specific domain",

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -87,6 +87,7 @@ func TestServerPreflightRequest(t *testing.T) {
 	req, err := http.NewRequest(http.MethodOptions, "http://localhost:8888", nil)
 	require.NoError(t, err)
 
+	req.Header.Add("Origin", "http://example.com")
 	req.Header.Add("Access-Control-Request-Method", "GET")
 
 	res, err := hc.Do(req)

--- a/internal/servers/webrtc/server_test.go
+++ b/internal/servers/webrtc/server_test.go
@@ -126,6 +126,7 @@ func TestPreflightRequest(t *testing.T) {
 	req, err := http.NewRequest(http.MethodOptions, "http://localhost:8886", nil)
 	require.NoError(t, err)
 
+	req.Header.Add("Origin", "http://example.com")
 	req.Header.Add("Access-Control-Request-Method", "GET")
 
 	res, err := hc.Do(req)


### PR DESCRIPTION
An allowed origin with wildcards was making the server accept origins with a different scheme. This is fixed.