### PR TITLE
stop returning wildcard in Access-Control-Allow-Origin

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -185,7 +185,7 @@ func TestPreflightRequest(t *testing.T) {
 	byts, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
-	require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "http://example.com", res.Header.Get("Access-Control-Allow-Origin"))
 	require.Equal(t, "OPTIONS, GET, POST, PATCH, DELETE", res.Header.Get("Access-Control-Allow-Methods"))
 	require.Equal(t, "Authorization, Content-Type", res.Header.Get("Access-Control-Allow-Headers"))
 	require.Equal(t, byts, []byte{})

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -528,7 +528,7 @@ func TestPreflightRequest(t *testing.T) {
 	byts, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
-	require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "http://example.com", res.Header.Get("Access-Control-Allow-Origin"))
 	require.Equal(t, "OPTIONS, GET", res.Header.Get("Access-Control-Allow-Methods"))
 	require.Equal(t, "Authorization", res.Header.Get("Access-Control-Allow-Headers"))
 	require.Equal(t, byts, []byte{})

--- a/internal/playback/server_test.go
+++ b/internal/playback/server_test.go
@@ -46,7 +46,7 @@ func TestPreflightRequest(t *testing.T) {
 	byts, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
-	require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "http://example.com", res.Header.Get("Access-Control-Allow-Origin"))
 	require.Equal(t, "OPTIONS, GET", res.Header.Get("Access-Control-Allow-Methods"))
 	require.Equal(t, "Authorization", res.Header.Get("Access-Control-Allow-Headers"))
 	require.Equal(t, byts, []byte{})

--- a/internal/pprof/pprof_test.go
+++ b/internal/pprof/pprof_test.go
@@ -46,7 +46,7 @@ func TestPreflightRequest(t *testing.T) {
 	byts, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
-	require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "http://example.com", res.Header.Get("Access-Control-Allow-Origin"))
 	require.Equal(t, "OPTIONS, GET", res.Header.Get("Access-Control-Allow-Methods"))
 	require.Equal(t, "Authorization", res.Header.Get("Access-Control-Allow-Headers"))
 	require.Equal(t, byts, []byte{})

--- a/internal/protocols/httpp/handler_origin.go
+++ b/internal/protocols/httpp/handler_origin.go
@@ -5,18 +5,17 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"slices"
 	"strings"
 )
 
-func isOriginAllowed(origin string, allowOrigins []string) (string, bool) {
+func isOriginAllowed(origin string, allowOrigins []string) bool {
 	if len(allowOrigins) == 0 {
-		return "", false
+		return false
 	}
 
 	originURL, err := url.Parse(origin)
 	if err != nil || originURL.Scheme == "" {
-		return "", false
+		return false
 	}
 
 	if originURL.Port() == "" && originURL.Scheme != "" {
@@ -29,6 +28,10 @@ func isOriginAllowed(origin string, allowOrigins []string) (string, bool) {
 	}
 
 	for _, o := range allowOrigins {
+		if o == "*" {
+			return true
+		}
+
 		allowedURL, errAllowed := url.Parse(o)
 		if errAllowed != nil {
 			continue
@@ -45,7 +48,7 @@ func isOriginAllowed(origin string, allowOrigins []string) (string, bool) {
 
 		if allowedURL.Scheme == originURL.Scheme &&
 			allowedURL.Host == originURL.Host {
-			return origin, true
+			return true
 		}
 
 		if allowedURL.Scheme == originURL.Scheme &&
@@ -55,18 +58,12 @@ func isOriginAllowed(origin string, allowOrigins []string) (string, bool) {
 			pattern = strings.ReplaceAll(pattern, `\*`, `.*`)
 			matched, errMatched := regexp.MatchString("^"+pattern+"$", originURL.Host)
 			if errMatched == nil && matched {
-				return origin, true
+				return true
 			}
 		}
 	}
 
-	// return wildcard as last resort only
-	// because it blocks cross-origin requests with cookies
-	if slices.Contains(allowOrigins, "*") {
-		return "*", true
-	}
-
-	return "", false
+	return false
 }
 
 // add Access-Control-Allow-Origin header.
@@ -77,9 +74,8 @@ type handlerOrigin struct {
 
 func (h *handlerOrigin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if origin := r.Header.Get("Origin"); origin != "" {
-		allowOrigin, ok := isOriginAllowed(origin, h.allowOrigins)
-		if ok {
-			w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+		if ok := isOriginAllowed(origin, h.allowOrigins); ok {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
 		}
 	}

--- a/internal/protocols/httpp/handler_origin_test.go
+++ b/internal/protocols/httpp/handler_origin_test.go
@@ -40,7 +40,7 @@ func TestHandlerOrigin(t *testing.T) {
 			"everything allowed, with origin",
 			"https://example.com",
 			[]string{"*"},
-			"*",
+			"https://example.com",
 		},
 		{
 			"allowed",

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -99,7 +99,7 @@ func TestServerPreflightRequest(t *testing.T) {
 	byts, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
-	require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "http://example.com", res.Header.Get("Access-Control-Allow-Origin"))
 	require.Equal(t, "OPTIONS, GET", res.Header.Get("Access-Control-Allow-Methods"))
 	require.Equal(t, "Authorization, Range", res.Header.Get("Access-Control-Allow-Headers"))
 	require.Equal(t, byts, []byte{})

--- a/internal/servers/webrtc/server_test.go
+++ b/internal/servers/webrtc/server_test.go
@@ -138,7 +138,7 @@ func TestPreflightRequest(t *testing.T) {
 	byts, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
-	require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "http://example.com", res.Header.Get("Access-Control-Allow-Origin"))
 	require.Equal(t, "OPTIONS, GET, POST, PATCH, DELETE", res.Header.Get("Access-Control-Allow-Methods"))
 	require.Equal(t, "Authorization, Content-Type, If-Match", res.Header.Get("Access-Control-Allow-Headers"))
 	require.Equal(t, byts, []byte{})


### PR DESCRIPTION
if domain is allowed, return the domain, otherwise nothing.