### PR TITLE
conf: fix comparison and sharing of the default authInternalUsers

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -203,10 +203,13 @@ type nilLogger struct{}
 func (nilLogger) Log(_ logger.Level, _ string, _ ...any) {
 }
 
+// defaultAuthInternalUsers is kept in the form produced by setAllNilSlicesToEmptyRecursive
+// (empty slices, not nil), so that Validate() can compare a loaded configuration against it.
 var defaultAuthInternalUsers = []AuthInternalUser{
 	{
 		User: "any",
 		Pass: "",
+		IPs:  IPNetworks{},
 		Permissions: []AuthInternalUserPermission{
 			{
 				Action: AuthActionPublish,
@@ -438,7 +441,7 @@ func (conf *Conf) setDefaults() {
 
 	// Authentication
 	conf.AuthMethod = AuthMethodInternal
-	conf.AuthInternalUsers = defaultAuthInternalUsers
+	conf.AuthInternalUsers = deepClone(reflect.ValueOf(defaultAuthInternalUsers)).Interface().([]AuthInternalUser)
 	conf.AuthJWTClaimKey = "mediamtx_permissions"
 
 	// Control API

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -368,6 +368,49 @@ func TestConfDeprecatedAuth(t *testing.T) {
 	}, conf.AuthInternalUsers)
 }
 
+func TestConfDeprecatedAuthWithEnvUser(t *testing.T) {
+	t.Setenv("MTX_AUTHINTERNALUSERS_0_USER", "myuser")
+
+	tmpf := createTempFile(t, []byte(
+		"paths:\n"+
+			"  cam:\n"+
+			"    readUser: myuser\n"+
+			"    readPass: mypass\n"))
+
+	_, _, err := Load(tmpf, nil, nil)
+	require.EqualError(t, err, "authInternalUsers and legacy credentials "+
+		"(publishUser, publishPass, publishIPs, readUser, readPass, readIPs) cannot be used together")
+}
+
+func TestConfDeprecatedAuthWithExplicitDefaults(t *testing.T) {
+	legacy := "paths:\n" +
+		"  cam:\n" +
+		"    readUser: myuser\n" +
+		"    readPass: mypass\n"
+
+	ref, _, err := Load(createTempFile(t, []byte(legacy)), nil, nil)
+	require.NoError(t, err)
+
+	conf, _, err := Load(createTempFile(t, []byte(
+		"authInternalUsers:\n"+
+			"  - user: any\n"+
+			"    ips: []\n"+
+			"    permissions:\n"+
+			"      - action: publish\n"+
+			"      - action: read\n"+
+			"      - action: playback\n"+
+			"  - user: any\n"+
+			"    ips: [\"127.0.0.1\", \"::1\"]\n"+
+			"    permissions:\n"+
+			"      - action: api\n"+
+			"      - action: metrics\n"+
+			"      - action: pprof\n"+
+			legacy)), nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, ref.AuthInternalUsers, conf.AuthInternalUsers)
+}
+
 func TestConfDeprecatedWebRTCICEServersIPv6(t *testing.T) {
 	tmpf := createTempFile(t, []byte(
 		"webrtcICEServers:\n"+
@@ -1114,4 +1157,26 @@ func TestClone(t *testing.T) {
 
 	conf2 := conf1.Clone()
 	require.Equal(t, conf1, conf2)
+}
+
+func TestDefaultAuthInternalUsersIsNormalized(t *testing.T) {
+	conf, _, err := Load("", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, defaultAuthInternalUsers, conf.AuthInternalUsers)
+}
+
+func TestConfDefaultsAreNotShared(t *testing.T) {
+	conf1, _, err := Load("", nil, nil)
+	require.NoError(t, err)
+
+	conf2, _, err := Load("", nil, nil)
+	require.NoError(t, err)
+
+	conf1.AuthInternalUsers[0].User = "modified"
+	conf1.AuthInternalUsers[0].Permissions[0].Path = "modified"
+
+	require.Equal(t, Credential("any"), conf2.AuthInternalUsers[0].User)
+	require.Equal(t, "", conf2.AuthInternalUsers[0].Permissions[0].Path)
+	require.Equal(t, Credential("any"), defaultAuthInternalUsers[0].User)
+	require.Equal(t, "", defaultAuthInternalUsers[0].Permissions[0].Path)
 }


### PR DESCRIPTION
## Problem

`defaultAuthInternalUsers` has two related problems.

1. A configuration whose `authInternalUsers` equals the default is rejected together with legacy credentials. `mediamtx.yml` ships such a block; adding a legacy path credential to it makes the server refuse to start with `authInternalUsers and legacy credentials (...) cannot be used together`, and `/v3/config/paths/add` with a legacy credential is rejected the same way on a running server. `Validate()` compares the loaded list with the package-level variable through `reflect.DeepEqual`; the loaded list has an empty `IPs` in its first entry (from `ips: []` and from `setAllNilSlicesToEmptyRecursive`), the variable has a nil one, and `reflect.DeepEqual` treats those as different.

2. The default is shared, not copied: `setDefaults()` assigns the package-level slice directly. Environment variables therefore modify the default in place, so the comparison above always reports "unchanged", and an `authInternalUsers` customized through `MTX_AUTHINTERNALUSERS_*` together with legacy credentials is silently discarded instead of rejected. The default stays modified for the lifetime of the process. A reload (`conf.Load()` from `Core.run()`) also writes the elements back in place while the running `auth.Manager` reads them, which `-race` reports; the writes are same-value, so no wrong authentication decision follows.

## Reproduction

1. `mediamtx.yml` as shipped, with this added under its existing `paths:` section. Current `main` refuses to start; `8a4f2f5f~1` starts.

```yaml
  cam:
    readUser: myuser
    readPass: mypass
```

2. `MTX_AUTHINTERNALUSERS_0_USER=alice` plus a file containing only `paths:` with the same `cam` entry: current `main` starts and discards `alice`.

3. One goroutine calling `conf.Load("", nil, nil)` in a loop while another calls `Authenticate` on an `auth.Manager` built from a loaded configuration: `go test -race` reports the write in `env.loadEnvInternal` (`internal/conf/env/env.go:265`) against the read in `auth.matchesPermission` (`internal/auth/manager.go:38`), and nothing with this PR.

## Cause

1. Regression from #5376 (`8a4f2f5f`): `IPNetworks.UnmarshalJSON`, which turned `[]` into nil, was replaced by generic decoding, which produces an empty slice; and `setAllNilSlicesToEmptyRecursive` (from #5375, which treated slices as leaves) started descending into slice elements, reaching `AuthInternalUsers[i].IPs`. Either change alone breaks the comparison.

2. #3460 (`9554fc4b`) moved the default from an inline literal in `setDefaults()` into a package-level variable to compare against it; the assignment copies only the slice header.

## Fix

Declare the first default entry with an empty `IPs`, keeping the variable in the form `Load()` produces (as #5375 intended for default slices), and copy the default on assignment with the existing `deepClone` helper, as `Conf.Clone()` and `Path.Clone()` already do. The two changes are in one PR because neither stands alone. `deepClone` without the `IPs` change rejects plain legacy-credential configurations that work today (`TestConfDeprecatedAuth` fails). The `IPs` change without `deepClone` cannot be guarded: while the default is shared, an earlier `Load()` in the same process normalizes it in place, so a test for the regression can pass with the fix reverted.

Tests: `TestDefaultAuthInternalUsersIsNormalized`, `TestConfDeprecatedAuthWithExplicitDefaults`, `TestConfDefaultsAreNotShared`, `TestConfDeprecatedAuthWithEnvUser`.

## Impact

For 1, the configuration starts again and, as when the block is absent, `authInternalUsers` is replaced by the list derived from the legacy credentials. For 2, a configuration that customizes `authInternalUsers` through environment variables and uses legacy credentials is now rejected, as #3460 intended; it starts today and will fail to start after this change. Everything else is unchanged.
