### PR TITLE
fix data race between configuration reload and hook logging

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -207,7 +207,7 @@ type Core struct {
 	confPath        string
 	conf            atomic.Pointer[conf.Conf]
 	supportsIPv6    bool
-	logger          *logger.Logger
+	logger          atomic.Pointer[logger.Logger]
 	externalCmdPool *externalcmd.Pool
 	authManager     *auth.Manager
 	metrics         *metrics.Metrics
@@ -346,7 +346,7 @@ func New(args []string) (*Core, bool) {
 
 	err = p.createResources(true)
 	if err != nil {
-		if p.logger != nil {
+		if p.logger.Load() != nil {
 			p.Log(logger.Error, "%s", err)
 		} else {
 			fmt.Printf("ERR: %s\n", err)
@@ -373,7 +373,12 @@ func (p *Core) Wait() {
 
 // Log implements logger.Writer.
 func (p *Core) Log(level logger.Level, format string, args ...any) {
-	p.logger.Log(level, format, args...)
+	// a configuration reload can remove the logger before installing the
+	// new one, and a shutdown removes it for good; entries produced while
+	// no logger is installed are discarded.
+	if l := p.logger.Load(); l != nil {
+		l.Log(level, format, args...)
+	}
 }
 
 func (p *Core) run() {
@@ -398,7 +403,7 @@ outer:
 		case <-confChanged:
 			p.Log(logger.Info, "reloading configuration (file changed)")
 
-			newConf, _, err := conf.Load(p.confPath, nil, p.logger)
+			newConf, _, err := conf.Load(p.confPath, nil, p.logger.Load())
 			if err != nil {
 				p.Log(logger.Error, "%s", err)
 				break outer
@@ -500,7 +505,7 @@ func (p *Core) createResources(initial bool) error {
 	currentConf := p.conf.Load()
 	var err error
 
-	if p.logger == nil {
+	if p.logger.Load() == nil {
 		i := &logger.Logger{
 			Level:        logger.Level(currentConf.LogLevel),
 			Destinations: currentConf.LogDestinations.ToDestinations(),
@@ -512,7 +517,7 @@ func (p *Core) createResources(initial bool) error {
 		if err != nil {
 			return err
 		}
-		p.logger = i
+		p.logger.Store(i)
 	}
 
 	if initial {
@@ -1329,16 +1334,16 @@ func (p *Core) closeResources(newConf *conf.Conf) {
 		p.externalCmdPool.Close()
 	}
 
-	if closeLogger && p.logger != nil {
+	if l := p.logger.Load(); closeLogger && l != nil {
 		if newConf == nil {
-			p.logger.Close()
+			l.Close()
 		}
-		p.logger = nil
+		p.logger.Store(nil)
 	}
 }
 
 func (p *Core) reloadConf(newConf *conf.Conf) error {
-	oldLogger := p.logger
+	oldLogger := p.logger.Load()
 
 	p.closeResources(newConf)
 
@@ -1346,11 +1351,11 @@ func (p *Core) reloadConf(newConf *conf.Conf) error {
 
 	err := p.createResources(false)
 	if err != nil {
-		p.logger = oldLogger
+		p.logger.Store(oldLogger)
 		return err
 	}
 
-	if p.logger != oldLogger {
+	if p.logger.Load() != oldLogger {
 		oldLogger.Close()
 	}
 

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/test"
 )
 
@@ -93,6 +95,14 @@ func TestCoreErrors(t *testing.T) {
 	}
 }
 
+func TestCoreLogWithoutLogger(t *testing.T) {
+	p := &Core{}
+
+	require.NotPanics(t, func() {
+		p.Log(logger.Info, "test %d", 1)
+	})
+}
+
 func TestCoreHotReloading(t *testing.T) {
 	confPath := filepath.Join(t.TempDir(), "rtsp-conf")
 
@@ -147,6 +157,83 @@ func TestCoreHotReloadingAndLoggerError(t *testing.T) {
 	require.NoError(t, err)
 
 	p.Wait()
+}
+
+func TestCoreHotReloadingWhileLogging(t *testing.T) {
+	confPath := filepath.Join(t.TempDir(), "rtsp-conf")
+
+	// all servers are disabled, since the test only needs the configuration
+	// reload and Core.Log().
+	writeConf := func(logLevel string) {
+		err := os.WriteFile(confPath, []byte("logLevel: "+logLevel+"\n"+
+			"rtsp: no\n"+
+			"rtmp: no\n"+
+			"hls: no\n"+
+			"webrtc: no\n"+
+			"srt: no\n"+
+			"moq: no\n"),
+			0o644)
+		require.NoError(t, err)
+	}
+
+	writeConf("error")
+
+	p, ok := New([]string{confPath})
+	require.Equal(t, true, ok)
+	defer p.Close()
+
+	// call Log() continuously, in order to read the logger while a
+	// configuration reload is replacing it. two goroutines are enough to keep
+	// a read in flight for the entire duration of the replacement.
+	// the level is Debug, that is filtered out by the log levels used by this
+	// test, therefore nothing is printed; but the filter is inside
+	// logger.Logger.Log(), i.e. after the logger has been read from the Core,
+	// therefore the race is triggered anyway.
+	stop := make(chan struct{})
+	var loggers sync.WaitGroup
+
+	// stop logging before closing the server.
+	defer func() {
+		close(stop)
+		loggers.Wait()
+	}()
+
+	for range 2 {
+		loggers.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+
+				p.Log(logger.Debug, "test")
+			}
+		})
+	}
+
+	// change the log level back and forth: each change replaces the logger
+	// and therefore opens a race window. two changes are enough to detect it.
+	for _, logLevel := range []string{"warn", "error"} {
+		// the configuration watcher discards changes that happen less than
+		// one second after the previous reload.
+		time.Sleep(1100 * time.Millisecond)
+
+		oldLogger := p.logger.Load()
+
+		writeConf(logLevel)
+
+		// make sure that the logger has been replaced. checking the
+		// configuration is not enough, since it is stored before the
+		// resources are recreated, therefore it is updated even when the
+		// reload fails. a nil logger does not mean that the replacement is
+		// done: it is either the window inside a reload or the state that
+		// a failed reload leaves behind.
+		require.Eventually(t, func() bool {
+			l := p.logger.Load()
+			return l != nil && l != oldLogger
+		}, 3*time.Second, 20*time.Millisecond)
+	}
 }
 
 func TestNewRejectsConflictingOneShotFlags(t *testing.T) {


### PR DESCRIPTION
## Problem

`Core.Log()` reads `Core.logger` while a configuration reload replaces it, without any synchronization.

Since #2278 ([`5a40a06e`](https://github.com/bluenviron/mediamtx/commit/5a40a06e9e5408370c8b7b6c43e38ff16be4facb)), a reload that changes a logging setting closes every subsystem that logs before the logger is replaced, so normally nobody is left to read the field. External command goroutines are the exception: [`externalCmdPool.Close()` is called only when `newConf` is nil](https://github.com/bluenviron/mediamtx/blob/2c6727904fbf233615de74a6c54a9b94dbf6025d/internal/core/core.go#L1327-L1330), that is, at shutdown. Nothing waits for those goroutines during a reload either: `Cmd.Close()` only closes a channel and returns. So when a hook exits, its `OnExit` callback logs through `Core.Log()` and reads `p.logger` while `closeResources()` and `createResources()` are writing it.

The nil half of this was already hit and fixed in #5249 ([`a0a75dfa`](https://github.com/bluenviron/mediamtx/commit/a0a75dfab6ad9094114cdc08a7ea9568451a25e8)) for issue #5132, but only on the `createResources()` failure path; `Core.Log()` itself stayed unguarded.

## Change

- `Core.logger` becomes an `atomic.Pointer[logger.Logger]`, like the `conf` field a few lines above. Every access goes through `Load()` or `Store()`.
- `Core.Log()` loads the pointer once and returns without logging when it is nil.
- Two tests are added, one for each half of the problem: the nil pointer and the race.

## Reproduction

The minimal condition is a reload that changes `logLevel`, plus a `Core.Log()` call while the logger is being replaced. `TestCoreHotReloadingWhileLogging` sets that up with every server disabled, so that the logger replacement is the only thing that runs concurrently with the logging. On a tree with `internal/core/core.go` reverted to `main`, and the test's two `p.logger.Load()` calls changed to `p.logger` since a plain pointer has no `Load()`:

```
$ go test -race -count=1 -run TestCoreHotReloadingWhileLogging ./internal/core
==================
WARNING: DATA RACE
Write at 0x00c0003d6238 by goroutine 12:
  github.com/bluenviron/mediamtx/internal/core.(*Core).closeResources()
      internal/core/core.go:1336
Previous read at 0x00c0003d6238 by goroutine 13:
  github.com/bluenviron/mediamtx/internal/core.(*Core).Log()
      internal/core/core.go:376
```

Run in 20 separate processes, that command failed 20 times out of 20 on macOS/arm64; every run also carried a second `DATA RACE` block, for the write in `createResources()`, and a nil dereference panic. Inside `golang:1.26-alpine3.24` on Linux/arm64 it failed 20 out of 20 the same way. `TestCoreLogWithoutLogger` covers the nil pointer and needs no race detector: on the same reverted tree it failed in all 3 runs, on the nil dereference inside `logger.Logger.Log()`. On this branch both tests pass:

```
$ go test -race -count=1 -run 'TestCoreLogWithoutLogger|TestCoreHotReloadingWhileLogging' ./internal/core
ok  	github.com/bluenviron/mediamtx/internal/core	3.920s
```

## Fix

The field becomes an atomic pointer rather than a mutex, for two reasons. The `conf` field is already one and `sync/atomic` is already imported, so no new concept enters the struct. And every subsystem's log entries end up in `Core.Log()`: entries that the level filter throws away would pay for the lock too, since that filter runs after the logger has been read.

A mutex that only guards the swap would end up doing the same thing: the reader takes the lock, sees no logger, and drops the entry. Making it lossless means holding it across `oldLogger.Close()` too, which serializes the reload against every log call in the process.

## Impact

Logging behavior is unchanged while a logger is installed. Entries produced while no logger is installed are discarded, where before they raced with the replacement or dereferenced a nil pointer.

The atomic pointer also closes unsafe publication, not only the nil dereference: without the release/acquire edge that `Store()` and `Load()` give, a reader can see the new `logger.Logger` pointer before the writes that fill it. A plain pointer with an `if p.logger != nil` check around the call still reported a race in 20 runs out of 20 on both platforms, between the read of `Level` inside `Logger.Log()` and those writes in `createResources()`. A few of those runs also panicked outright, because that form loads the field twice and the value can turn nil between the check and the use.

One pre-existing case is left as it is: `reloadConf()` closes the old logger, so an entry that loaded the pointer just before can still be written to a logger that is already closed. This PR neither creates that path nor widens it.
